### PR TITLE
[refactor]: (SqlExecWorkflow) List and Create Module

### DIFF
--- a/packages/base/src/icon/sideMenu.tsx
+++ b/packages/base/src/icon/sideMenu.tsx
@@ -305,6 +305,27 @@ export const IconSQLOrder = () => {
   );
 };
 
+export const IconSQLExecWorkflow = () => {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.5 3V6H13.5V3H15.0049C15.4164 3 15.75 3.33371 15.75 3.74505V15.7549C15.75 16.1664 15.4163 16.5 15.0049 16.5H2.99505C2.58357 16.5 2.25 16.1663 2.25 15.7549V3.74505C2.25 3.33357 2.58371 3 2.99505 3H4.5ZM6.75 12.75H5.25V14.25H6.75V12.75ZM6.75 10.5H5.25V12H6.75V10.5ZM6.75 8.25H5.25V9.75H6.75V8.25Z"
+        fill="#C3C6CD"
+      />
+      <path
+        d="M11 1.5C11.5523 1.5 12 1.94772 12 2.5V3.5C12 4.05228 11.5523 4.5 11 4.5H7C6.44772 4.5 6 4.05228 6 3.5V2.5C6 1.94772 6.44772 1.5 7 1.5H11Z"
+        fill="#8A8F99"
+      />
+    </svg>
+  );
+};
+
 export const IconAuditPlan = () => {
   return (
     <svg

--- a/packages/base/src/locale/zh-CN/dmsMenu.ts
+++ b/packages/base/src/locale/zh-CN/dmsMenu.ts
@@ -20,6 +20,7 @@ export default {
   sqlOptimization: '智能调优',
   sqlManagement: 'SQL管控',
   SQLOrder: 'SQL工单',
+  sqlWorkflow: 'SQL工单',
   auditPlan: '智能扫描',
   permissionGroup: '权限组',
   permissionTemplate: '权限模板',

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/base.tsx
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/base.tsx
@@ -71,3 +71,12 @@ export const dataExportMenuItem: GenerateMenuItemType = (projectID) => ({
   key: `project/${SIDE_MENU_DATA_PLACEHOLDER_KEY}/data/export`,
   structKey: 'data-export'
 });
+
+const baseMenusCollection = [
+  dbServiceManagementMenuItem,
+  memberManagementMenItem,
+  cloudBeaverMenuItem,
+  dataExportMenuItem
+];
+
+export default baseMenusCollection;

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/index.type.ts
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/index.type.ts
@@ -27,6 +27,7 @@ export type MenuStructTreeKey =
   | 'plugin-audit'
   | 'sql-optimization'
   | 'sql-order'
+  | 'exec-workflow'
   | 'sql-management'
   | 'audit-plane'
   | 'rule-template'

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/menu.data.tsx
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/menu.data.tsx
@@ -1,57 +1,15 @@
 import { SystemRole } from '@actiontech/shared/lib/enum';
 import { t } from '../../../../../locale';
-import {
-  GenerateMenuItemType,
-  MenuStructTreeType,
-  MenuStructTreeKey
-} from './index.type';
+import { MenuStructTreeType, MenuStructTreeKey } from './index.type';
 import { genMenuItemsWithMenuStructTree } from './common';
-import {
-  dbServiceManagementMenuItem,
-  memberManagementMenItem,
-  cloudBeaverMenuItem,
-  dataExportMenuItem
-} from './base';
-import {
-  projectOverviewMenuItem,
-  dashboardMenuItem,
-  sqlAuditMenuItem,
-  pluginAuditMenuItem,
-  sqlOptimizationMenuItem,
-  sqlOrderMenuItem,
-  sqlManagementMenuItem,
-  auditPlanMenuItem,
-  projectRuleTemplateMenuItem,
-  whiteListMenuItem,
-  workflowTemplateMenuItem,
-  sqleOperationRecordMenuItem
-} from './sqle';
+import baseMenusCollection from './base';
+import sqleMenusCollection from './sqle';
 
 export const sideMenuData = (
   projectID: string,
   role: SystemRole | '',
   sqlOptimizationIsSupport: boolean
 ) => {
-  const allMenuItems: GenerateMenuItemType[] = [
-    dbServiceManagementMenuItem,
-    memberManagementMenItem,
-    cloudBeaverMenuItem,
-    dataExportMenuItem,
-
-    projectOverviewMenuItem,
-    dashboardMenuItem,
-    sqlAuditMenuItem,
-    pluginAuditMenuItem,
-    sqlOrderMenuItem,
-    sqlManagementMenuItem,
-    auditPlanMenuItem,
-    projectRuleTemplateMenuItem,
-    whiteListMenuItem,
-    workflowTemplateMenuItem,
-    sqleOperationRecordMenuItem,
-    sqlOptimizationMenuItem
-  ];
-
   const sqlDevGroup: MenuStructTreeKey[] = [
     'cloud-beaver',
     'data-export',
@@ -84,7 +42,7 @@ export const sideMenuData = (
     {
       type: 'group',
       label: t('dmsMenu.groupLabel.SQLExecute'),
-      group: ['sql-order']
+      group: ['sql-order', 'exec-workflow']
     },
     {
       type: 'group',
@@ -113,7 +71,7 @@ export const sideMenuData = (
 
   return genMenuItemsWithMenuStructTree(
     projectID,
-    allMenuItems,
+    [...sqleMenusCollection, ...baseMenusCollection],
     menuStruct,
     role
   );

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/sqle.tsx
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/sqle.tsx
@@ -13,7 +13,8 @@ import {
   IconSqlManagement,
   IconTodoList,
   IconWhitelist,
-  IconWorkflowTemplate
+  IconWorkflowTemplate,
+  IconSQLExecWorkflow
 } from '../../../../../icon/sideMenu';
 import { t } from '../../../../../locale';
 import { SystemRole } from '@actiontech/shared/lib/enum';
@@ -88,6 +89,17 @@ export const sqlOrderMenuItem: GenerateMenuItemType = (projectID) => ({
   structKey: 'sql-order'
 });
 
+export const sqlExecWorkflowMenuItem: GenerateMenuItemType = (projectID) => ({
+  label: (
+    <Link to={`/sqle/project/${projectID}/exec-workflow`}>
+      {t('dmsMenu.sqlWorkflow')}
+    </Link>
+  ),
+  icon: <Icon component={IconSQLExecWorkflow} />,
+  key: `sqle/project/${SIDE_MENU_DATA_PLACEHOLDER_KEY}/exec-workflow`,
+  structKey: 'exec-workflow'
+});
+
 export const sqlManagementMenuItem: GenerateMenuItemType = (projectID) => ({
   label: (
     <Link to={`/sqle/project/${projectID}/sql-management`}>
@@ -158,3 +170,22 @@ export const sqleOperationRecordMenuItem: GenerateMenuItemType = (
   structKey: 'sqle-log',
   role: [SystemRole.admin]
 });
+
+const sqleMenusCollection = [
+  projectOverviewMenuItem,
+  dashboardMenuItem,
+  sqlAuditMenuItem,
+  pluginAuditMenuItem,
+  sqlOptimizationMenuItem,
+  sqlOrderMenuItem,
+  sqlExecWorkflowMenuItem,
+  sqlManagementMenuItem,
+  auditPlanMenuItem,
+  projectRuleTemplateMenuItem,
+  whiteListMenuItem,
+  workflowTemplateMenuItem,
+  workflowTemplateMenuItem,
+  sqleOperationRecordMenuItem
+];
+
+export default sqleMenusCollection;

--- a/packages/shared/lib/components/CustomSegmentedFilter/index.tsx
+++ b/packages/shared/lib/components/CustomSegmentedFilter/index.tsx
@@ -1,0 +1,129 @@
+import classnames from 'classnames';
+import {
+  CustomSegmentedFilterDefaultOptionsType,
+  CustomSegmentedFilterProps
+} from './index.type';
+import { useControllableValue } from 'ahooks';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SegmentedProps } from 'antd';
+import BasicSegmented from '../BasicSegmented';
+
+const CustomSegmentedFilter = <V extends string | number | undefined = string>(
+  props: CustomSegmentedFilterProps<V>
+) => {
+  const { t } = useTranslation();
+
+  const { labelDictionary, withAll, noStyle, className, style, options } =
+    props;
+  const [value, onChange] = useControllableValue<V>(
+    typeof props.value !== undefined
+      ? {
+          value: props.value,
+          onChange: props.onChange,
+          defaultValue: props.defaultValue
+        }
+      : {
+          onChange: props.onChange,
+          defaultValue: props.defaultValue
+        }
+  );
+
+  const mergeOptions = useMemo<
+    CustomSegmentedFilterDefaultOptionsType<V>
+  >(() => {
+    const transformOptions: CustomSegmentedFilterDefaultOptionsType<V> =
+      options.map((item) => {
+        if (labelDictionary) {
+          if (typeof item === 'string') {
+            return {
+              label: labelDictionary[item] ?? item,
+              value: item as V
+            };
+          }
+
+          return {
+            label:
+              typeof item.label === 'string'
+                ? labelDictionary[item.label] ?? item.label
+                : item.label,
+            value: item.value as V
+          };
+        } else {
+          if (typeof item === 'string') {
+            return {
+              label: item,
+              value: item as V
+            };
+          }
+
+          return {
+            label: item.label,
+            value: item.value
+          };
+        }
+      });
+
+    if (withAll === undefined || withAll === false) {
+      return transformOptions;
+    }
+
+    if (withAll === true) {
+      return [
+        { label: t('common.all'), value: undefined as V },
+        ...transformOptions
+      ];
+    }
+
+    if (typeof withAll === 'string') {
+      return [{ label: withAll, value: withAll as V }, ...transformOptions];
+    }
+
+    return [withAll, ...transformOptions];
+  }, [labelDictionary, options, t, withAll]);
+
+  const mergeClassNames = classnames(
+    'custom-segmented-filter-wrapper',
+    className
+  );
+
+  const render = () => {
+    if (noStyle) {
+      return (
+        <div style={style} className={mergeClassNames}>
+          {mergeOptions.map((item) => {
+            return (
+              <div
+                key={item.value}
+                className={classnames('custom-segmented-filter-item', {
+                  'custom-segmented-filter-item-checked': value === item.value
+                })}
+                onClick={() => {
+                  onChange(item.value);
+                }}
+              >
+                {item.label}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    return (
+      <BasicSegmented
+        className={mergeClassNames}
+        value={value}
+        defaultValue={props.defaultValue}
+        onChange={(val) => {
+          onChange(val as V);
+        }}
+        options={mergeOptions as SegmentedProps['options']}
+      />
+    );
+  };
+
+  return render();
+};
+
+export default CustomSegmentedFilter;

--- a/packages/shared/lib/components/CustomSegmentedFilter/index.type.ts
+++ b/packages/shared/lib/components/CustomSegmentedFilter/index.type.ts
@@ -1,0 +1,64 @@
+import { CSSProperties, ReactNode } from 'react';
+
+export type CustomSegmentedFilterDefaultOptionsType<
+  V extends string | number | undefined = string
+> = Array<{ label: ReactNode; value: V }>;
+
+export type CustomSegmentedFilterProps<
+  V extends string | number | undefined = string
+> = {
+  value?: V;
+
+  onChange?: (val: V) => void;
+
+  defaultValue?: V;
+
+  /**
+   * 当 options 类型为 string[] 时，会自动通过该字典数据进行 label to value
+   * eg:
+   * options: ['failed', 'finished']
+   * dictionary:{
+   *     failed: '执行失败',
+   *     finished: '执行结束'
+   * }
+   *
+   * 最终会会自动渲染成 [
+   *   {
+   *     label: '执行失败',
+   *     value: 'failed'
+   *   },
+   *   {
+   *     label: '执行结束',
+   *     value: 'finished'
+   *   }
+   * ]
+   */
+  labelDictionary?: Record<string, string>;
+
+  /**
+   * 生成 Segmented Options 的集合
+   */
+  options: CustomSegmentedFilterDefaultOptionsType<V> | string[];
+
+  /**
+   * 是否自动添加 “全部” 项作为筛选项
+   * 默认值： false
+   *
+   * 当为 true 时，默认添加的 “全部” 筛选项对应的 option 为 {label:'全部', value: undefined}
+   * 当为 string 类型数据 时，默认添加的 “全部” 筛选项对应的 option 为 {label:'全部', value: undefined}
+   * 单位 Record 时，会将该对象合并进入 options
+   */
+  withAll?: boolean | CustomSegmentedFilterDefaultOptionsType<V>[0] | string;
+
+  /**
+   * 是否清空样式
+   * 默认值： false
+   * 组件默认使用 BasicSegmented 的样式作为包裹
+   * 当设置为 true 时，清空样式，用户可执行使用 StyleWrapper 进行包裹或执行添加 Class 来处理样式
+   */
+
+  noStyle?: boolean;
+
+  className?: string;
+  style?: CSSProperties;
+};

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -31,6 +31,7 @@ export { default as TokenCom } from './components/TokenCom';
 export { default as ToggleTokens } from './components/ToggleTokens';
 export { default as SQLRenderer } from './components/SQLRenderer';
 export { default as ModeSwitcher } from './components/ModeSwitcher';
+export { default as CustomSegmentedFilter } from './components/CustomSegmentedFilter';
 
 export { default as Copy } from './utils/Copy';
 export { default as Download } from './utils/Download';

--- a/packages/sqle/src/components/ReportDrawer/useAuditResultRuleInfo.ts
+++ b/packages/sqle/src/components/ReportDrawer/useAuditResultRuleInfo.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import { useRequest } from 'ahooks';
+import { IAuditResult } from '@actiontech/shared/lib/api/sqle/service/common';
+import rule_template from '@actiontech/shared/lib/api/sqle/service/rule_template/index';
+
+const useAuditResultRuleInfo = (
+  auditResult: IAuditResult[],
+  dbType?: string
+) => {
+  const filterRuleNames = useMemo(
+    () => (auditResult?.map((v) => v.rule_name ?? '') ?? []).filter((v) => !!v),
+    [auditResult]
+  );
+
+  const { data: ruleInfo, loading } = useRequest(
+    () =>
+      rule_template
+        .getRuleListV1({
+          filter_rule_names: filterRuleNames.join(','),
+          filter_db_type: dbType
+        })
+        .then((res) => res.data.data),
+    {
+      ready: !!filterRuleNames.length,
+      refreshDeps: [filterRuleNames]
+    }
+  );
+
+  const auditResultRuleInfo = useMemo(() => {
+    return (
+      auditResult?.map((item) => {
+        const findData =
+          ruleInfo?.find((i) => i.rule_name === item.rule_name) ?? {};
+        return {
+          ...findData,
+          ...item,
+          isRuleDeleted: item.rule_name
+            ? JSON.stringify(findData) === '{}'
+            : false
+        };
+      }) ?? []
+    );
+  }, [ruleInfo, auditResult]);
+
+  return { ruleInfo, loading, auditResultRuleInfo };
+};
+
+export default useAuditResultRuleInfo;

--- a/packages/sqle/src/hooks/useStaticStatus/index.data.ts
+++ b/packages/sqle/src/hooks/useStaticStatus/index.data.ts
@@ -11,6 +11,16 @@ import { getWorkflowsV1FilterStatusEnum } from '@actiontech/shared/lib/api/sqle/
 import { StaticEnumDictionary } from './index.type';
 import { getSQLAuditRecordsV1FilterSqlAuditStatusEnum } from '@actiontech/shared/lib/api/sqle/service/sql_audit_record/index.enum';
 import { GetSqlManageListFilterStatusEnum } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
+import { t } from '../../locale';
+
+export const translateDictionaryI18nLabel = <T extends string>(
+  dic: StaticEnumDictionary<T>
+) => {
+  return Object.keys(dic).reduce<Record<keyof T, string>>((acc, cur) => {
+    const key = cur as keyof StaticEnumDictionary<T>;
+    return { ...acc, [key]: t(dic[key]) };
+  }, {} as Record<keyof T, string>);
+};
 
 export const execStatusDictionary: StaticEnumDictionary<getAuditTaskSQLsV2FilterExecStatusEnum> =
   {

--- a/packages/sqle/src/icon/SqlExecWorkflow.tsx
+++ b/packages/sqle/src/icon/SqlExecWorkflow.tsx
@@ -1,0 +1,707 @@
+import {
+  CustomIconProps,
+  CommonIconStyleWrapper
+} from '@actiontech/shared/lib/Icon';
+
+import classnames from 'classnames';
+
+export const IconMinus: React.FC<CustomIconProps> = ({
+  className,
+  ...props
+}) => {
+  return (
+    <CommonIconStyleWrapper
+      role="img"
+      className={classnames(className, 'custom-icon custom-icon-minus')}
+      {...props}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M7.00002 12.8333C3.77827 12.8333 1.16669 10.2217 1.16669 6.99996C1.16669 3.77821 3.77827 1.16663 7.00002 1.16663C10.2218 1.16663 12.8334 3.77821 12.8334 6.99996C12.8334 10.2217 10.2218 12.8333 7.00002 12.8333ZM7.00002 11.6666C8.2377 11.6666 9.42468 11.175 10.2999 10.2998C11.175 9.42462 11.6667 8.23764 11.6667 6.99996C11.6667 5.76228 11.175 4.5753 10.2999 3.70013C9.42468 2.82496 8.2377 2.33329 7.00002 2.33329C5.76234 2.33329 4.57536 2.82496 3.70019 3.70013C2.82502 4.5753 2.33335 5.76228 2.33335 6.99996C2.33335 8.23764 2.82502 9.42462 3.70019 10.2998C4.57536 11.175 5.76234 11.6666 7.00002 11.6666ZM4.08335 6.41663H9.91669V7.58329H4.08335V6.41663Z" />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowId = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="12"
+        height="14"
+        viewBox="0 0 12 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2 1.66671V4.33337H10V1.66671H11.3377C11.7035 1.66671 12 1.96334 12 2.32897V13.0044C12 13.3702 11.7034 13.6667 11.3377 13.6667H0.662267C0.296507 13.6667 0 13.3701 0 13.0044V2.32897C0 1.96321 0.296633 1.66671 0.662267 1.66671H2ZM4 10.3334H2.66667V11.6667H4V10.3334ZM4 8.33337H2.66667V9.66671H4V8.33337ZM4 6.33337H2.66667V7.66671H4V6.33337ZM8.66667 0.333374V3.00004H3.33333V0.333374H8.66667Z"
+          fill="#C3C6CD"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsWaitAudit = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#7453DA"
+          strokeWidth="1.5"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsWaitExecution = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#7470ED"
+          strokeWidth="1.5"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M8 3.15466V7.99996L12.2067 10.4038C12.2864 10.2588 12.3301 10.0938 12.3301 9.92261V6.07731C12.3301 5.72005 12.1395 5.38992 11.8301 5.21129L8.5 3.28864C8.3453 3.19932 8.17265 3.15466 8 3.15466Z"
+          fill="#7470ED"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsExecScheduled = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#6094FC"
+          strokeWidth="1.5"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M7.99995 3.15479V8.00008L3.79321 10.4039C3.87976 10.5616 4.00868 10.6957 4.16982 10.7888L7.49995 12.7114C7.80935 12.89 8.19055 12.89 8.49995 12.7114L11.8301 10.7888C12.1395 10.6101 12.3301 10.28 12.3301 9.92273V6.07744C12.3301 5.72017 12.1395 5.39004 11.8301 5.21141L8.49995 3.28876C8.34525 3.19944 8.1726 3.15478 7.99995 3.15479Z"
+          fill="#6094FC"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsExecuting = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#6094FC"
+          strokeWidth="1.5"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M7.99995 3.15466V7.99996L3.79321 10.4038C3.87976 10.5615 4.00868 10.6956 4.16982 10.7886L7.49995 12.7113C7.80935 12.8899 8.19055 12.8899 8.49995 12.7113L11.8301 10.7886C12.1395 10.61 12.3301 10.2799 12.3301 9.92261V6.07731C12.3301 5.72005 12.1395 5.38992 11.8301 5.21129L8.49995 3.28864C8.34525 3.19932 8.1726 3.15466 7.99995 3.15466Z"
+          fill="#6094FC"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsFinished = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#41BF9A"
+          strokeWidth="1.5"
+        />
+        <path
+          d="M5.08325 7.99996L7.16659 10.0833L11.3333 5.91663"
+          stroke="#41BF9A"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsRejected = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#EBAD1C"
+          strokeWidth="1.5"
+        />
+        <path d="M5 8H11" stroke="#EBAD1C" strokeWidth="1.5" />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsFailed = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#F59957"
+          strokeWidth="1.5"
+        />
+        <path d="M8 10L8 12" stroke="#F59957" strokeWidth="1.5" />
+        <path d="M8 4L8.00415 8.5" stroke="#F59957" strokeWidth="1.5" />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusIsCanceled = () => {
+  return (
+    <CommonIconStyleWrapper className="custom-icon">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.875 1.51554C7.57115 1.11362 8.42885 1.11362 9.125 1.51554L13.0532 3.78349C13.7494 4.18542 14.1782 4.9282 14.1782 5.73205V10.2679C14.1782 11.0718 13.7494 11.8146 13.0532 12.2165L9.125 14.4845C8.42885 14.8864 7.57115 14.8864 6.875 14.4845L2.9468 12.2165C2.25064 11.8146 1.8218 11.0718 1.8218 10.2679V5.73205C1.8218 4.9282 2.25064 4.18542 2.9468 3.78349L6.875 1.51554Z"
+          stroke="#7D8CA8"
+          strokeWidth="1.5"
+        />
+        <path
+          d="M5.91675 5.91663L10.0834 10.0833"
+          stroke="#7D8CA8"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M5.91675 10.0833L10.0834 5.91663"
+          stroke="#7D8CA8"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowCreateTitle: React.FC<CustomIconProps> = ({
+  className,
+  color
+}) => {
+  return (
+    <CommonIconStyleWrapper
+      className={classnames(
+        className,
+        'custom-icon workflow-create-title-icon title-icon'
+      )}
+    >
+      <svg
+        width="24"
+        height="28"
+        viewBox="0 0 24 28"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4 3.33333V8.66666H20V3.33333H22.6755C23.4069 3.33333 24 3.9266 24 4.65786V26.0088C24 26.7403 23.4068 27.3333 22.6755 27.3333H1.32453C0.593013 27.3333 0 26.7401 0 26.0088V4.65786C0 3.92634 0.593267 3.33333 1.32453 3.33333H4ZM8 20.6667H5.33333V23.3333H8V20.6667ZM8 16.6667H5.33333V19.3333H8V16.6667ZM8 12.6667H5.33333V15.3333H8V12.6667ZM17.3333 0.666664V6H6.66667V0.666664H17.3333Z"
+          fill={color ?? 'currentColor'}
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowSQLUpload: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 18 18"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M15 7.5H3V14.25H15V7.5ZM2.25 2.25H15.75C16.1642 2.25 16.5 2.58579 16.5 3V15C16.5 15.4142 16.1642 15.75 15.75 15.75H2.25C1.83579 15.75 1.5 15.4142 1.5 15V3C1.5 2.58579 1.83579 2.25 2.25 2.25ZM3.75 4.5V6H5.25V4.5H3.75ZM6.75 4.5V6H8.25V4.5H6.75ZM3.75 8.25H6V12H3.75V8.25Z"
+          fill="currentColor"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowFileUpload: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 18 18"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 1.5L15.75 5.25V15.756C15.7498 15.9534 15.6712 16.1426 15.5316 16.2821C15.392 16.4216 15.2026 16.5 15.0052 16.5H2.99475C2.79778 16.4986 2.60926 16.4198 2.46991 16.2806C2.33056 16.1414 2.25157 15.953 2.25 15.756V2.244C2.25 1.833 2.58375 1.5 2.99475 1.5H12ZM9.75 9H12L9 6L6 9H8.25V12H9.75V9Z"
+          fill="currentColor"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowDownloadReport: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14 6V13.9953C14.0006 14.0829 13.984 14.1697 13.951 14.2508C13.9181 14.3319 13.8695 14.4058 13.808 14.4681C13.7466 14.5304 13.6734 14.5801 13.5928 14.6141C13.5121 14.6482 13.4255 14.6661 13.338 14.6667H2.662C2.48654 14.6667 2.31826 14.597 2.19413 14.473C2.07 14.349 2.00018 14.1808 2 14.0053V1.99466C2 1.63666 2.298 1.33333 2.66533 1.33333H9.33333V5.33333C9.33333 5.51014 9.40357 5.67971 9.52859 5.80473C9.65362 5.92976 9.82319 6 10 6H14ZM14 4.66666H10.6667V1.33533L14 4.66666ZM5.33333 4.66666V6H7.33333V4.66666H5.33333ZM5.33333 7.33333V8.66666H10.6667V7.33333H5.33333ZM5.33333 10V11.3333H10.6667V10H5.33333Z"
+          fill="currentColor"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowDownloadSQL: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M13.333 6.66667H2.66634V12.6667H13.333V6.66667ZM1.99967 2H13.9997C14.3679 2 14.6663 2.29848 14.6663 2.66667V13.3333C14.6663 13.7015 14.3679 14 13.9997 14H1.99967C1.63149 14 1.33301 13.7015 1.33301 13.3333V2.66667C1.33301 2.29848 1.63149 2 1.99967 2ZM3.33301 4V5.33333H4.66634V4H3.33301ZM5.99967 4V5.33333H7.33301V4H5.99967ZM3.33301 7.33333H5.33301V10.6667H3.33301V7.33333Z"
+          fill="currentColor"
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowStatusWrapper: React.FC<
+  CustomIconProps & { filter?: string }
+> = ({ color, filter = 'filter0_d_1360_13602' }) => {
+  return (
+    <CommonIconStyleWrapper className="icon-workflow-status-wrapper">
+      <svg
+        width="74"
+        height="55"
+        viewBox="0 0 74 55"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g filter={`url(#${filter})`}>
+          <path
+            d="M69 0H5V31.6481C5 33.2482 5.95359 34.6944 7.42432 35.3247L33.8487 46.6494C35.861 47.5119 38.139 47.5119 40.1514 46.6494L66.5757 35.3247C68.0464 34.6944 69 33.2482 69 31.6481V0Z"
+            fill={color ?? 'currentColor'}
+          />
+        </g>
+        <defs>
+          <filter
+            id={filter}
+            x="0"
+            y="-3"
+            width="74"
+            height="57.2961"
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feFlood floodOpacity="0" result="BackgroundImageFix" />
+            <feColorMatrix
+              in="SourceAlpha"
+              type="matrix"
+              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+              result="hardAlpha"
+            />
+            <feOffset dy="2" />
+            <feGaussianBlur stdDeviation="2.5" />
+            <feComposite in2="hardAlpha" operator="out" />
+            <feColorMatrix
+              type="matrix"
+              values="0 0 0 0 0.454902 0 0 0 0 0.32549 0 0 0 0 0.854902 0 0 0 0.4 0"
+            />
+            <feBlend
+              mode="normal"
+              in2="BackgroundImageFix"
+              result="effect1_dropShadow_2935_18512"
+            />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="effect1_dropShadow_2935_18512"
+              result="shape"
+            />
+          </filter>
+        </defs>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowRejectReason: React.FC = () => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M21 11.6736C20.0907 11.2417 19.0736 11 18 11C14.134 11 11 14.134 11 18C11 19.4872 11.4638 20.8662 12.2547 22H3.9934C3.44476 22 3 21.5447 3 21.0082V2.9918C3 2.44405 3.44495 2 3.9934 2H16L21 7V11.6736ZM18 23C15.2386 23 13 20.7614 13 18C13 15.2386 15.2386 13 18 13C20.7614 13 23 15.2386 23 18C23 20.7614 20.7614 23 18 23ZM16.7066 20.7076C17.0982 20.895 17.5369 21 18 21C19.6569 21 21 19.6569 21 18C21 17.5369 20.895 17.0982 20.7076 16.7066L16.7066 20.7076ZM15.2924 19.2934L19.2934 15.2924C18.9018 15.105 18.4631 15 18 15C16.3431 15 15 16.3431 15 18C15 18.4631 15.105 18.9018 15.2924 19.2934Z"
+        fill="#EBAD1C"
+      />
+    </svg>
+  );
+};
+
+export const IconWorkflowResultLayout: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="layout-bottom-2-line">
+          <path
+            id="Vector"
+            d="M12.2501 1.75C12.5723 1.75 12.8334 2.01117 12.8334 2.33333V11.6667C12.8334 11.9888 12.5723 12.25 12.2501 12.25H1.75008C1.42792 12.25 1.16675 11.9888 1.16675 11.6667V2.33333C1.16675 2.01117 1.42792 1.75 1.75008 1.75H12.2501ZM11.6667 2.91667H2.33341V11.0833H11.6667V2.91667ZM10.5001 8.75V9.91667H3.50008V8.75H10.5001Z"
+            fill="#292C33"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowResultListLayout: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="layout-bottom-2-fill">
+          <path
+            id="Vector"
+            d="M13.9999 2C14.3681 2 14.6666 2.29848 14.6666 2.66667V13.3333C14.6666 13.7015 14.3681 14 13.9999 14H1.99992C1.63173 14 1.33325 13.7015 1.33325 13.3333V2.66667C1.33325 2.29848 1.63173 2 1.99992 2H13.9999ZM12.6666 10.6667H3.33325V12H12.6666V10.6667Z"
+            fill="#8A8F99"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowResultWaterFallLayout: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="layout-row-fill">
+          <path
+            id="Vector"
+            d="M12.6667 8H3.33333V12.6667H12.6667V8ZM2.66667 2H13.3333C13.7015 2 14 2.29848 14 2.66667V13.3333C14 13.7015 13.7015 14 13.3333 14H2.66667C2.29848 14 2 13.7015 2 13.3333V2.66667C2 2.29848 2.29848 2 2.66667 2Z"
+            fill="#8A8F99"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowAuditResultSuccess: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="checkbox-circle-fill">
+          <path
+            id="Vector"
+            d="M8.00004 14.6666C4.31804 14.6666 1.33337 11.6819 1.33337 7.99992C1.33337 4.31792 4.31804 1.33325 8.00004 1.33325C11.682 1.33325 14.6667 4.31792 14.6667 7.99992C14.6667 11.6819 11.682 14.6666 8.00004 14.6666ZM7.33537 10.6666L12.0487 5.95259L11.106 5.00992L7.33537 8.78125L5.44937 6.89525L4.50671 7.83792L7.33537 10.6666Z"
+            fill="#41BF9A"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowAuditResultNotice: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="spam-2-fill">
+          <path
+            id="Vector"
+            d="M10.6234 1.66724L14.3334 5.37722V10.6239L10.6234 14.3339H5.37673L1.66675 10.6239V5.37722L5.37673 1.66724H10.6234ZM7.33295 10V11.3334H8.66628V10H7.33295ZM7.33295 4.66674V8.66672H8.66628V4.66674H7.33295Z"
+            fill="#6094FC"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowAuditResultError: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="close-circle-fill">
+          <path
+            id="Vector"
+            d="M7.99992 14.6666C4.31792 14.6666 1.33325 11.6819 1.33325 7.99992C1.33325 4.31792 4.31792 1.33325 7.99992 1.33325C11.6819 1.33325 14.6666 4.31792 14.6666 7.99992C14.6666 11.6819 11.6819 14.6666 7.99992 14.6666ZM7.99992 7.05725L6.11459 5.17125L5.17125 6.11459L7.05725 7.99992L5.17125 9.88525L6.11459 10.8286L7.99992 8.94258L9.88525 10.8286L10.8286 9.88525L8.94258 7.99992L10.8286 6.11459L9.88525 5.17125L7.99992 7.05725Z"
+            fill="#F66074"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowAuditResultWarning: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper className={classnames(className, 'custom-icon ')}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="alert-fill">
+          <path
+            id="Vector"
+            d="M8.57658 2.0002L14.9274 13.0002C15.1115 13.3191 15.0022 13.7268 14.6834 13.9109C14.582 13.9694 14.4671 14.0002 14.35 14.0002H1.64836C1.28016 14.0002 0.981689 13.7017 0.981689 13.3335C0.981689 13.2165 1.01249 13.1015 1.071 13.0002L7.42185 2.0002C7.60598 1.68133 8.01365 1.57208 8.33252 1.75618C8.43392 1.81469 8.51805 1.89885 8.57658 2.0002ZM7.33252 10.6669V12.0002H8.66585V10.6669H7.33252ZM7.33252 6.0002V9.33355H8.66585V6.0002H7.33252Z"
+            fill="#EBAD1C"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconInitializedWorkflowStep: React.FC = () => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.99992 14.6668C4.31792 14.6668 1.33325 11.6822 1.33325 8.00016C1.33325 4.31816 4.31792 1.3335 7.99992 1.3335C11.6819 1.3335 14.6666 4.31816 14.6666 8.00016C14.6666 11.6822 11.6819 14.6668 7.99992 14.6668ZM7.33325 7.3335H4.66659V8.66683H7.33325V11.3335H8.66659V8.66683H11.3333V7.3335H8.66659V4.66683H7.33325V7.3335Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
+export const IconProgressWorkflowStep: React.FC<CustomIconProps> = ({
+  color
+}) => {
+  return (
+    <CommonIconStyleWrapper className="icon-failed-workflow-step">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7.99992 14.6644C4.31802 14.6644 1.33325 11.6796 1.33325 7.99773C1.33325 4.31582 4.31802 1.33105 7.99992 1.33105C11.6818 1.33105 14.6666 4.31582 14.6666 7.99773C14.6666 11.6796 11.6818 14.6644 7.99992 14.6644ZM7.99992 13.3311C10.9455 13.3311 13.3333 10.9433 13.3333 7.99773C13.3333 5.0522 10.9455 2.66439 7.99992 2.66439C5.0544 2.66439 2.66659 5.0522 2.66659 7.99773C2.66659 10.9433 5.0544 13.3311 7.99992 13.3311ZM7.99992 11.9977V3.99772C10.2091 3.99772 11.9999 5.78858 11.9999 7.99773C11.9999 10.2069 10.2091 11.9977 7.99992 11.9977Z"
+          fill={color ?? 'currentColor'}
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconFinishedWorkflowStep: React.FC = () => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.99992 14.6668C4.31792 14.6668 1.33325 11.6822 1.33325 8.00016C1.33325 4.31816 4.31792 1.3335 7.99992 1.3335C11.6819 1.3335 14.6666 4.31816 14.6666 8.00016C14.6666 11.6822 11.6819 14.6668 7.99992 14.6668ZM7.33525 10.6668L12.0486 5.95283L11.1059 5.01016L7.33525 8.7815L5.44925 6.8955L4.50659 7.83816L7.33525 10.6668Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
+export const IconFailedWorkflowStep: React.FC<CustomIconProps> = ({
+  color
+}) => {
+  return (
+    <CommonIconStyleWrapper className="icon-failed-workflow-step">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7.99998 14.6663C4.31798 14.6663 1.33331 11.6817 1.33331 7.99967C1.33331 4.31767 4.31798 1.33301 7.99998 1.33301C11.682 1.33301 14.6666 4.31767 14.6666 7.99967C14.6666 11.6817 11.682 14.6663 7.99998 14.6663ZM7.99998 7.05701L6.11465 5.17101L5.17131 6.11434L7.05731 7.99967L5.17131 9.88501L6.11465 10.8283L7.99998 8.94234L9.88531 10.8283L10.8286 9.88501L8.94265 7.99967L10.8286 6.11434L9.88531 5.17101L7.99998 7.05701Z"
+          fill={color ?? 'currentColor'}
+        />
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};
+
+export const IconWorkflowUploadTypeChecked: React.FC<CustomIconProps> = ({
+  className
+}) => {
+  return (
+    <CommonIconStyleWrapper
+      className={classnames('icon-workflow-upload-checked', className)}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="Frame">
+          <path
+            id="Vector"
+            d="M3.88879 7.00002L6.22213 9.33335L10.8888 4.66669"
+            stroke="#FCFBF9"
+            strokeWidth="1.5"
+            strokeLinejoin="round"
+          />
+        </g>
+      </svg>
+    </CommonIconStyleWrapper>
+  );
+};

--- a/packages/sqle/src/locale/zh-CN/execWorkflow.ts
+++ b/packages/sqle/src/locale/zh-CN/execWorkflow.ts
@@ -1,0 +1,203 @@
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  list: {
+    pageTitle: '工单列表',
+    pageDesc: '工单列表中只会展示与您相关的工单。',
+
+    allWorkflowAboutMe: '所有与我相关的工单',
+    workflowStatus: {
+      review: '待审核',
+      exec: '待上线'
+    },
+    batchClose: {
+      buttonText: '批量关闭',
+      closePopTitle: '您确认关闭所选工单吗？',
+      messageWarn:
+        '您所选的工单包含不可关闭的工单!（只有工单状态为“{{process}}”和“{{reject}}”的工单可以关闭。）'
+    },
+
+    exportWorkflow: {
+      buttonText: '导出工单',
+      exporting: '正在导出历史工单',
+      exportSuccessTips: '历史工单导出成功'
+    },
+
+    createButtonText: '创建工单',
+
+    name: '工单名称',
+    dataSource: '数据源',
+    schema: '数据库',
+    schemaPlaceholder: '请选择数据库（选填）',
+    createUser: '创建人',
+    assignee: '待操作人',
+    createTime: '创建时间',
+    executeTime: '上线时间',
+    desc: '工单描述',
+    status: '工单状态',
+    time: '定时时间',
+    stepType: '当前步骤类型',
+    sqlTaskStatus: 'Sql审核状态',
+    instanceName: '数据源',
+    passRate: '审核通过率',
+    taskScore: '审核结果评分',
+    id: '工单号'
+  },
+  create: {
+    backToList: '返回工单列表',
+    title: '创建工单',
+    mustAuditTips: '您必须先对您的SQL进行审核才能进行创建工单',
+    mustHaveAuditResultTips: '不能对审核结果为空的SQL进行创建工单',
+
+    form: {
+      baseInfo: {
+        title: '工单基本信息',
+
+        name: '工单名称',
+        workflowNameRule: '只能包含字母、数字、中文、中划线和下划线',
+        describe: '工单描述',
+        describePlaceholder: '点此添加工单描述（选填）'
+      },
+
+      sqlInfo: {
+        title: '审核SQL语句信息',
+
+        isSameSqlForAll: '选择相同SQL',
+        tipsDataSourceTypeForSameSql: '当数据源类型相同时，才能使用相同SQL模式',
+        sameSql: '相同Sql',
+        differenceSql: '不同Sql',
+
+        instanceName: '数据源',
+
+        instanceNameTips: '后续添加的数据源流程模板与当前数据源相同',
+        instanceSchema: '数据库',
+        schemaPlaceholder: '请选择数据库（选填）',
+
+        sql: 'SQL语句',
+        sqlFile: 'SQL文件',
+        sqlFileTips: '点击选择SQL文件或将文件拖拽到此区域',
+        mybatisFile: 'Mybatis的XML文件',
+        mybatisFileTips: '点击选择XML文件或将文件拖拽到此区域',
+        zipFile: 'zip文件',
+        zipFileTips: '点击选择zip文件或将文件拖拽到此区域',
+
+        addInstanceTips: '请添加数据源',
+        addInstance: '添加数据源',
+        uploadType: '选择SQL语句上传方式',
+        manualInput: '输入SQL语句',
+        uploadFile: '上传SQL文件',
+        updateMybatisFile: '上传Mybatis的XML文件',
+        uploadZipFile: '上传ZIP文件',
+
+        audit: '审核',
+        analyze: 'SQL分析',
+        format: 'SQL美化',
+        formatTips:
+          '目前，支持 SQL 美化的数据库类型有 {{supportType}}。如果未选择数据源或选择的数据源类型尚未得到支持，进行 SQL 美化可能会导致 SQL 语句语法错误。',
+
+        selectExecuteMode: '选择上线模式',
+        selectExecuteModeTips:
+          '当选择文件模式上线时，审核结果将以文件为单位进行聚合展示',
+        executeSqlMode: 'SQL模式',
+        executeFileMode: '文件模式'
+      }
+    },
+
+    auditResult: {
+      clearDuplicate: '数据去重',
+      allLevel: '全部等级',
+      submit: '提交工单',
+      updateInfo: '编辑工单信息',
+      disabledOperatorWorkflowBtnTips:
+        '项目 {{currentProject}} 创建工单时最高只能允许有 {{allowAuditLevel}} 等级的审核错误，但是当前审核结果中最高包含 {{currentAuditLevel}} 等级的审核结果。',
+      mustHaveAuditResultTips: '不能对审核结果为空的SQL进行创建工单',
+      leaveTip: '是否离开本页面？当前工单暂未提交！'
+    },
+    createResult: {
+      success: '工单创建成功',
+      guide: '查看刚刚创建的工单',
+      cloneWorkflow: '克隆工单',
+      viewWorkflowDetail: '查看工单详情'
+    }
+  },
+
+  audit: {
+    result: '审核结果',
+    passRage: '审核通过率',
+    source: '审核结果评分',
+    duplicate: '是否去重',
+    downloadSql: '下载SQL语句',
+    downloadReport: '下载审核报告',
+    table: {
+      number: '序号',
+      auditLevel: '规则等级',
+      auditStatus: '审核状态',
+      auditResult: '审核结果',
+      execSql: '执行语句',
+      execStatus: '执行状态',
+      execResult: '执行结果',
+      rollback: '回滚语句',
+      rollbackTips: '仅提示，不支持执行回滚',
+      describe: '说明',
+      analyze: '分析',
+      addDescribe: '添加说明'
+    },
+
+    filterForm: {
+      highestAuditLevel: '最高审核告警等级'
+    },
+
+    sqlFileSource: {
+      tips: '当前仅支持查看SQL/ZIP文件中的SQL来源',
+      source: '所在文件',
+      fileLine: '所在行'
+    },
+
+    auditStatus: {
+      initialized: '准备审核',
+      doing: '正在审核',
+      finished: '审核完毕'
+    },
+    copyExecSql: '复制执行语句',
+    auditSuccess: '审核通过',
+
+    fileModeExecute: {
+      headerTitle: '文件信息概览',
+      sqlsTips: '当前仅展示前5条数据，<0>查看更多<0>'
+    },
+
+    fileModeSqls: {
+      backToDetail: '返回工单详情',
+      title: '文件信息详情',
+
+      statistics: {
+        audit: '审核结果信息',
+        execute: '执行结果信息'
+      }
+    }
+  },
+
+  common: {
+    workflowStatus: {
+      finished: '上线成功',
+      canceled: '已关闭',
+      executing: '正在上线',
+      execFailed: '上线失败',
+      waitForAudit: '待审核',
+      waitForExecution: '待上线',
+      reject: '已驳回',
+
+      process: '处理中'
+    },
+    execStatus: {
+      initialized: '准备执行',
+      doing: '正在执行',
+      succeeded: '执行成功',
+      failed: '执行失败',
+      manually_executed: '人工执行',
+      terminate_fail: '中止失败',
+      terminate_succ: '中止成功',
+      terminating: '正在中止',
+      allStatus: '全部状态'
+    }
+  }
+};

--- a/packages/sqle/src/locale/zh-CN/index.ts
+++ b/packages/sqle/src/locale/zh-CN/index.ts
@@ -19,6 +19,7 @@ import sqlManagement from './sqlManagement';
 import sqlAudit from './sqlAudit';
 import pluginAudit from './pluginAudit';
 import sqlOptimization from './sqlOptimization';
+import execWorkflow from './execWorkflow';
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
@@ -43,6 +44,7 @@ export default {
     sqlManagement,
     sqlAudit,
     pluginAudit,
-    sqlOptimization
+    sqlOptimization,
+    execWorkflow
   }
 };

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.tsx
@@ -1,0 +1,92 @@
+import { Space } from 'antd';
+import { AuditResultFilterContainerStyleWrapper } from './style';
+import { AuditResultFilterContainerProps } from './index.type';
+import { CustomSegmentedFilter, EmptyBox } from '@actiontech/shared';
+import { useMemo } from 'react';
+import { AuditTaskResV1AuditLevelEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import classNames from 'classnames';
+import { floatToPercent } from '@actiontech/shared/lib/utils/Math';
+import { floatRound } from '@actiontech/shared/lib/utils/Math';
+import { useTranslation } from 'react-i18next';
+
+const AuditResultFilterContainer = <
+  T extends string | number | undefined = string
+>(
+  props: AuditResultFilterContainerProps<T>
+) => {
+  const { t } = useTranslation();
+  const {
+    score,
+    passRate,
+    instanceSchemaName,
+    auditLevel,
+    className,
+    ...filterProps
+  } = props;
+
+  const auditLevelScoreCommonClass = useMemo(() => {
+    return {
+      'audit-level-normal':
+        auditLevel === AuditTaskResV1AuditLevelEnum.normal || !auditLevel,
+      'audit-level-error': auditLevel === AuditTaskResV1AuditLevelEnum.error,
+      'audit-level-notice': auditLevel === AuditTaskResV1AuditLevelEnum.notice,
+      'audit-level-warn': auditLevel === AuditTaskResV1AuditLevelEnum.warn
+    };
+  }, [auditLevel]);
+
+  return (
+    <AuditResultFilterContainerStyleWrapper
+      className={classNames('audit-result-filter-container-wrapper')}
+    >
+      <CustomSegmentedFilter
+        {...filterProps}
+        noStyle
+        className="audit-result-filter-option"
+      />
+
+      <Space className="audit-result-info" size={20}>
+        <div className="audit-result-info-item">
+          <EmptyBox if={typeof passRate === 'number'} defaultNode="-">
+            <span
+              className={classNames(
+                'audit-result-info-item-value',
+                auditLevelScoreCommonClass
+              )}
+            >
+              {floatToPercent(passRate!)}%
+            </span>
+          </EmptyBox>
+
+          <span className="audit-result-info-item-text">
+            {t('execWorkflow.audit.passRage')}
+          </span>
+        </div>
+        <div className="audit-result-info-item">
+          <EmptyBox if={typeof score === 'number'} defaultNode="-">
+            <span
+              className={classNames(
+                'audit-result-info-item-value',
+                auditLevelScoreCommonClass
+              )}
+            >
+              {floatRound(score!)}
+            </span>
+          </EmptyBox>
+          <span className="audit-result-info-item-text">
+            {t('execWorkflow.audit.source')}
+          </span>
+        </div>
+        <EmptyBox if={!!instanceSchemaName}>
+          <div className="audit-result-info-item">
+            <span className="audit-result-info-item-schema-value">
+              {instanceSchemaName}
+            </span>
+            <span className="audit-result-info-item-text">Schema</span>
+          </div>
+        </EmptyBox>
+      </Space>
+    </AuditResultFilterContainerStyleWrapper>
+  );
+};
+
+export default AuditResultFilterContainer;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.type.ts
@@ -1,0 +1,12 @@
+import { AuditTaskResV1AuditLevelEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { CustomSegmentedFilterProps } from '@actiontech/shared/lib/components/CustomSegmentedFilter/index.type';
+
+export type AuditResultFilterContainerProps<
+  T extends string | number | undefined = string
+> = {
+  className?: string;
+  passRate?: number;
+  score?: number;
+  instanceSchemaName?: string;
+  auditLevel?: AuditTaskResV1AuditLevelEnum;
+} & Omit<CustomSegmentedFilterProps<T>, 'noStyle' | 'className'>;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/style.ts
@@ -1,0 +1,154 @@
+import { styled } from '@mui/material';
+
+export const AuditResultFilterContainerStyleWrapper = styled('div')`
+  display: flex;
+  padding: 20px 40px;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  border-bottom: 1px solid
+    ${({ theme }) => theme.sqleTheme.order.common.auditResultFilter.borderColor};
+  background: ${({ theme }) =>
+    theme.sqleTheme.order.common.auditResultFilter.bgColor};
+
+  &.audit-result-filter-container-borderless {
+    border-bottom: 0;
+  }
+
+  &.no-padding-style {
+    padding: 0;
+  }
+
+  .audit-result-info {
+    &-item {
+      display: flex;
+      padding: 8px 0;
+      flex-direction: column;
+      align-items: center;
+      border-radius: 4px;
+      background: ${({ theme }) =>
+        theme.sqleTheme.order.common.auditResultFilter.auditResultInfo
+          .itemBgColor};
+
+      &-text {
+        color: ${({ theme }) =>
+          theme.sqleTheme.order.common.auditResultFilter.auditResultInfo
+            .textColor};
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 20px;
+      }
+
+      &-value {
+        font-size: 16px;
+        font-weight: 700;
+        line-height: 24px;
+      }
+
+      &-schema-value {
+        color: ${({ theme }) =>
+          theme.sqleTheme.order.common.auditResultFilter.auditResultInfo
+            .schemaValueColor};
+        font-size: 16px;
+        font-weight: 700;
+        line-height: 24px;
+      }
+
+      &-value.audit-level-normal {
+        color: ${({ theme }) =>
+          theme.sqleTheme.statistics.auditRateStatus.success.color};
+      }
+
+      &-value.audit-level-error {
+        color: ${({ theme }) =>
+          theme.sqleTheme.statistics.auditRateStatus.error.color};
+      }
+
+      &-value.audit-level-notice {
+        color: ${({ theme }) =>
+          theme.sqleTheme.statistics.auditRateStatus.tip.color};
+      }
+
+      &-value.audit-level-warn {
+        color: ${({ theme }) =>
+          theme.sqleTheme.statistics.auditRateStatus.warning.color};
+      }
+    }
+  }
+
+  .audit-result-filter-option {
+    display: flex;
+
+    .custom-segmented-filter-item {
+      &:not(:last-of-type) {
+        margin-right: 8px;
+      }
+
+      cursor: pointer;
+      display: flex;
+      padding: 8px 16px;
+      flex-direction: column;
+      align-items: flex-start;
+      align-items: center;
+      border-radius: 4px;
+      background: ${({ theme }) =>
+        theme.sqleTheme.order.common.auditResultFilter.options.bgColor};
+      font-weight: 700;
+      line-height: 24px;
+      transition: background-color 0.3s;
+      transition: color 0.3s;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 20px;
+      color: ${({ theme }) =>
+        theme.sqleTheme.order.common.auditResultFilter.options.textColor};
+    }
+
+    .custom-segmented-filter-item-checked {
+      background: ${({ theme }) =>
+        theme.sqleTheme.order.common.auditResultFilter.options.activeBgColor};
+      color: ${({ theme }) =>
+        theme.sqleTheme.order.common.auditResultFilter.options.textActiveColor};
+    }
+  }
+`;
+
+export const AuditResultFilterOptionsStyleWrapper = styled('div')<{
+  active: boolean;
+}>`
+  cursor: pointer;
+  display: flex;
+  padding: 8px 16px;
+  flex-direction: column;
+  align-items: flex-start;
+  align-items: center;
+  border-radius: 4px;
+  background: ${({ active, theme }) =>
+    active
+      ? theme.sqleTheme.order.common.auditResultFilter.options.activeBgColor
+      : theme.sqleTheme.order.common.auditResultFilter.options.bgColor};
+  font-weight: 700;
+  line-height: 24px;
+  transition: background-color 0.3s;
+  transition: color 0.3s;
+
+  .text {
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 20px;
+    color: ${({ active, theme }) =>
+      active
+        ? theme.sqleTheme.order.common.auditResultFilter.options.textActiveColor
+        : theme.sqleTheme.order.common.auditResultFilter.options.textColor};
+  }
+
+  .num {
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 24px;
+    color: ${({ active, theme }) =>
+      active
+        ? theme.sqleTheme.order.common.auditResultFilter.options.numActiveColor
+        : theme.sqleTheme.order.common.auditResultFilter.options.numColor};
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/useAuditResultFilterParams.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/useAuditResultFilterParams.ts
@@ -1,0 +1,24 @@
+import {
+  getAuditTaskSQLsV2FilterAuditLevelEnum,
+  getAuditTaskSQLsV2FilterExecStatusEnum
+} from '@actiontech/shared/lib/api/sqle/service/task/index.enum';
+import { useState } from 'react';
+
+const useAuditResultFilterParams = () => {
+  const [noDuplicate, setNoDuplicate] = useState(false);
+  const [auditLevelFilterValue, setAuditLevelFilterValue] =
+    useState<getAuditTaskSQLsV2FilterAuditLevelEnum>();
+  const [execStatusFilterValue, setExecStatusFilterValue] =
+    useState<getAuditTaskSQLsV2FilterExecStatusEnum>();
+
+  return {
+    noDuplicate,
+    setNoDuplicate,
+    auditLevelFilterValue,
+    setAuditLevelFilterValue,
+    execStatusFilterValue,
+    setExecStatusFilterValue
+  };
+};
+
+export default useAuditResultFilterParams;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BackToList/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BackToList/index.tsx
@@ -1,0 +1,19 @@
+import { BasicButton } from '@actiontech/shared';
+import { IconLeftArrow } from '@actiontech/shared/lib/Icon/common';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+const BackToList: React.FC<{ isAuditing: boolean }> = ({ isAuditing }) => {
+  const { t } = useTranslation();
+  const { projectID } = useCurrentProject();
+  return (
+    <Link to={`/sqle/project/${projectID}/exec-workflow`}>
+      <BasicButton icon={<IconLeftArrow />} disabled={isAuditing}>
+        {t('execWorkflow.create.backToList')}
+      </BasicButton>
+    </Link>
+  );
+};
+
+export default BackToList;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.tsx
@@ -1,0 +1,39 @@
+import classNames from 'classnames';
+import { BasicInfoStyleWrapper } from './style';
+import { BasicInfoWrapperProps } from './index.type';
+import { IconOrderStatusWrapper } from '../../../../icon/Order';
+import { EmptyBox } from '@actiontech/shared';
+import { useTranslation } from 'react-i18next';
+import { orderStatusDictionary } from '../../../../hooks/useStaticStatus/index.data';
+
+const BasicInfoWrapper: React.FC<BasicInfoWrapperProps> = ({
+  title,
+  desc,
+  className,
+  status,
+  gap = 12
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <BasicInfoStyleWrapper
+      className={classNames(className)}
+      gap={gap}
+      status={status}
+    >
+      <EmptyBox if={!!status}>
+        <div className="workflow-base-info-status">
+          <IconOrderStatusWrapper />
+          <span className="workflow-base-info-status-text">
+            {status && t(orderStatusDictionary[status])}
+          </span>
+        </div>
+      </EmptyBox>
+
+      <div className="workflow-base-info-title">{title}</div>
+      <div className="workflow-base-info-desc">{desc ?? '-'}</div>
+    </BasicInfoStyleWrapper>
+  );
+};
+
+export default BasicInfoWrapper;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.type.ts
@@ -1,0 +1,9 @@
+import { WorkflowRecordResV2StatusEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+
+export type BasicInfoWrapperProps = {
+  title: string;
+  desc?: string;
+  status?: WorkflowRecordResV2StatusEnum;
+  className?: string;
+  gap?: number;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/style.ts
@@ -1,0 +1,67 @@
+import { WorkflowRecordResV2StatusEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { styled } from '@mui/material/styles';
+
+export const BasicInfoStyleWrapper = styled('div')<{
+  gap: number;
+  status?: WorkflowRecordResV2StatusEnum;
+}>`
+  display: flex;
+  padding: 24px 40px;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  border-bottom: 1px solid
+    ${({ theme }) => theme.sqleTheme.order.common.basicInfo.borderColor};
+  background: ${({ theme }) => theme.sqleTheme.order.common.basicInfo.bgColor};
+
+  &.hasTopHeader {
+    padding-top: 60px;
+  }
+
+  &.clearPaddingTop {
+    padding-top: 0;
+  }
+
+  .workflow-base-info-status {
+    position: relative;
+    display: flex;
+    height: 48px;
+    width: 64px;
+    justify-content: center;
+    margin-bottom: 20px;
+
+    .icon-workflow-status-wrapper {
+      position: absolute;
+      z-index: 9;
+      color: ${({ theme, status }) =>
+        status
+          ? theme.sqleTheme.statistics.auditResultStatusColor[status]
+          : theme.sqleTheme.statistics.auditResultStatusColor.wait_for_audit};
+    }
+
+    &-text {
+      margin-top: 10px;
+      z-index: 10;
+      color: ${({ theme }) => theme.sharedTheme.basic.colorWhite};
+      text-align: center;
+      font-size: 12px;
+      font-weight: 600;
+      line-height: 20px;
+    }
+  }
+
+  .workflow-base-info-title {
+    color: ${({ theme }) => theme.sqleTheme.order.common.basicInfo.titleColor};
+    font-size: 24px;
+    font-weight: 500;
+    line-height: 32px;
+    margin-bottom: ${({ gap }) => `${gap}px`};
+  }
+
+  .workflow-base-info-desc {
+    color: ${({ theme }) => theme.sqleTheme.order.common.basicInfo.descColor};
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 22px;
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/DownloadRecord/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/DownloadRecord/index.tsx
@@ -1,0 +1,85 @@
+import { Popover, Space } from 'antd';
+import { DownloadRecordProps } from './index.type';
+import { BasicButton } from '@actiontech/shared';
+import {
+  IconArrowDown,
+  IconArrowUp,
+  IconDownload
+} from '@actiontech/shared/lib/Icon';
+import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
+import {
+  IconOrderDownloadReport,
+  IconOrderDownloadSQL
+} from '../../../../icon/Order';
+import task from '@actiontech/shared/lib/api/sqle/service/task';
+import { DownloadDropdownStyleWrapper } from './style';
+
+const DownloadRecord: React.FC<DownloadRecordProps> = ({
+  noDuplicate,
+  taskId
+}) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const downloadSql = () => {
+    task.downloadAuditTaskSQLFileV1(
+      {
+        task_id: taskId
+      },
+      { responseType: 'blob' }
+    );
+    setOpen(false);
+  };
+
+  const downloadReport = () => {
+    task.downloadAuditTaskSQLReportV1(
+      {
+        task_id: taskId,
+        no_duplicate: noDuplicate
+      },
+      { responseType: 'blob' }
+    );
+    setOpen(false);
+  };
+
+  const renderDownloadDropdown = () => {
+    return (
+      <DownloadDropdownStyleWrapper>
+        <div className="download-record-item" onClick={downloadReport}>
+          <IconOrderDownloadReport className="download-record-item-icon" />
+          {t('execWorkflow.audit.downloadReport')}
+        </div>
+
+        <div className="download-record-item" onClick={downloadSql}>
+          <IconOrderDownloadSQL className="download-record-item-icon" />
+          {t('execWorkflow.audit.downloadSql')}
+        </div>
+      </DownloadDropdownStyleWrapper>
+    );
+  };
+
+  return (
+    <Popover
+      open={open}
+      arrow={false}
+      trigger={['click']}
+      onOpenChange={setOpen}
+      placement="bottomLeft"
+      content={renderDownloadDropdown()}
+      overlayInnerStyle={{
+        padding: 0
+      }}
+    >
+      <BasicButton size="small">
+        <Space size={5}>
+          <IconDownload />
+          {t('common.download')}
+          {open ? <IconArrowUp /> : <IconArrowDown />}
+        </Space>
+      </BasicButton>
+    </Popover>
+  );
+};
+
+export default DownloadRecord;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/DownloadRecord/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/DownloadRecord/index.type.ts
@@ -1,0 +1,4 @@
+export type DownloadRecordProps = {
+  noDuplicate: boolean;
+  taskId: string;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/DownloadRecord/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/DownloadRecord/style.ts
@@ -1,0 +1,47 @@
+import { styled } from '@mui/material';
+
+export const DownloadDropdownStyleWrapper = styled('div')`
+  display: flex;
+  width: 160px;
+  padding: 6px;
+  flex-direction: column;
+  align-items: start;
+  border-radius: 8px;
+  border: 1px solid
+    ${({ theme }) =>
+      theme.sqleTheme.order.createOrder.auditResult.download.borderColor};
+  background: ${({ theme }) =>
+    theme.sqleTheme.order.createOrder.auditResult.download.bgColor};
+  box-shadow: ${({ theme }) =>
+    theme.sqleTheme.order.createOrder.auditResult.download.boxShadow};
+
+  .download-record-item {
+    cursor: pointer;
+    display: flex;
+    height: 32px;
+    padding: 0 10px;
+    align-items: center;
+    align-self: stretch;
+    overflow: hidden;
+    color: ${({ theme }) =>
+      theme.sqleTheme.order.createOrder.auditResult.download.itemColor};
+    text-overflow: ellipsis;
+    font-size: 13px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 20px;
+    transition: background-color 0.3s;
+
+    &:hover {
+      border-radius: 4px;
+      background: ${({ theme }) =>
+        theme.sqleTheme.order.createOrder.auditResult.download.itemHoverColor};
+    }
+
+    &-icon {
+      margin-right: 6px;
+      color: ${({ theme }) =>
+        theme.sqleTheme.order.createOrder.auditResult.download.itemIconColor};
+    }
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/InstanceSegmentedLabel/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/InstanceSegmentedLabel/index.tsx
@@ -1,0 +1,40 @@
+import {
+  IconLevelError,
+  IconLevelNormal,
+  IconLevelNotice,
+  IconLevelWarn
+} from '@actiontech/shared/lib/Icon/LevelIcon';
+import { AuditTaskResV1AuditLevelEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { InstanceSegmentedLabelStyleWrapper } from './style';
+
+export type InstanceSegmentedLabelProps = {
+  auditLevel?: AuditTaskResV1AuditLevelEnum;
+  instanceName: string;
+};
+
+const InstanceSegmentedLabel: React.FC<InstanceSegmentedLabelProps> = ({
+  auditLevel,
+  instanceName
+}) => {
+  const levelIcon = () => {
+    if (auditLevel === AuditTaskResV1AuditLevelEnum.error) {
+      return <IconLevelError width={14} height={14} />;
+    } else if (auditLevel === AuditTaskResV1AuditLevelEnum.normal) {
+      return <IconLevelNormal width={14} height={14} />;
+    } else if (auditLevel === AuditTaskResV1AuditLevelEnum.notice) {
+      return <IconLevelNotice width={14} height={14} />;
+    } else if (auditLevel === AuditTaskResV1AuditLevelEnum.warn) {
+      return <IconLevelWarn width={14} height={14} />;
+    }
+    return null;
+  };
+
+  return (
+    <InstanceSegmentedLabelStyleWrapper className="instance-segmented-label">
+      <span className="instance-segmented-label-text">{instanceName}</span>
+      <span className="instance-segmented-label-icon">{levelIcon()}</span>
+    </InstanceSegmentedLabelStyleWrapper>
+  );
+};
+
+export default InstanceSegmentedLabel;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/InstanceSegmentedLabel/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/InstanceSegmentedLabel/style.ts
@@ -1,0 +1,12 @@
+import { styled } from '@mui/material';
+
+export const InstanceSegmentedLabelStyleWrapper = styled('div')`
+  .instance-segmented-label {
+    display: flex;
+    align-items: center;
+
+    &-icon {
+      margin-left: 4px;
+    }
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/style.ts
@@ -1,0 +1,25 @@
+import { styled } from '@mui/material';
+
+export const ToggleButtonStyleWrapper = styled('div')<{ active: boolean }>`
+  height: 28px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-radius: 4px;
+  border: 1px solid
+    ${({ theme }) =>
+      theme.sqleTheme.order.createOrder.auditResult.toggleButton.borderColor};
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 20px;
+  color: ${({ active, theme }) =>
+    !!active
+      ? theme.sqleTheme.order.createOrder.auditResult.toggleButton.activeColor
+      : theme.sqleTheme.order.createOrder.auditResult.toggleButton.color};
+  background: ${({ active, theme }) =>
+    !!active
+      ? theme.sqleTheme.order.createOrder.auditResult.toggleButton.activeBgColor
+      : theme.sqleTheme.order.createOrder.auditResult.toggleButton.bgColor};
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/AuditResultDrawer.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/AuditResultDrawer.tsx
@@ -1,0 +1,40 @@
+import ReportDrawer from '../../../../../../../../components/ReportDrawer';
+import useAuditResultRuleInfo from '../../../../../../../../components/ReportDrawer/useAuditResultRuleInfo';
+import { AuditResultDrawerProps } from './index.type';
+import { AuditResultDrawerTitleStyleWrapper } from './style';
+
+const AuditResultDrawer: React.FC<AuditResultDrawerProps> = ({
+  onClose,
+  open,
+  auditResultRecord,
+  dbType
+}) => {
+  const { auditResultRuleInfo } = useAuditResultRuleInfo(
+    auditResultRecord?.audit_result ?? [],
+    dbType ?? ''
+  );
+
+  return (
+    <ReportDrawer
+      open={open}
+      onClose={onClose}
+      data={{
+        auditResult: auditResultRuleInfo,
+        sql: auditResultRecord?.exec_sql ?? '',
+        sqlSourceFile: auditResultRecord?.sql_source_file ?? '',
+        sqlStartLine: auditResultRecord?.sql_start_line
+      }}
+      showSourceFile
+      title={
+        <AuditResultDrawerTitleStyleWrapper>
+          <span className="audit-result-drawer-number">
+            {auditResultRecord?.number ? `#${auditResultRecord.number}` : '-'}
+          </span>
+        </AuditResultDrawerTitleStyleWrapper>
+      }
+      showAnnotation
+    />
+  );
+};
+
+export default AuditResultDrawer;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/column.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/column.tsx
@@ -1,0 +1,115 @@
+import {
+  IAuditResult,
+  IAuditTaskSQLResV2
+} from '@actiontech/shared/lib/api/sqle/service/common';
+import {
+  ActiontechTableActionMeta,
+  ActiontechTableColumn
+} from '@actiontech/shared/lib/components/ActiontechTable';
+import { EditText, SQLRenderer } from '@actiontech/shared';
+import { tooltipsCommonProps } from '@actiontech/shared/lib/components/BasicToolTips';
+import { t } from '../../../../../../../../locale';
+import ResultIconRender from '../../../../../../../../components/AuditResultMessage/ResultIconRender';
+import AuditResultMessage from '../../../../../../../../components/AuditResultMessage';
+
+export const AuditResultForCreateWorkflowColumn = (
+  updateSqlDescribe: (sqlNum: number, sqlDescribe: string) => void,
+  onClickAuditResult: (record: IAuditTaskSQLResV2) => void
+): ActiontechTableColumn<IAuditTaskSQLResV2> => {
+  return [
+    {
+      dataIndex: 'number',
+      title: () => t('execWorkflow.audit.table.number'),
+      width: 100
+    },
+    {
+      dataIndex: 'exec_sql',
+      title: () => t('execWorkflow.audit.table.execSql'),
+      className: 'audit-result-exec-sql-column',
+      render: (sql = '', record) => {
+        return (
+          <SQLRenderer.Snippet
+            sql={sql}
+            rows={1}
+            tooltip={false}
+            onClick={() => onClickAuditResult(record)}
+            showCopyIcon
+          />
+        );
+      }
+    },
+    {
+      dataIndex: 'audit_result',
+      title: () => t('execWorkflow.audit.table.auditResult'),
+      className: 'audit-result-column',
+      render: (result: IAuditResult[], record) => {
+        return (
+          <div onClick={() => onClickAuditResult(record)}>
+            {result?.length > 1 ? (
+              <ResultIconRender
+                iconLevels={result.map((item) => {
+                  return item.level ?? '';
+                })}
+              />
+            ) : (
+              <AuditResultMessage
+                auditResult={
+                  Array.isArray(result) && result.length ? result[0] : {}
+                }
+              />
+            )}
+          </div>
+        );
+      }
+    },
+    {
+      dataIndex: 'description',
+      title: () => t('execWorkflow.audit.table.describe'),
+      className: 'audit-result-describe-column',
+      render: (description: string, record) => {
+        return (
+          <EditText
+            editButtonProps={{
+              children: t('execWorkflow.audit.table.addDescribe'),
+              size: 'small'
+            }}
+            editable={{
+              autoSize: true,
+              onEnd: (val) => {
+                updateSqlDescribe(record.number ?? 0, val);
+              }
+            }}
+            ellipsis={{
+              expandable: false,
+              tooltip: {
+                arrow: false,
+                ...tooltipsCommonProps(description, 500)
+              },
+              rows: 1
+            }}
+            value={description}
+          />
+        );
+      }
+    }
+  ];
+};
+
+export const AuditResultForCreateWorkflowActions = (
+  clickAnalyze: (sqlNum?: number) => void
+): ActiontechTableActionMeta<IAuditTaskSQLResV2>[] => {
+  return [
+    {
+      key: 'jumpAnalyze',
+      text: t('execWorkflow.audit.table.analyze'),
+      buttonProps: (record) => {
+        return {
+          onClick: (e) => {
+            e.stopPropagation();
+            clickAnalyze(record?.number);
+          }
+        };
+      }
+    }
+  ];
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/index.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from 'react';
+import { useBoolean, useRequest } from 'ahooks';
+
+import task from '@actiontech/shared/lib/api/sqle/service/task';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { IAuditTaskSQLResV2 } from '@actiontech/shared/lib/api/sqle/service/common';
+
+import {
+  ActiontechTable,
+  useTableRequestError,
+  useTableRequestParams
+} from '@actiontech/shared/lib/components/ActiontechTable';
+import { AuditResultTableProps } from './index.type';
+import {
+  AuditResultForCreateWorkflowActions,
+  AuditResultForCreateWorkflowColumn
+} from './column';
+import AuditResultDrawer from './AuditResultDrawer';
+
+const AuditResultTable: React.FC<AuditResultTableProps> = ({
+  noDuplicate,
+  taskID,
+  auditLevelFilterValue,
+  projectID,
+  updateTaskRecordCount,
+  dbType
+}) => {
+  const [currentAuditResultRecord, setCurrentAuditResultRecord] =
+    useState<IAuditTaskSQLResV2>();
+  const [
+    auditResultDrawerVisibility,
+    { setFalse: closeAuditResultDrawer, setTrue: openAuditResultDrawer }
+  ] = useBoolean();
+  const { pagination, tableChange, setPagination } = useTableRequestParams();
+  const { requestErrorMessage, handleTableRequestError } =
+    useTableRequestError();
+
+  const handleClickAnalyze = (sqlNum?: number) => {
+    if (typeof sqlNum === 'undefined') {
+      return;
+    }
+    window.open(
+      `/sqle/project/${projectID}/exec-workflow/${taskID}/${sqlNum}/analyze`
+    );
+  };
+  const updateSqlDescribeProtect = useRef(false);
+  const updateSqlDescribe = (sqlNum: number, sqlDescribe: string) => {
+    if (updateSqlDescribeProtect.current) {
+      return;
+    }
+    updateSqlDescribeProtect.current = true;
+    task
+      .updateAuditTaskSQLsV1({
+        number: `${sqlNum}`,
+        description: sqlDescribe,
+        task_id: taskID!
+      })
+      .then((res) => {
+        if (res.data.code === ResponseCode.SUCCESS) {
+          refresh();
+        }
+      })
+      .finally(() => {
+        updateSqlDescribeProtect.current = false;
+      });
+  };
+
+  const onClickAuditResult = (record: IAuditTaskSQLResV2) => {
+    openAuditResultDrawer();
+    setCurrentAuditResultRecord(record);
+  };
+
+  const { data, loading, refresh } = useRequest(
+    () =>
+      handleTableRequestError(
+        task.getAuditTaskSQLsV2({
+          task_id: taskID!,
+          filter_audit_level: auditLevelFilterValue,
+          page_index: pagination.page_index.toString(),
+          page_size: pagination.page_size.toString(),
+          no_duplicate: noDuplicate
+        })
+      ),
+    {
+      ready: typeof taskID === 'string',
+      refreshDeps: [pagination, taskID],
+      onSuccess(res) {
+        console.log(auditLevelFilterValue);
+        if (auditLevelFilterValue === undefined) {
+          updateTaskRecordCount?.(taskID ?? '', res.total ?? 0);
+        }
+      },
+      onError() {
+        updateTaskRecordCount?.(taskID ?? '', 0);
+      }
+    }
+  );
+
+  // @feature: useTableRequestParams 整合自定义filter info
+  useEffect(() => {
+    setPagination({
+      page_index: 1,
+      page_size: pagination.page_size
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auditLevelFilterValue, noDuplicate]);
+
+  return (
+    <>
+      <ActiontechTable
+        errorMessage={requestErrorMessage}
+        rowKey="number"
+        columns={AuditResultForCreateWorkflowColumn(
+          updateSqlDescribe,
+          onClickAuditResult
+        )}
+        loading={loading}
+        dataSource={data?.list}
+        onChange={tableChange}
+        pagination={{
+          total: data?.total ?? 0,
+          current: pagination.page_index ?? 1
+        }}
+        actions={AuditResultForCreateWorkflowActions(handleClickAnalyze)}
+      />
+      <AuditResultDrawer
+        open={auditResultDrawerVisibility}
+        onClose={closeAuditResultDrawer}
+        auditResultRecord={currentAuditResultRecord}
+        dbType={dbType}
+      />
+    </>
+  );
+};
+
+export default AuditResultTable;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/index.type.ts
@@ -1,0 +1,18 @@
+import { IAuditTaskSQLResV2 } from '@actiontech/shared/lib/api/sqle/service/common';
+import { getAuditTaskSQLsV2FilterAuditLevelEnum } from '@actiontech/shared/lib/api/sqle/service/task/index.enum';
+
+export type AuditResultTableProps = {
+  noDuplicate: boolean;
+  taskID?: string;
+  auditLevelFilterValue?: getAuditTaskSQLsV2FilterAuditLevelEnum;
+  projectID: string;
+  updateTaskRecordCount?: (taskId: string, sqlNumber: number) => void;
+  dbType?: string;
+};
+
+export type AuditResultDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  auditResultRecord?: IAuditTaskSQLResV2;
+  dbType?: string;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/Table/style.ts
@@ -1,0 +1,16 @@
+import { styled } from '@mui/material/styles';
+
+export const AuditResultDrawerTitleStyleWrapper = styled(`div`)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .audit-result-drawer-number {
+    color: ${({ theme }) =>
+      theme.sqleTheme.order.createOrder.auditResult.auditResultDrawer
+        .numberColor};
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 21px;
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/index.type.ts
@@ -1,0 +1,6 @@
+import { IAuditTaskResV1 } from '@actiontech/shared/lib/api/sqle/service/common';
+
+export type AuditResultListProps = {
+  tasks: IAuditTaskResV1[];
+  updateTaskRecordCount?: (taskId: string, sqlNumber: number) => void;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/AuditResultList/style.ts
@@ -1,0 +1,24 @@
+import { styled } from '@mui/material';
+
+export const AuditResultForCreateWorkflowStyleWrapper = styled('section')`
+  .audit-result-describe-column {
+    max-width: 600px;
+  }
+
+  .audit-result-exec-sql-column,
+  .audit-result-column {
+    max-width: 500px;
+    cursor: pointer;
+  }
+
+  .instance-segmented-label {
+    display: flex;
+    align-items: center;
+
+    &-icon {
+      display: flex;
+      align-items: center;
+      margin-left: 4px;
+    }
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/BaseInfoTag.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/BaseInfoTag.tsx
@@ -1,0 +1,30 @@
+import { BasicTag } from '@actiontech/shared';
+import {
+  IconProjectFlag,
+  IconClock,
+  IconUser
+} from '@actiontech/shared/lib/Icon/common';
+import { Space } from 'antd';
+import dayjs from 'dayjs';
+import {
+  useCurrentProject,
+  useCurrentUser
+} from '@actiontech/shared/lib/global';
+
+const BaseInfoTag: React.FC = () => {
+  const { projectName } = useCurrentProject();
+  const { username } = useCurrentUser();
+  return (
+    <Space className="base-info-form-item-slot">
+      <BasicTag icon={<IconProjectFlag width={12} height={12} />}>
+        {projectName}
+      </BasicTag>
+      <BasicTag icon={<IconClock width={12} height={12} />}>
+        {dayjs().format('YYYY-MM-DD')}
+      </BasicTag>
+      <BasicTag icon={<IconUser width={12} height={12} />}>{username}</BasicTag>
+    </Space>
+  );
+};
+
+export default BaseInfoTag;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/index.tsx
@@ -1,0 +1,93 @@
+import { BasicDrawer } from '@actiontech/shared';
+import {
+  UpdateBaseInfoFormStyleWrapper,
+  UpdateWorkflowFormTitleStyleWrapper,
+  UpdateSqlAuditInfoFormStyleWrapper
+} from './style';
+import { useForm } from 'antd/es/form/Form';
+import { useTranslation } from 'react-i18next';
+import BaseInfoTag from './BaseInfoTag';
+import { useRef } from 'react';
+import { Divider, Spin } from 'antd';
+import {
+  SqlAuditInfoFormFields,
+  WorkflowBaseInfoFormFields
+} from '../../../../index.type';
+import { UpdateFormDrawerProps } from './index.type';
+import { SqlAuditInfoFormProps } from '../../../FormStep/SqlAuditInfoForm/index.type';
+import BaseInfoFormItem from '../../../FormStep/BaseInfoForm/BaseInfoFormItem';
+import SqlAuditInfoFormItem from '../../../FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem';
+
+const UpdateFormDrawer: React.FC<UpdateFormDrawerProps> = ({
+  open,
+  onClose,
+  baseFormValues,
+  sqlAuditInfoFormValues,
+  auditAction,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const syncDataReady = useRef(false);
+  const [baseInfoForm] = useForm<WorkflowBaseInfoFormFields>();
+  const [sqlAuditInfoForm] = useForm<SqlAuditInfoFormFields>();
+
+  const closeHandle = () => {
+    if (props.isAuditing.value) {
+      return;
+    }
+
+    onClose();
+  };
+
+  const internalSubmit: SqlAuditInfoFormProps['auditAction'] = (values) => {
+    return auditAction(values, baseInfoForm.getFieldsValue()).finally(() => {
+      onClose();
+    });
+  };
+
+  return (
+    <BasicDrawer
+      afterOpenChange={(_open) => {
+        if (_open && !syncDataReady.current) {
+          baseInfoForm.setFieldsValue({ ...baseFormValues });
+          sqlAuditInfoForm.setFieldsValue({ ...sqlAuditInfoFormValues });
+          syncDataReady.current = true;
+        }
+      }}
+      open={open}
+      size="large"
+      title={false}
+      closeIcon={false}
+      onClose={closeHandle}
+      bodyStyle={{
+        padding: 0
+      }}
+      width={735}
+      noBodyPadding
+    >
+      <Spin spinning={props.isAuditing.value}>
+        <UpdateBaseInfoFormStyleWrapper form={baseInfoForm}>
+          <UpdateWorkflowFormTitleStyleWrapper>
+            {t('execWorkflow.create.form.baseInfo.title')}
+          </UpdateWorkflowFormTitleStyleWrapper>
+          <BaseInfoFormItem slot={<BaseInfoTag />} />
+        </UpdateBaseInfoFormStyleWrapper>
+
+        <Divider style={{ marginTop: 12 }} />
+
+        <UpdateSqlAuditInfoFormStyleWrapper
+          labelAlign="left"
+          form={sqlAuditInfoForm}
+          colon={false}
+        >
+          <UpdateWorkflowFormTitleStyleWrapper>
+            {t('execWorkflow.create.form.sqlInfo.title')}
+          </UpdateWorkflowFormTitleStyleWrapper>
+          <SqlAuditInfoFormItem auditAction={internalSubmit} {...props} />
+        </UpdateSqlAuditInfoFormStyleWrapper>
+      </Spin>
+    </BasicDrawer>
+  );
+};
+
+export default UpdateFormDrawer;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/index.type.ts
@@ -1,0 +1,14 @@
+import {
+  SharedStepDetails,
+  SqlAuditInfoFormFields,
+  WorkflowBaseInfoFormFields
+} from '../../../../index.type';
+import { SqlAuditInfoFormProps } from '../../../FormStep/SqlAuditInfoForm/index.type';
+
+export type UpdateFormDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  baseFormValues?: WorkflowBaseInfoFormFields;
+  sqlAuditInfoFormValues?: SqlAuditInfoFormFields;
+} & Omit<SqlAuditInfoFormProps, 'form'> &
+  SharedStepDetails;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/components/UpdateFormDrawer/style.ts
@@ -1,0 +1,73 @@
+import { styled } from '@mui/material/styles';
+import { Form } from 'antd';
+
+export const UpdateWorkflowFormTitleStyleWrapper = styled('div')`
+  color: ${({ theme }) =>
+    theme.sqleTheme.order.createOrder.editForm.titleColor};
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 20px;
+  margin-bottom: 24px;
+`;
+
+export const UpdateBaseInfoFormStyleWrapper = styled(Form)`
+  padding: 24px 24px 0 !important;
+
+  .ant-input.basic-input-wrapper.workflow-name-input-wrapper {
+    border: none !important;
+    padding: 0 0 16px !important;
+  }
+
+  .workflow-base-info-desc-form-item {
+    margin-bottom: 0 !important;
+
+    .ant-input-affix-wrapper {
+      border: none !important;
+
+      &:focus {
+        box-shadow: none !important;
+      }
+    }
+  }
+
+  .base-info-form-item-slot {
+    margin-bottom: 16px;
+
+    .project-flag-icon {
+      color: ${({ theme }) =>
+        theme.sqleTheme.order.createOrder.editForm.projectFlagIconColor};
+    }
+  }
+
+  .ant-form-item {
+    .ant-form-item-label {
+      display: none !important;
+    }
+  }
+`;
+
+export const UpdateSqlAuditInfoFormStyleWrapper = styled(Form)`
+  padding: 0 24px 24px !important;
+
+  .custom-icon-ellipse {
+    margin-right: 8px;
+  }
+
+  .data-source-row-select {
+    width: 276px !important;
+  }
+
+  .data-source-row-divider {
+    height: 36px !important;
+    margin: 0 !important;
+  }
+
+  .data-source-row-button {
+    height: 36px !important;
+    width: 36px !important;
+  }
+
+  .data-source-col-delete-button {
+    width: 35px !important;
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/index.tsx
@@ -1,0 +1,91 @@
+import BasicInfoWrapper from '../../../Common/BasicInfoWrapper';
+import { AuditResultStepProps } from './index.type';
+import { BasicButton, BasicToolTips, PageHeader } from '@actiontech/shared';
+import BackToList from '../../../Common/BackToList';
+import { Space } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { useBoolean } from 'ahooks';
+import AuditResultList from './components/AuditResultList';
+import UpdateFormDrawer from './components/UpdateFormDrawer';
+
+const AuditResultStep: React.FC<AuditResultStepProps> = ({
+  baseFormValues,
+  tasks,
+  isAuditing,
+  isDisableFinallySubmitButton,
+  disabledOperatorOrderBtnTips,
+  updateTaskRecordCount,
+  createAction,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const [creating, { setFalse: finishCreate, setTrue: startCreate }] =
+    useBoolean();
+  const [
+    updateSqlAuditInfoOpen,
+    {
+      setFalse: closeUpdateSqlAuditInfoDrawer,
+      setTrue: openUpdateSqlAuditInfoDrawer
+    }
+  ] = useBoolean(false);
+
+  const internalCreateWorkflow = () => {
+    startCreate();
+
+    createAction().finally(() => {
+      finishCreate();
+    });
+  };
+
+  return (
+    <>
+      <PageHeader
+        title={<BackToList isAuditing={isAuditing.value} />}
+        extra={
+          <Space>
+            <BasicButton
+              onClick={openUpdateSqlAuditInfoDrawer}
+              disabled={creating}
+            >
+              {t('execWorkflow.create.auditResult.updateInfo')}
+            </BasicButton>
+            <BasicToolTips
+              title={
+                isDisableFinallySubmitButton ? disabledOperatorOrderBtnTips : ''
+              }
+              overlayClassName="whitespace-pre-line"
+            >
+              <BasicButton
+                loading={creating}
+                disabled={isDisableFinallySubmitButton || creating}
+                type="primary"
+                onClick={internalCreateWorkflow}
+              >
+                {t('execWorkflow.create.auditResult.submit')}
+              </BasicButton>
+            </BasicToolTips>
+          </Space>
+        }
+      />
+      <BasicInfoWrapper
+        title={baseFormValues?.workflow_subject ?? ''}
+        desc={baseFormValues?.desc}
+      />
+
+      <AuditResultList
+        tasks={tasks}
+        updateTaskRecordCount={updateTaskRecordCount}
+      />
+
+      <UpdateFormDrawer
+        open={updateSqlAuditInfoOpen}
+        onClose={closeUpdateSqlAuditInfoDrawer}
+        baseFormValues={baseFormValues}
+        isAuditing={isAuditing}
+        {...props}
+      />
+    </>
+  );
+};
+
+export default AuditResultStep;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/index.type.ts
@@ -1,0 +1,20 @@
+import { IAuditTaskResV1 } from '@actiontech/shared/lib/api/sqle/service/common';
+import {
+  SharedStepDetails,
+  SqlAuditInfoFormFields,
+  WorkflowBaseInfoFormFields
+} from '../../index.type';
+
+export type AuditResultStepProps = {
+  tasks: IAuditTaskResV1[];
+  updateTaskRecordCount?: (taskId: string, sqlNumber: number) => void;
+  baseFormValues?: WorkflowBaseInfoFormFields;
+  sqlAuditInfoFormValues?: SqlAuditInfoFormFields;
+  isDisableFinallySubmitButton: boolean;
+  disabledOperatorOrderBtnTips: string;
+  createAction: () => Promise<void>;
+  auditAction: (
+    value: SqlAuditInfoFormFields,
+    baseInfo?: WorkflowBaseInfoFormFields
+  ) => Promise<void>;
+} & SharedStepDetails;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/CreateResultStep/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/CreateResultStep/index.tsx
@@ -1,0 +1,38 @@
+import { BasicButton, BasicResult, PageHeader } from '@actiontech/shared';
+import { IconSuccessResult } from '@actiontech/shared/lib/Icon/common';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { CreateResultStepProps } from './index.type';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import BackToList from '../../../Common/BackToList';
+
+const CreateResultStep: React.FC<CreateResultStepProps> = ({
+  workflowID,
+  desc
+}) => {
+  const { t } = useTranslation();
+  const { projectID } = useCurrentProject();
+
+  return (
+    <>
+      <PageHeader title={<BackToList isAuditing={false} />} />
+      <BasicResult
+        icon={<IconSuccessResult />}
+        title={t('execWorkflow.create.createResult.success')}
+        subTitle={desc}
+        extra={[
+          <Link
+            key="jumpToWorkflowOrderDetail"
+            to={`/sqle/project/${projectID}/exec-workflow/${workflowID}`}
+          >
+            <BasicButton type="primary">
+              {t('execWorkflow.create.createResult.guide')}
+            </BasicButton>
+          </Link>
+        ]}
+      />
+    </>
+  );
+};
+
+export default CreateResultStep;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/CreateResultStep/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/CreateResultStep/index.type.ts
@@ -1,0 +1,4 @@
+export type CreateResultStepProps = {
+  workflowID: string;
+  desc?: string;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/BaseInfoForm/BaseInfoFormItem.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/BaseInfoForm/BaseInfoFormItem.tsx
@@ -1,0 +1,64 @@
+import { BasicInput } from '@actiontech/shared';
+import {
+  FormInputBotBorder,
+  FormItemNoLabel,
+  FormItemLabel
+} from '@actiontech/shared/lib/components/FormCom';
+import { workflowNameRule } from '@actiontech/shared/lib/utils/FormRule';
+import { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const BaseInfoFormItem: React.FC<{ slot?: ReactNode }> = ({ slot }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <FormItemNoLabel
+        name="workflow_subject"
+        rules={[
+          {
+            required: true,
+            message: t('common.form.placeholder.input', {
+              name: t('execWorkflow.create.form.baseInfo.name')
+            })
+          },
+          {
+            validator: workflowNameRule()
+          },
+          {
+            max: 59
+          }
+        ]}
+      >
+        <FormInputBotBorder
+          className="workflow-name-input-wrapper"
+          placeholder={t('common.form.placeholder.input', {
+            name: t('execWorkflow.create.form.baseInfo.name')
+          })}
+        />
+      </FormItemNoLabel>
+
+      {slot}
+
+      <FormItemLabel
+        className="workflow-base-info-desc-form-item"
+        name="desc"
+        label={t('execWorkflow.create.form.baseInfo.describe')}
+      >
+        <BasicInput.TextArea
+          autoSize={{
+            maxRows: 10,
+            minRows: 8
+          }}
+          placeholder={t(
+            'execWorkflow.create.form.baseInfo.describePlaceholder'
+          )}
+          maxLength={3000}
+          showCount
+        />
+      </FormItemLabel>
+    </>
+  );
+};
+
+export default BaseInfoFormItem;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/BaseInfoForm/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/BaseInfoForm/index.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+import {
+  FormAreaBlockStyleWrapper,
+  FormAreaLineStyleWrapper
+} from '@actiontech/shared/lib/components/FormCom/style';
+import { FormItemBigTitle } from '@actiontech/shared/lib/components/FormCom';
+import BaseInfoFormItem from './BaseInfoFormItem';
+import { IconWorkflowCreateTitle } from '../../../../../../icon/SqlExecWorkflow';
+import useThemeStyleData from '../../../../../../hooks/useThemeStyleData';
+
+const BaseInfoForm: React.FC = () => {
+  const { t } = useTranslation();
+  const { sqleTheme } = useThemeStyleData();
+
+  return (
+    <FormAreaLineStyleWrapper className="has-border">
+      <FormAreaBlockStyleWrapper>
+        <FormItemBigTitle>
+          <IconWorkflowCreateTitle
+            color={sqleTheme.order.createOrder.form.baseInfoTitleIconColor}
+          />
+          <span>{t('execWorkflow.create.title')}</span>
+        </FormItemBigTitle>
+        <BaseInfoFormItem />
+      </FormAreaBlockStyleWrapper>
+    </FormAreaLineStyleWrapper>
+  );
+};
+
+export default BaseInfoForm;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/hooks/useRenderDatabaseSelectionItems.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/hooks/useRenderDatabaseSelectionItems.tsx
@@ -1,0 +1,186 @@
+import instance from '@actiontech/shared/lib/api/sqle/service/instance';
+import { DatabaseSelectionItemProps } from '../../../index.type';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { BasicButton, BasicToolTips } from '@actiontech/shared';
+import {
+  IconDelete,
+  IconDeleteActive,
+  IconFillList,
+  IconFillListActive
+} from '@actiontech/shared/lib/Icon/common';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { FormListFieldData } from 'antd';
+
+const useRenderDatabaseSelectionItems = ({
+  dbSourceInfoCollection,
+  sqlStatementTabActiveKey
+}: Pick<
+  DatabaseSelectionItemProps,
+  'dbSourceInfoCollection' | 'sqlStatementTabActiveKey'
+>) => {
+  const { t } = useTranslation();
+  const { projectName, projectID } = useCurrentProject();
+  const updateSchemaList = async (key: string, instanceName: string) => {
+    instance
+      .getInstanceSchemasV1({
+        instance_name: instanceName,
+        project_name: projectName
+      })
+      .then((res) => {
+        if (res.data.code === ResponseCode.SUCCESS) {
+          dbSourceInfoCollection.set(key, {
+            schemaList: res.data.data?.schema_name_list
+          });
+        }
+      })
+      .finally(() => {
+        dbSourceInfoCollection.set(key, {
+          getSchemaLoading: false
+        });
+      });
+  };
+
+  const updateRuleTemplateName = (key: string, instanceName: string) => {
+    instance
+      .getInstanceV2({ instance_name: instanceName, project_name: projectName })
+      .then((res) => {
+        if (res.data.code === ResponseCode.SUCCESS) {
+          dbSourceInfoCollection.set(key, {
+            dbType: res.data.data?.db_type,
+            ruleTemplate: res.data.data?.rule_template
+          });
+        }
+      });
+  };
+
+  const handleInstanceChange = async (key: string, instanceName?: string) => {
+    if (instanceName) {
+      dbSourceInfoCollection.set(key, {
+        instanceName,
+        schemaName: undefined,
+        getSchemaLoading: true
+      });
+      updateSchemaList(key, instanceName);
+      updateRuleTemplateName(key, instanceName);
+      sqlStatementTabActiveKey.set(key);
+    }
+  };
+
+  const handleInstanceSchemaChange = (key: string, schemaName?: string) => {
+    dbSourceInfoCollection.set(key, {
+      schemaName
+    });
+  };
+
+  const getInstanceSchemaOptions = (key: string) => {
+    return (
+      dbSourceInfoCollection.value?.[key]?.schemaList?.map((item) => {
+        return {
+          label: item,
+          value: item
+        };
+      }) ?? []
+    );
+  };
+
+  const getInstanceSchemaLoading = (key: string) => {
+    return dbSourceInfoCollection.value?.[key]?.getSchemaLoading;
+  };
+
+  const renderRuleTemplateDisplay = (key: string) => {
+    const rule = dbSourceInfoCollection.value?.[key]?.ruleTemplate;
+    const dbType = dbSourceInfoCollection.value?.[key]?.dbType;
+
+    if (!rule || !dbType) {
+      return (
+        <BasicButton className="data-source-row-rule-template">
+          <IconFillList />
+        </BasicButton>
+      );
+    }
+
+    const path = rule.is_global_rule_template
+      ? `/sqle/rule-manager/global-detail/${rule.name}/${dbType}`
+      : `/sqle/project/${projectID}/rule/template/detail/${rule.name}/${dbType}`;
+
+    return (
+      <BasicToolTips
+        title={
+          <Link to={path} target="_blank">
+            {t('rule.form.ruleTemplate')}: {rule.name}
+          </Link>
+        }
+      >
+        <BasicButton className="data-source-row-rule-template">
+          <IconFillListActive />
+        </BasicButton>
+      </BasicToolTips>
+    );
+  };
+
+  const renderDeleteItemButton = (
+    fields: FormListFieldData[],
+    key: string,
+    handleClick: () => void
+  ) => {
+    const removeItem = () => {
+      dbSourceInfoCollection.set(key, undefined);
+      sqlStatementTabActiveKey.set(
+        Object.keys(dbSourceInfoCollection.value).filter(
+          (v) => v !== key
+        )?.[0] ?? ''
+      );
+    };
+
+    return (
+      <BasicButton
+        className="data-source-row-button data-source-col-delete-button"
+        onClick={() => {
+          if (fields.length <= 1) {
+            return;
+          }
+          handleClick();
+          removeItem();
+        }}
+      >
+        {fields.length > 1 ? <IconDeleteActive /> : <IconDelete />}
+      </BasicButton>
+    );
+  };
+
+  const renderAddItemButton = (
+    fields: FormListFieldData[],
+    handleClick: () => void
+  ) => {
+    /**
+     * 新增时为什么没有同步更新 dbSourceInfoCollection
+     * 由于无法获取最新的 key，所以无法直接在这里新增。只能通过选择数据源时更新 dbSourceInfoCollection 数据
+     */
+    const addAction = () => {
+      handleClick();
+    };
+    return (
+      <BasicButton
+        onClick={addAction}
+        type="primary"
+        disabled={fields.length >= 10}
+      >
+        {t('execWorkflow.create.form.sqlInfo.addInstance')}
+      </BasicButton>
+    );
+  };
+
+  return {
+    handleInstanceChange,
+    handleInstanceSchemaChange,
+    getInstanceSchemaOptions,
+    getInstanceSchemaLoading,
+    renderRuleTemplateDisplay,
+    renderDeleteItemButton,
+    renderAddItemButton
+  };
+};
+
+export default useRenderDatabaseSelectionItems;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/hooks/useTestDatabaseConnect.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/hooks/useTestDatabaseConnect.tsx
@@ -1,0 +1,110 @@
+import { BasicToolTips } from '@actiontech/shared';
+import { IconFailed, IconSucceeded } from '@actiontech/shared/lib/Icon/common';
+import instance from '@actiontech/shared/lib/api/sqle/service/instance';
+import { TestConnectResultStyleWrapper } from '@actiontech/shared/lib/components/TestDatabaseConnectButton/style';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import { useBoolean } from 'ahooks';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DatabaseSelectionItemProps } from '../../../index.type';
+import { IBatchCheckInstanceIsConnectableByNameParams } from '@actiontech/shared/lib/api/sqle/service/instance/index.d';
+import { DatabaseSelectionFields } from '../index.type';
+
+const useTestDatabaseConnect = ({
+  databaseInfo,
+  instanceTestConnectResults
+}: {
+  databaseInfo: Array<DatabaseSelectionFields>;
+  instanceTestConnectResults: DatabaseSelectionItemProps['instanceTestConnectResults'];
+}) => {
+  const { t } = useTranslation();
+  const { projectName } = useCurrentProject();
+  const [testLoading, { setTrue: testStart, setFalse: testFinish }] =
+    useBoolean();
+
+  const disabledTestConnect = useMemo(
+    () =>
+      databaseInfo?.map((v) => v?.instanceName)?.filter((v: string) => !!v)
+        .length === 0,
+    [databaseInfo]
+  );
+
+  const testDatabaseConnect = useCallback(async () => {
+    const instances =
+      (databaseInfo ?? [])
+        .map((v) => ({
+          name: v?.instanceName
+        }))
+        ?.filter((v: { name: string }) => !!v.name) ?? [];
+
+    if (instances.length === 0) {
+      return;
+    }
+
+    const params: IBatchCheckInstanceIsConnectableByNameParams = {
+      instances: instances,
+      project_name: projectName
+    };
+
+    testStart();
+    instance
+      .batchCheckInstanceIsConnectableByName(params)
+      .then((res) => {
+        if (res.data.code === ResponseCode.SUCCESS) {
+          instanceTestConnectResults.set(res.data.data ?? []);
+        }
+      })
+      .finally(() => {
+        testFinish();
+      });
+  }, [
+    databaseInfo,
+    instanceTestConnectResults,
+    projectName,
+    testFinish,
+    testStart
+  ]);
+
+  const renderTestDatabasesConnectInfo = useCallback(
+    (name: string) => {
+      const result = instanceTestConnectResults.value?.find(
+        (v) => v.instance_name === name
+      );
+      if (!result) {
+        return null;
+      }
+
+      return (
+        <TestConnectResultStyleWrapper
+          success={!!result.is_instance_connectable}
+        >
+          {!!result.is_instance_connectable && (
+            <TestConnectResultStyleWrapper success>
+              <IconSucceeded />
+              {t('common.testDatabaseConnectButton.testSuccess')}
+            </TestConnectResultStyleWrapper>
+          )}
+          {!result.is_instance_connectable && (
+            <BasicToolTips title={result.connect_error_message}>
+              <TestConnectResultStyleWrapper success={false}>
+                <IconFailed />
+                {t('common.testDatabaseConnectButton.testFailed')}
+              </TestConnectResultStyleWrapper>
+            </BasicToolTips>
+          )}
+        </TestConnectResultStyleWrapper>
+      );
+    },
+    [instanceTestConnectResults.value, t]
+  );
+
+  return {
+    testDatabaseConnect,
+    testLoading,
+    renderTestDatabasesConnectInfo,
+    disabledTestConnect
+  };
+};
+
+export default useTestDatabaseConnect;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/index.tsx
@@ -1,0 +1,196 @@
+import {
+  IconDatabase,
+  IconDatabaseActive,
+  IconDatabaseSchema,
+  IconDatabaseSchemaActive,
+  IconEllipse
+} from '@actiontech/shared/lib/Icon/common';
+import {
+  FormItemLabel,
+  FormItemNoLabel
+} from '@actiontech/shared/lib/components/FormCom';
+import { useTranslation } from 'react-i18next';
+import { DatabaseSelectionItemProps } from '../../index.type';
+import { Divider, Form, Space } from 'antd';
+import { useEffect } from 'react';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import useInstance from '../../../../../../../../hooks/useInstance';
+import { getInstanceTipListV1FunctionalModuleEnum } from '@actiontech/shared/lib/api/sqle/service/instance/index.enum';
+import useTestDatabaseConnect from './hooks/useTestDatabaseConnect';
+import { SqlAuditInfoFormFields } from '../../../../../index.type';
+import { CustomSelect } from '@actiontech/shared/lib/components/CustomSelect';
+import useRenderDatabaseSelectionItems from './hooks/useRenderDatabaseSelectionItems';
+import { BasicButton } from '@actiontech/shared';
+
+const DatabaseSelectionItem: React.FC<DatabaseSelectionItemProps> = ({
+  dbSourceInfoCollection,
+  instanceTestConnectResults,
+  sqlStatementTabActiveKey,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const form = Form.useFormInstance<SqlAuditInfoFormFields>();
+  const { projectName } = useCurrentProject();
+
+  const {
+    testDatabaseConnect,
+    testLoading,
+    renderTestDatabasesConnectInfo,
+    disabledTestConnect
+  } = useTestDatabaseConnect({
+    databaseInfo: Form.useWatch('databaseInfo', form),
+    instanceTestConnectResults: instanceTestConnectResults
+  });
+
+  const {
+    handleInstanceChange,
+    handleInstanceSchemaChange,
+    getInstanceSchemaOptions,
+    getInstanceSchemaLoading,
+    renderRuleTemplateDisplay,
+    renderDeleteItemButton,
+    renderAddItemButton
+  } = useRenderDatabaseSelectionItems({
+    dbSourceInfoCollection,
+    sqlStatementTabActiveKey
+  });
+
+  const {
+    loading: instanceTipsLoading,
+    updateInstanceList,
+    instanceOptions
+  } = useInstance();
+
+  useEffect(() => {
+    updateInstanceList({
+      project_name: projectName,
+      functional_module:
+        getInstanceTipListV1FunctionalModuleEnum.create_workflow
+    });
+  }, [projectName, updateInstanceList]);
+
+  return (
+    <>
+      <FormItemLabel
+        className="has-required-style form-item-label-mb-16"
+        label={
+          <>
+            <IconEllipse />
+            <span>{t('execWorkflow.create.form.sqlInfo.instanceName')}</span>
+          </>
+        }
+      />
+
+      <Form.List name="databaseInfo" initialValue={[{}]}>
+        {(fields, { remove, add }) => {
+          return (
+            <>
+              {fields.map((field, index) => {
+                const fieldKey = field.key.toString();
+                return (
+                  <Space key={field.key} align="start" size={12}>
+                    <FormItemNoLabel
+                      extra={renderTestDatabasesConnectInfo(
+                        form.getFieldValue([
+                          'databaseInfo',
+                          field.name,
+                          'instanceName'
+                        ])
+                      )}
+                      name={[field.name, 'instanceName']}
+                      rules={[
+                        {
+                          required: true,
+                          message: t('common.form.placeholder.input', {
+                            name: t(
+                              'execWorkflow.create.form.sqlInfo.instanceName'
+                            )
+                          })
+                        }
+                      ]}
+                    >
+                      <CustomSelect
+                        allowClear={false}
+                        popupMatchSelectWidth
+                        className="data-source-row-select"
+                        prefix={<IconDatabase />}
+                        valuePrefix={<IconDatabaseActive />}
+                        size="middle"
+                        loading={instanceTipsLoading}
+                        options={instanceOptions}
+                        onChange={(name) => {
+                          form.setFieldValue(
+                            ['databaseInfo', field.name, 'instanceSchema'],
+                            undefined
+                          );
+                          props.handleInstanceNameChange?.(name);
+                          handleInstanceChange(fieldKey, name);
+                        }}
+                      />
+                    </FormItemNoLabel>
+
+                    <FormItemNoLabel name={[field.name, 'instanceSchema']}>
+                      <CustomSelect
+                        className="data-source-row-select"
+                        disabled={
+                          !form.getFieldValue('databaseInfo')?.[index]
+                            ?.instanceName
+                        }
+                        onChange={(value) =>
+                          handleInstanceSchemaChange(fieldKey, value)
+                        }
+                        prefix={<IconDatabaseSchema />}
+                        valuePrefix={<IconDatabaseSchemaActive />}
+                        size="middle"
+                        options={getInstanceSchemaOptions(fieldKey)}
+                        placeholder={t(
+                          'execWorkflow.create.form.sqlInfo.schemaPlaceholder'
+                        )}
+                        loading={!!getInstanceSchemaLoading(fieldKey)}
+                      />
+                    </FormItemNoLabel>
+
+                    <Divider
+                      className="data-source-row-divider"
+                      type="vertical"
+                    />
+
+                    {renderRuleTemplateDisplay(fieldKey)}
+
+                    {/* #if [ee] */}
+                    {renderDeleteItemButton(
+                      fields,
+                      fieldKey,
+                      remove.bind(null, field.name)
+                    )}
+                    {/* #endif */}
+                  </Space>
+                );
+              })}
+
+              <FormItemNoLabel>
+                <Space size={12} align="start">
+                  {/* #if [ee] */}
+                  {renderAddItemButton(fields, add.bind(null, {}))}
+                  {/* #endif */}
+
+                  <BasicButton
+                    loading={testLoading}
+                    onClick={testDatabaseConnect}
+                    disabled={testLoading || disabledTestConnect}
+                  >
+                    {t(
+                      'common.testDatabaseConnectButton.testDatabaseConnection'
+                    )}
+                  </BasicButton>
+                </Space>
+              </FormItemNoLabel>
+            </>
+          );
+        }}
+      </Form.List>
+    </>
+  );
+};
+
+export default DatabaseSelectionItem;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/index.type.ts
@@ -1,0 +1,4 @@
+export type DatabaseSelectionFields = {
+  instanceName: string;
+  instanceSchema: string;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormController/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormController/index.tsx
@@ -1,0 +1,89 @@
+import { Empty } from 'antd';
+import SqlStatementFormItem from '../SqlStatementFormItem';
+import { SqlStatementFormItemProps } from '../SqlStatementFormItem/index.type';
+import { useControllableValue } from 'ahooks';
+import { useTranslation } from 'react-i18next';
+import { BasicSegmented, EmptyBox } from '@actiontech/shared';
+import { SAME_SQL_MODE_DEFAULT_FIELD_KEY } from '../SqlStatementFormItem/index.data';
+
+type SqlStatementFormControllerProps = Omit<
+  SqlStatementFormItemProps,
+  'fieldPrefixPath'
+> & {
+  activeKey?: string;
+  onChange?: (activeKey: string) => void;
+  defaultActiveKey?: string;
+  isSameSqlForAll: boolean;
+  databaseInfo: Array<{
+    key: string;
+    instanceName: string | undefined;
+    schemaName: string | undefined;
+  }>;
+};
+
+const SqlStatementFormController: React.FC<SqlStatementFormControllerProps> = ({
+  isSameSqlForAll,
+  databaseInfo,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const [activeKey, setActiveKey] = useControllableValue<string>(
+    typeof props.activeKey !== 'undefined' && props.onChange
+      ? {
+          value: props.activeKey,
+          onChange: props.onChange,
+          defaultValue: props.defaultActiveKey
+        }
+      : { onChange: props.onChange, defaultValue: props.defaultActiveKey }
+  );
+
+  const render = () => {
+    if (isSameSqlForAll) {
+      return (
+        <SqlStatementFormItem
+          fieldPrefixPath={SAME_SQL_MODE_DEFAULT_FIELD_KEY}
+          {...props}
+        />
+      );
+    }
+    return (
+      <EmptyBox
+        if={databaseInfo?.length > 0}
+        defaultNode={
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={t('execWorkflow.create.form.sqlInfo.addInstanceTips')}
+          />
+        }
+      >
+        <BasicSegmented
+          block
+          value={activeKey}
+          onChange={(v) => {
+            setActiveKey(v as string);
+          }}
+          options={databaseInfo?.map((v) => ({
+            label: v.schemaName
+              ? `${v.instanceName}-${v.schemaName}`
+              : v.instanceName,
+            key: v.key,
+            value: v.key
+          }))}
+          style={{ marginBottom: 16 }}
+        />
+
+        {databaseInfo?.map((v) => {
+          return (
+            <div key={v.key} hidden={v.key !== activeKey}>
+              <SqlStatementFormItem fieldPrefixPath={v.key} {...props} />
+            </div>
+          );
+        })}
+      </EmptyBox>
+    );
+  };
+
+  return render();
+};
+
+export default SqlStatementFormController;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/SqlExecModeSelector.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/SqlExecModeSelector.tsx
@@ -1,0 +1,60 @@
+import {
+  FormItemLabel,
+  FormItemNoLabel
+} from '@actiontech/shared/lib/components/FormCom';
+import { SqlExecModeSelectorProps } from './index.type';
+import {
+  AuditTaskResV1SqlSourceEnum,
+  CreateAuditTasksGroupReqV1ExecModeEnum
+} from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { EmptyBox, ModeSwitcher } from '@actiontech/shared';
+import { sqlExecModeOptions } from '../index.data';
+import { useTranslation } from 'react-i18next';
+import { IconEllipse } from '@actiontech/shared/lib/Icon/common';
+import { Form } from 'antd';
+import { SqlAuditInfoFormFields } from '../../../../../../index.type';
+
+const SqlExecModeSelector: React.FC<SqlExecModeSelectorProps> = ({
+  fieldPrefixPath,
+  isSupportFileModeExecuteSQL
+}) => {
+  const { t } = useTranslation();
+  const form = Form.useFormInstance<SqlAuditInfoFormFields>();
+  const currentSqlUploadType = Form.useWatch(
+    [fieldPrefixPath, 'currentUploadType'],
+    form
+  ) as AuditTaskResV1SqlSourceEnum;
+  return (
+    <EmptyBox
+      if={
+        currentSqlUploadType !== AuditTaskResV1SqlSourceEnum.form_data &&
+        isSupportFileModeExecuteSQL.value
+      }
+    >
+      <FormItemLabel
+        className="has-label-tip form-item-label-mb-16"
+        label={
+          <div className="label-cont-custom">
+            <div>
+              <IconEllipse />
+              <span>
+                {t('execWorkflow.create.form.sqlInfo.selectExecuteMode')}
+              </span>
+            </div>
+            <div className="tip-content-box">
+              {t('execWorkflow.create.form.sqlInfo.selectExecuteModeTips')}
+            </div>
+          </div>
+        }
+      />
+      <FormItemNoLabel
+        name={[fieldPrefixPath, 'exec_mode']}
+        initialValue={CreateAuditTasksGroupReqV1ExecModeEnum.sqls}
+      >
+        <ModeSwitcher rowProps={{ gutter: 10 }} options={sqlExecModeOptions} />
+      </FormItemNoLabel>
+    </EmptyBox>
+  );
+};
+
+export default SqlExecModeSelector;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/SqlFormatterAndSubmitter.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/SqlFormatterAndSubmitter.tsx
@@ -1,0 +1,105 @@
+import { BasicButton, BasicToolTips } from '@actiontech/shared';
+import { FormItemNoLabel } from '@actiontech/shared/lib/components/FormCom';
+import { Form, Space } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { SqlAuditInfoFormFields } from '../../../../../../index.type';
+import { AuditTaskResV1SqlSourceEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { SqlFormatterAndSubmitterProps } from './index.type';
+import {
+  FormatLanguageSupport,
+  formatterSQL
+} from '@actiontech/shared/lib/utils/FormatterSQL';
+import instance from '@actiontech/shared/lib/api/sqle/service/instance';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import { SqlFiledInitialValue } from '../../../../../../../../../data/common';
+import { useBoolean } from 'ahooks';
+
+const SqlFormatterAndSubmitter: React.FC<SqlFormatterAndSubmitterProps> = ({
+  fieldPrefixPath,
+  isAuditing,
+  auditAction
+}) => {
+  const { t } = useTranslation();
+  const { projectName } = useCurrentProject();
+  const form = Form.useFormInstance<SqlAuditInfoFormFields>();
+  const currentSqlUploadType = Form.useWatch(
+    [fieldPrefixPath, 'currentUploadType'],
+    form
+  ) as AuditTaskResV1SqlSourceEnum;
+
+  const [
+    formatterLoading,
+    { setFalse: finishFormatter, setTrue: startFormatter }
+  ] = useBoolean();
+
+  const internalSubmit = async () => {
+    const values = await form.validateFields();
+    auditAction(values);
+  };
+
+  const formatSql = async () => {
+    const getInstanceType = (name: string) => {
+      startFormatter();
+      return instance
+        .getInstanceV2({
+          project_name: projectName,
+          instance_name: name
+        })
+        .then((res) => res.data.data)
+        .finally(() => {
+          finishFormatter();
+        });
+    };
+    const originSql = form.getFieldValue([fieldPrefixPath, 'form_data']);
+    const instanceName = form.getFieldValue([
+      'databaseInfo',
+      fieldPrefixPath,
+      'instanceName'
+    ]);
+    if (originSql && originSql !== SqlFiledInitialValue) {
+      if (instanceName) {
+        const info = await getInstanceType(instanceName);
+        form.setFieldValue(
+          [fieldPrefixPath, 'form_data'],
+          formatterSQL(originSql, info?.db_type)
+        );
+      } else {
+        form.setFieldValue(
+          [fieldPrefixPath, 'form_data'],
+          formatterSQL(originSql)
+        );
+      }
+    }
+  };
+  return (
+    <FormItemNoLabel>
+      <Space size={12}>
+        <BasicButton
+          onClick={internalSubmit}
+          type="primary"
+          loading={isAuditing.value}
+        >
+          {t('execWorkflow.create.form.sqlInfo.audit')}
+        </BasicButton>
+
+        {currentSqlUploadType === AuditTaskResV1SqlSourceEnum.form_data && (
+          <BasicToolTips
+            suffixIcon
+            title={t('execWorkflow.create.form.sqlInfo.formatTips', {
+              supportType: Object.keys(FormatLanguageSupport).join('、')
+            })}
+          >
+            <BasicButton
+              onClick={formatSql}
+              loading={isAuditing.value || formatterLoading}
+            >
+              {t('execWorkflow.create.form.sqlInfo.format')}
+            </BasicButton>
+          </BasicToolTips>
+        )}
+      </Space>
+    </FormItemNoLabel>
+  );
+};
+
+export default SqlFormatterAndSubmitter;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/SqlUploadContent.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/SqlUploadContent.tsx
@@ -1,0 +1,120 @@
+import { Form } from 'antd';
+import { SqlUploadContentProps } from './index.type';
+import { SqlAuditInfoFormFields } from '../../../../../../index.type';
+import { CustomDraggerUpload, EmptyBox } from '@actiontech/shared';
+import { AuditTaskResV1SqlSourceEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { FormItemNoLabel } from '@actiontech/shared/lib/components/FormCom';
+import { getFileFromUploadChangeEvent } from '@actiontech/shared/lib/utils/Common';
+import { useTranslation } from 'react-i18next';
+import { SqlFiledInitialValue } from '../../../../../../../../../data/common';
+import { whiteSpaceSql } from '@actiontech/shared/lib/utils/FormRule';
+import {
+  MonacoEditor,
+  useMonacoEditor
+} from '@actiontech/shared/lib/components/MonacoEditor';
+import { NamePath } from 'antd/es/form/interface';
+
+const SqlUploadContent: React.FC<SqlUploadContentProps> = ({
+  fieldPrefixPath
+}) => {
+  const { t } = useTranslation();
+  const form = Form.useFormInstance<SqlAuditInfoFormFields>();
+  const currentSqlUploadType = Form.useWatch(
+    [fieldPrefixPath, 'currentUploadType'],
+    form
+  ) as AuditTaskResV1SqlSourceEnum;
+
+  const generateFieldName = (name: string) => {
+    return [fieldPrefixPath, name];
+  };
+
+  const { editorDidMount } = useMonacoEditor(form, {
+    formName: generateFieldName('form_data')
+  });
+
+  const removeFile = (fieldName: NamePath) => {
+    form.setFieldValue(fieldName, []);
+  };
+
+  return (
+    <>
+      <EmptyBox
+        if={currentSqlUploadType === AuditTaskResV1SqlSourceEnum.form_data}
+      >
+        <FormItemNoLabel
+          name={generateFieldName('form_data')}
+          initialValue={SqlFiledInitialValue}
+          rules={[
+            {
+              required: true,
+              message: t('common.form.placeholder.input', {
+                name: t('common.sqlStatements')
+              })
+            },
+            ...whiteSpaceSql()
+          ]}
+        >
+          <MonacoEditor
+            width="100%"
+            height="400px"
+            language="sql"
+            onMount={editorDidMount}
+            options={{
+              automaticLayout: true
+            }}
+          />
+        </FormItemNoLabel>
+      </EmptyBox>
+      <EmptyBox
+        if={currentSqlUploadType === AuditTaskResV1SqlSourceEnum.sql_file}
+      >
+        <FormItemNoLabel
+          valuePropName="fileList"
+          name={generateFieldName('sql_file')}
+          rules={[
+            {
+              required: true,
+              message: t('common.form.placeholder.upload', {
+                name: t('execWorkflow.create.form.sqlInfo.sqlFile')
+              })
+            }
+          ]}
+          getValueFromEvent={getFileFromUploadChangeEvent}
+        >
+          <CustomDraggerUpload
+            accept=".sql"
+            beforeUpload={() => false}
+            onRemove={removeFile.bind(null, generateFieldName('sql_file'))}
+            title={t('execWorkflow.create.form.sqlInfo.sqlFileTips')}
+          />
+        </FormItemNoLabel>
+      </EmptyBox>
+      <EmptyBox
+        if={currentSqlUploadType === AuditTaskResV1SqlSourceEnum.zip_file}
+      >
+        <FormItemNoLabel
+          valuePropName="fileList"
+          name={generateFieldName('zip_file')}
+          rules={[
+            {
+              required: true,
+              message: t('common.form.placeholder.upload', {
+                name: t('execWorkflow.create.form.sqlInfo.zipFile')
+              })
+            }
+          ]}
+          getValueFromEvent={getFileFromUploadChangeEvent}
+        >
+          <CustomDraggerUpload
+            accept=".zip"
+            beforeUpload={() => false}
+            onRemove={removeFile.bind(null, generateFieldName('zip_file'))}
+            title={t('execWorkflow.create.form.sqlInfo.zipFileTips')}
+          />
+        </FormItemNoLabel>
+      </EmptyBox>
+    </>
+  );
+};
+
+export default SqlUploadContent;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/components/index.type.ts
@@ -1,0 +1,16 @@
+import { SqlStatementFormItemProps } from '../index.type';
+
+export type SqlUploadContentProps = Pick<
+  SqlStatementFormItemProps,
+  'fieldPrefixPath'
+>;
+
+export type SqlExecModeSelectorProps = Pick<
+  SqlStatementFormItemProps,
+  'fieldPrefixPath' | 'isSupportFileModeExecuteSQL'
+>;
+
+export type SqlFormatterAndSubmitterProps = Pick<
+  SqlStatementFormItemProps,
+  'fieldPrefixPath' | 'isAuditing' | 'auditAction'
+>;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/index.data.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/index.data.tsx
@@ -1,0 +1,58 @@
+import { ModeSwitcherOptionsType } from '@actiontech/shared/lib/components/ModeSwitcher/index.type';
+import {
+  AuditTaskResV1SqlSourceEnum,
+  CreateAuditTasksGroupReqV1ExecModeEnum
+} from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import {
+  IconWorkflowFileUpload,
+  IconWorkflowSQLUpload
+} from '../../../../../../../../icon/SqlExecWorkflow';
+import { t } from '../../../../../../../../locale';
+
+export const SAME_SQL_MODE_DEFAULT_FIELD_KEY = '0';
+
+export const defaultUploadTypeOptions: ModeSwitcherOptionsType = [
+  {
+    icon: <IconWorkflowSQLUpload />,
+    label: t('execWorkflow.create.form.sqlInfo.manualInput'),
+    value: AuditTaskResV1SqlSourceEnum.form_data,
+    colProps: {
+      span: 8
+    }
+  },
+  {
+    icon: <IconWorkflowFileUpload />,
+    label: t('execWorkflow.create.form.sqlInfo.uploadFile'),
+    value: AuditTaskResV1SqlSourceEnum.sql_file,
+    colProps: {
+      span: 8
+    }
+  },
+  {
+    icon: <IconWorkflowFileUpload />,
+    label: t('execWorkflow.create.form.sqlInfo.uploadZipFile'),
+    value: AuditTaskResV1SqlSourceEnum.zip_file,
+    colProps: {
+      span: 8
+    }
+  }
+];
+
+export const sqlExecModeOptions: ModeSwitcherOptionsType = [
+  {
+    label: t('execWorkflow.create.form.sqlInfo.executeSqlMode'),
+    icon: <IconWorkflowFileUpload />,
+    value: CreateAuditTasksGroupReqV1ExecModeEnum.sqls,
+    colProps: {
+      span: 12
+    }
+  },
+  {
+    label: t('execWorkflow.create.form.sqlInfo.executeFileMode'),
+    icon: <IconWorkflowFileUpload />,
+    value: CreateAuditTasksGroupReqV1ExecModeEnum.sql_file,
+    colProps: {
+      span: 12
+    }
+  }
+];

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/index.tsx
@@ -1,0 +1,81 @@
+import { ModeSwitcher } from '@actiontech/shared';
+import { IconEllipse } from '@actiontech/shared/lib/Icon/common';
+import { AuditTaskResV1SqlSourceEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import {
+  FormItemLabel,
+  FormItemNoLabel
+} from '@actiontech/shared/lib/components/FormCom';
+import { useTranslation } from 'react-i18next';
+import { defaultUploadTypeOptions } from './index.data';
+import { SqlStatementFormItemProps } from './index.type';
+import { useMemo } from 'react';
+import SqlUploadContent from './components/SqlUploadContent';
+import { Form } from 'antd';
+import { SqlAuditInfoFormProps } from '../../index.type';
+import SqlExecModeSelector from './components/SqlExecModeSelector';
+import SqlFormatterAndSubmitter from './components/SqlFormatterAndSubmitter';
+
+const SqlStatementFormItem: React.FC<SqlStatementFormItemProps> = ({
+  fieldPrefixPath,
+  clearSqlContentFormWhenChangeUploadType = true,
+  isAuditing,
+  auditAction,
+  isSupportFileModeExecuteSQL
+}) => {
+  const { t } = useTranslation();
+  const form = Form.useFormInstance<SqlAuditInfoFormProps>();
+
+  const currentUploadTypeFieldName = useMemo(() => {
+    return [fieldPrefixPath, 'currentUploadType'];
+  }, [fieldPrefixPath]);
+
+  const uploadTypeChangeHandle = () => {
+    if (clearSqlContentFormWhenChangeUploadType) {
+      form.resetFields([
+        [fieldPrefixPath, 'form_data'],
+        [fieldPrefixPath, 'sql_file'],
+        [fieldPrefixPath, 'zip_file']
+      ]);
+    }
+  };
+
+  return (
+    <>
+      <FormItemLabel
+        label={
+          <>
+            <IconEllipse />
+            <span>{t('execWorkflow.create.form.sqlInfo.uploadType')}</span>
+          </>
+        }
+        className="form-item-label-mb-16"
+      />
+
+      <FormItemNoLabel
+        name={currentUploadTypeFieldName}
+        initialValue={defaultUploadTypeOptions[0].value}
+      >
+        <ModeSwitcher<AuditTaskResV1SqlSourceEnum>
+          rowProps={{ gutter: 12 }}
+          options={defaultUploadTypeOptions}
+          onChange={uploadTypeChangeHandle}
+        />
+      </FormItemNoLabel>
+
+      <SqlUploadContent fieldPrefixPath={fieldPrefixPath} />
+
+      <SqlExecModeSelector
+        fieldPrefixPath={fieldPrefixPath}
+        isSupportFileModeExecuteSQL={isSupportFileModeExecuteSQL}
+      />
+
+      <SqlFormatterAndSubmitter
+        fieldPrefixPath={fieldPrefixPath}
+        isAuditing={isAuditing}
+        auditAction={auditAction}
+      />
+    </>
+  );
+};
+
+export default SqlStatementFormItem;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/index.type.ts
@@ -1,0 +1,9 @@
+import { SqlAuditInfoFormProps } from '../../index.type';
+
+export type SqlStatementFormItemProps = {
+  fieldPrefixPath: string;
+  clearSqlContentFormWhenChangeUploadType?: boolean;
+} & Pick<
+  SqlAuditInfoFormProps,
+  'isAuditing' | 'auditAction' | 'isSupportFileModeExecuteSQL'
+>;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/index.tsx
@@ -1,0 +1,128 @@
+import { Form } from 'antd';
+import { SqlAuditInfoFormItemProps } from '../index.type';
+import DatabaseSelectionItem from './DatabaseSelectionItems';
+import { FormItemLabel } from '@actiontech/shared/lib/components/FormCom';
+import { IconEllipse } from '@actiontech/shared/lib/Icon/common';
+import { useTranslation } from 'react-i18next';
+import { BasicSwitch } from '@actiontech/shared';
+import { useEffect, useMemo } from 'react';
+import { SqlAuditInfoFormFields } from '../../../../index.type';
+import SqlStatementFormController from './SqlStatementFormController';
+import SqlStatementFormItem from './SqlStatementFormItem';
+import { SAME_SQL_MODE_DEFAULT_FIELD_KEY } from './SqlStatementFormItem/index.data';
+import system from '@actiontech/shared/lib/api/sqle/service/system';
+import {
+  getSystemModuleStatusDbTypeEnum,
+  getSystemModuleStatusModuleNameEnum
+} from '@actiontech/shared/lib/api/sqle/service/system/index.enum';
+
+const SqlAuditInfoFormItem: React.FC<SqlAuditInfoFormItemProps> = ({
+  isDisabledForDifferenceSql,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const form = Form.useFormInstance<SqlAuditInfoFormFields>();
+
+  const isSameSqlForAll = Form.useWatch('isSameSqlForAll', form);
+  const databaseInfo = useMemo(() => {
+    return Object.keys(props.dbSourceInfoCollection.value)
+      .map((key) => {
+        return {
+          key,
+          instanceName: props.dbSourceInfoCollection.value?.[key]?.instanceName,
+          schemaName: props.dbSourceInfoCollection.value?.[key]?.schemaName
+        };
+      })
+      .filter((v) => !!v.instanceName);
+  }, [props.dbSourceInfoCollection]);
+
+  useEffect(() => {
+    const dbTypeSet = new Set(
+      Object.keys(props.dbSourceInfoCollection.value)
+        ?.map((key) => {
+          return props.dbSourceInfoCollection.value?.[key].dbType;
+        })
+        .filter((v) => !!v)
+    );
+    // #if [ee]
+    const getSupportedFileModeByInstanceType = (types: string[]) => {
+      Promise.all(
+        types.map((type) => {
+          return system.getSystemModuleStatus({
+            db_type: type as getSystemModuleStatusDbTypeEnum,
+            module_name:
+              getSystemModuleStatusModuleNameEnum.execute_sql_file_mode
+          });
+        })
+      ).then((res) => {
+        props.isSupportFileModeExecuteSQL.set(
+          res.every((item) => !!item.data.data?.is_supported)
+        );
+      });
+    };
+    if (dbTypeSet.size > 0) {
+      getSupportedFileModeByInstanceType(Array.from(dbTypeSet) as string[]);
+    }
+    // #endif
+
+    if (dbTypeSet.size > 1) {
+      form.setFieldValue('isSameSqlForAll', false);
+      isDisabledForDifferenceSql.set(true);
+    } else {
+      isDisabledForDifferenceSql.set(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form, props.dbSourceInfoCollection.value]);
+
+  return (
+    <>
+      <DatabaseSelectionItem {...props} />
+
+      <FormItemLabel
+        // #if [ce]
+        hidden={true}
+        // #endif
+        name="isSameSqlForAll"
+        valuePropName="checked"
+        initialValue={true}
+        className="has-label-tip"
+        label={
+          <div className="label-cont-custom">
+            <div>
+              <IconEllipse />
+              <span>
+                {t('execWorkflow.create.form.sqlInfo.isSameSqlForAll')}
+              </span>
+            </div>
+            <div className="tip-content-box">
+              {t(
+                'execWorkflow.create.form.sqlInfo.tipsDataSourceTypeForSameSql'
+              )}
+            </div>
+          </div>
+        }
+        labelCol={{ span: 22 }}
+        wrapperCol={{ span: 2 }}
+      >
+        <BasicSwitch disabled={isDisabledForDifferenceSql.value} />
+      </FormItemLabel>
+
+      {/* #if [ee] */}
+      <SqlStatementFormController
+        activeKey={props.sqlStatementTabActiveKey.value}
+        onChange={props.sqlStatementTabActiveKey.set}
+        isSameSqlForAll={isSameSqlForAll}
+        databaseInfo={databaseInfo}
+        {...props}
+      />
+      {/* #elif [ce] */}
+      <SqlStatementFormItem
+        fieldPrefixPath={SAME_SQL_MODE_DEFAULT_FIELD_KEY}
+        {...props}
+      />
+      {/* #endif */}
+    </>
+  );
+};
+
+export default SqlAuditInfoFormItem;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/index.tsx
@@ -1,0 +1,19 @@
+import { FormItemSubTitle } from '@actiontech/shared/lib/components/FormCom';
+import { FormAreaBlockStyleWrapper } from '@actiontech/shared/lib/components/FormCom/style';
+import { useTranslation } from 'react-i18next';
+import SqlAuditInfoFormItem from './SqlAuditInfoFormItem';
+import { SqlAuditInfoFormProps } from './index.type';
+
+const SqlAuditInfoForm: React.FC<SqlAuditInfoFormProps> = (props) => {
+  const { t } = useTranslation();
+  return (
+    <FormAreaBlockStyleWrapper>
+      <FormItemSubTitle>
+        {t('execWorkflow.create.form.sqlInfo.title')}
+      </FormItemSubTitle>
+      <SqlAuditInfoFormItem {...props} />
+    </FormAreaBlockStyleWrapper>
+  );
+};
+
+export default SqlAuditInfoForm;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/index.type.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/index.type.tsx
@@ -1,0 +1,17 @@
+import { SharedStepDetails } from '../../../index.type';
+import { CreateWorkflowFormStepProps } from '../index.type';
+
+export type SqlAuditInfoFormProps = {
+  handleInstanceNameChange?: (name: string) => void;
+} & SharedStepDetails &
+  Pick<CreateWorkflowFormStepProps, 'auditAction'>;
+
+export type SqlAuditInfoFormItemProps = SqlAuditInfoFormProps;
+
+export type DatabaseSelectionItemProps = Pick<
+  SqlAuditInfoFormItemProps,
+  | 'dbSourceInfoCollection'
+  | 'instanceTestConnectResults'
+  | 'handleInstanceNameChange'
+  | 'sqlStatementTabActiveKey'
+>;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/index.tsx
@@ -1,0 +1,76 @@
+import { FormStyleWrapper } from '@actiontech/shared/lib/components/FormCom/style';
+import BaseInfoForm from './BaseInfoForm';
+import { CreateWorkflowFormStepProps } from './index.type';
+import { PageLayoutHasFixedHeaderStyleWrapper } from '@actiontech/shared/lib/styleWrapper/element';
+import { BasicButton, PageHeader } from '@actiontech/shared';
+import { useTranslation } from 'react-i18next';
+import SqlAuditInfoForm from './SqlAuditInfoForm';
+import { SqlAuditInfoFormStyleWrapper } from './style';
+import { useCallback } from 'react';
+import dayjs from 'dayjs';
+import BackToList from '../../../Common/BackToList';
+
+const FormStep: React.FC<CreateWorkflowFormStepProps> = ({
+  baseInfoForm,
+  sqlAuditInfoForm,
+  isAuditing,
+  resetAllSharedData,
+  ...sharedStepDetail
+}) => {
+  const { t } = useTranslation();
+
+  const resetAllForm = () => {
+    baseInfoForm.resetFields();
+    sqlAuditInfoForm.resetFields();
+    resetAllSharedData();
+  };
+
+  const handleInstanceNameChange = useCallback(
+    (name: string) => {
+      if (!baseInfoForm.isFieldTouched('workflow_subject')) {
+        baseInfoForm.setFieldsValue({
+          workflow_subject: `${name}_${dayjs().format('YYYYMMDDhhmmss')}`
+        });
+      }
+    },
+    [baseInfoForm]
+  );
+
+  return (
+    <PageLayoutHasFixedHeaderStyleWrapper>
+      <PageHeader
+        fixed
+        title={<BackToList isAuditing={isAuditing.value} />}
+        extra={
+          <BasicButton onClick={resetAllForm} disabled={isAuditing.value}>
+            {t('common.reset')}
+          </BasicButton>
+        }
+      />
+      <FormStyleWrapper
+        form={baseInfoForm}
+        className="hasTopHeader clearPaddingBottom"
+        colon={false}
+        layout="vertical"
+        labelAlign="left"
+      >
+        <BaseInfoForm />
+      </FormStyleWrapper>
+
+      <SqlAuditInfoFormStyleWrapper
+        form={sqlAuditInfoForm}
+        colon={false}
+        labelAlign="left"
+      >
+        <SqlAuditInfoForm
+          isAuditing={isAuditing}
+          resetAllSharedData={resetAllSharedData}
+          handleInstanceNameChange={handleInstanceNameChange}
+          {...sharedStepDetail}
+        />
+      </SqlAuditInfoFormStyleWrapper>
+    </PageLayoutHasFixedHeaderStyleWrapper>
+  );
+};
+
+export default FormStep;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/index.type.ts
@@ -1,0 +1,15 @@
+import { FormInstance } from 'antd';
+import {
+  SharedStepDetails,
+  SqlAuditInfoFormFields,
+  WorkflowBaseInfoFormFields
+} from '../../index.type';
+
+export type CreateWorkflowFormStepProps = {
+  baseInfoForm: FormInstance<WorkflowBaseInfoFormFields>;
+  sqlAuditInfoForm: FormInstance<SqlAuditInfoFormFields>;
+  auditAction: (
+    value: SqlAuditInfoFormFields,
+    baseInfo?: WorkflowBaseInfoFormFields
+  ) => Promise<void>;
+} & SharedStepDetails;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/style.ts
@@ -1,0 +1,35 @@
+import { FormStyleWrapper } from '@actiontech/shared/lib/components/FormCom/style';
+import { styled } from '@mui/material/styles';
+
+export const SqlAuditInfoFormStyleWrapper = styled(FormStyleWrapper)`
+  .custom-icon-ellipse {
+    display: none;
+  }
+
+  .form-item-label-mb-16 {
+    margin-bottom: 16px !important;
+  }
+
+  .data-source-row-select {
+    width: 300px !important;
+  }
+
+  .data-source-row-divider {
+    height: 36px !important;
+    margin: 0 !important;
+  }
+
+  .data-source-row-button {
+    height: 36px !important;
+    width: 36px !important;
+  }
+
+  .data-source-col-delete-button {
+    width: 35px !important;
+  }
+
+  .data-source-row-rule-template {
+    height: 36px !important;
+    width: 36px !important;
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useAllowAuditLevel.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useAllowAuditLevel.ts
@@ -1,0 +1,93 @@
+import { WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import workflow from '@actiontech/shared/lib/api/sqle/service/workflow';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const judgeLevelMap = new Map<
+  WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum,
+  number
+>([
+  [WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum.normal, 0],
+  [WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum.notice, 1],
+  [WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum.warn, 2],
+  [WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum.error, 3]
+]);
+
+export const useAllowAuditLevel = () => {
+  const { t } = useTranslation();
+
+  const [disabledOperatorWorkflowBtnTips, setDisabledOperatorWorkflowBtnTips] =
+    useState('');
+  const judgeAuditLevel = useCallback(
+    async (
+      taskInfos: Array<{
+        projectName: string;
+        instanceName: string;
+        currentAuditLevel?: WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum;
+      }>,
+      setBtnDisabled: () => void,
+      resetBtnDisabled: () => void
+    ) => {
+      const request = (projectName: string) => {
+        return workflow.getWorkflowTemplateV1({
+          project_name: projectName
+        });
+      };
+
+      const tips: string[] = [];
+      Promise.all(
+        taskInfos.map((taskInfo) => request(taskInfo.projectName))
+      ).then((res) => {
+        const invalidTasks = res.filter((v, index) => {
+          const projectName = taskInfos[index].projectName;
+          const currentAuditLevel = taskInfos[index].currentAuditLevel;
+          const allowAuditLevel = v.data.data
+            ?.allow_submit_when_less_audit_level as
+            | WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum
+            | undefined;
+          if (isExistNotAllowLevel(currentAuditLevel, allowAuditLevel)) {
+            tips.push(
+              t(
+                'execWorkflow.create.auditResult.disabledOperatorWorkflowBtnTips',
+                {
+                  currentProject: projectName,
+                  allowAuditLevel: allowAuditLevel,
+                  currentAuditLevel: currentAuditLevel
+                }
+              )
+            );
+            return true;
+          }
+          return false;
+        });
+        if (invalidTasks.length > 0 && tips.length > 0) {
+          setDisabledOperatorWorkflowBtnTips([...new Set(tips)].join('\n'));
+          setBtnDisabled();
+        } else {
+          resetBtnDisabled();
+          setDisabledOperatorWorkflowBtnTips('');
+        }
+      });
+    },
+    [t]
+  );
+
+  const isExistNotAllowLevel = (
+    currentAuditLevel?: WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum,
+    allowAuditLevel?: WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum
+  ) => {
+    if (!currentAuditLevel || !allowAuditLevel) {
+      return false;
+    }
+    return (
+      (judgeLevelMap.get(currentAuditLevel) ?? 0) >
+      (judgeLevelMap.get(allowAuditLevel) ?? 0)
+    );
+  };
+
+  return {
+    judgeAuditLevel,
+    disabledOperatorWorkflowBtnTips,
+    setDisabledOperatorWorkflowBtnTips
+  };
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useAuditWorkflow.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useAuditWorkflow.tsx
@@ -1,0 +1,207 @@
+import { useBoolean } from 'ahooks';
+import { useCallback, useState } from 'react';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import { useAllowAuditLevel } from './useAllowAuditLevel';
+import { IAuditTaskResV1 } from '@actiontech/shared/lib/api/sqle/service/common';
+import {
+  CreateAuditTaskReqV1ExecModeEnum,
+  WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum
+} from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import {
+  ICreateAuditTasksV1Params,
+  IAuditTaskGroupIdV1Params,
+  ICreateAndAuditTaskV1Params
+} from '@actiontech/shared/lib/api/sqle/service/task/index.d';
+import task from '@actiontech/shared/lib/api/sqle/service/task';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import {
+  DataSourceSchemaCollection,
+  SqlAuditInfoFormFields,
+  SqlStatementFields
+} from '../index.type';
+import { SAME_SQL_MODE_DEFAULT_FIELD_KEY } from '../components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/SqlStatementFormItem/index.data';
+
+const useAuditWorkflow = () => {
+  const { projectName } = useCurrentProject();
+  const [taskInfos, setTaskInfos] = useState<IAuditTaskResV1[]>([]);
+  const [
+    isDisableFinallySubmitButton,
+    {
+      setTrue: disableFinallySubmitButton,
+      setFalse: cancelDisableFinallySubmitButton
+    }
+  ] = useBoolean(false);
+
+  const {
+    disabledOperatorWorkflowBtnTips,
+    judgeAuditLevel,
+    setDisabledOperatorWorkflowBtnTips
+  } = useAllowAuditLevel();
+
+  const resetFinallySubmitButtonStatus = useCallback(() => {
+    cancelDisableFinallySubmitButton();
+    setDisabledOperatorWorkflowBtnTips('');
+  }, [cancelDisableFinallySubmitButton, setDisabledOperatorWorkflowBtnTips]);
+
+  const commonJudgeAuditLevel = useCallback(
+    (tasks: IAuditTaskResV1[]) => {
+      judgeAuditLevel(
+        tasks.map((v) => ({
+          projectName,
+          instanceName: v.instance_name ?? '',
+          currentAuditLevel: v.audit_level as
+            | WorkflowTemplateDetailResV1AllowSubmitWhenLessAuditLevelEnum
+            | undefined
+        })) ?? [],
+        disableFinallySubmitButton,
+        cancelDisableFinallySubmitButton
+      );
+    },
+    [
+      cancelDisableFinallySubmitButton,
+      disableFinallySubmitButton,
+      judgeAuditLevel,
+      projectName
+    ]
+  );
+
+  /**
+   * 相同 sql 模式下的表单提交
+   * @param values 提交的表单数据
+   *
+   * 2024.04.23 changelog: 支持sql上线、文件上线模式
+   *
+   * values 数据格式:
+   * {
+   *    SAME_SQL_MODE_DEFAULT_FIELD_KEY: SqlStatementFields, sql语句信息, 因为相同sql模式下只会有一份该数据
+   *    databaseInfo:  Array<DatabaseInfoFields>, 数据源以及数据库信息, 可能会有多份
+   *    other data
+   * }
+   * 1. 首先使用 createAuditTasksV1 接口提交数据 获取 task_group_id
+   * 2. 再使用 auditTaskGroupIdV1 提交后获取最后的 tasks 数据
+   * 3. 通过 tasks 数据去判断是否可以进行最后的创建或者修改. 大致逻辑为判断 sql 语句的规则等级, 详细逻辑见 useAllowAuditLevel
+   * 4. 返回 taskInfos
+   */
+  const auditWorkflowWithSameSql = useCallback(
+    async (values: SqlAuditInfoFormFields) => {
+      const sqlStatementInfo = values[
+        SAME_SQL_MODE_DEFAULT_FIELD_KEY
+      ] as SqlStatementFields;
+
+      const createAuditTasksParams: ICreateAuditTasksV1Params = {
+        // #if [ee]
+        exec_mode: values.executeMode,
+        // #endif
+        project_name: projectName,
+        instances:
+          values.databaseInfo.map((v) => ({
+            instance_name: v.instanceName,
+            instance_schema: v.instanceSchema
+          })) ?? []
+      };
+      const taskGroupInfo = await task.createAuditTasksV1(
+        createAuditTasksParams
+      );
+      if (
+        taskGroupInfo.data.code === ResponseCode.SUCCESS &&
+        taskGroupInfo.data.data?.task_group_id
+      ) {
+        const auditTaskPrams: IAuditTaskGroupIdV1Params = {
+          task_group_id: taskGroupInfo.data.data?.task_group_id,
+          sql: sqlStatementInfo.form_data,
+          input_sql_file: sqlStatementInfo.sql_file?.[0],
+          input_zip_file: sqlStatementInfo.zip_file?.[0]
+        };
+        const res = await task.auditTaskGroupIdV1(auditTaskPrams);
+        if (res && res.data.code === ResponseCode.SUCCESS) {
+          const tasks = res.data.data?.tasks ?? [];
+          setTaskInfos(tasks);
+
+          if (tasks.length > 0) {
+            commonJudgeAuditLevel(tasks);
+          }
+        }
+      }
+    },
+    [commonJudgeAuditLevel, projectName]
+  );
+
+  /**
+   * 不同 sql 模式下的表单提交
+   *
+   * 2023.09.19 changelog: 审核多数据源时批量审核
+   *
+   * 2024.04.23 changelog: 支持sql上线、文件上线模式
+   *
+   * @param values 提交的表单数据
+   *
+   * values 数据格式
+   * {
+   *   [key in {0, 1, 2...}]: SqlStatementFields, sql语句信息, 因为不同sql模式下只会多份数据, 这里的 key 值对应的是 sql 语句录入 的 tabs 的 key, 也是 DataSourceSchemaCollection 中的 key
+   *   databaseInfo:  Array<DatabaseInfoFields>, 数据源以及数据库信息, 可能会有多份
+   *   other data
+   * }
+   *
+   * 1. 直接通过 createAndAuditTaskV1 获取 taskInfo 数据
+   * 2. 因为每次提交时 仅仅只对当前 tab 下个 sql 语句进行审核, 所以需要注意的是再次对已经审核过的 tab 时, 需要使用新的 taskInfo 替换掉之前的数据
+   */
+  const auditWorkflowWthDifferenceSql = useCallback(
+    async (
+      values: SqlAuditInfoFormFields,
+      dbSourceInfoCollection: DataSourceSchemaCollection
+    ) => {
+      const params: ICreateAndAuditTaskV1Params[] = Object.keys(
+        dbSourceInfoCollection
+      ).map((key) => {
+        const record = dbSourceInfoCollection[key];
+        const sqlStatementInfo = values[key] as SqlStatementFields;
+        return {
+          project_name: projectName,
+          instance_name: record.instanceName!,
+          instance_schema: record.schemaName,
+          sql: sqlStatementInfo.form_data,
+          input_sql_file: sqlStatementInfo.sql_file?.[0],
+          input_zip_file: sqlStatementInfo.zip_file?.[0],
+          // #if [ee]
+          exec_mode:
+            values.executeMode as unknown as CreateAuditTaskReqV1ExecModeEnum
+          // #endif
+        };
+      });
+
+      const results = await Promise.all(
+        params.map((param) => task.createAndAuditTaskV1(param))
+      );
+
+      //todo 需要考虑部分成功, 部分失败的情况
+      if (
+        results.every(
+          (res) => res.data.code === ResponseCode.SUCCESS && !!res.data.data
+        )
+      ) {
+        const tasks = results.map((v) => v.data.data!);
+        setTaskInfos(tasks);
+        if (tasks.length > 0) {
+          commonJudgeAuditLevel(tasks);
+        }
+      }
+    },
+    [commonJudgeAuditLevel, projectName]
+  );
+
+  const clearTaskInfos = useCallback(() => {
+    setTaskInfos([]);
+  }, []);
+
+  return {
+    taskInfos,
+    clearTaskInfos,
+    auditWorkflowWithSameSql,
+    auditWorkflowWthDifferenceSql,
+    isDisableFinallySubmitButton,
+    disabledOperatorWorkflowBtnTips,
+    resetFinallySubmitButtonStatus
+  };
+};
+
+export default useAuditWorkflow;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useCreateWorkflowSteps.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useCreateWorkflowSteps.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+const useCreateWorkflowSteps = () => {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const isAtFormStep = currentStep === 0;
+  const isAtAuditResultStep = currentStep === 1;
+  const isAtCreateResultStep = currentStep === 2;
+
+  const goToFormStep = () => {
+    setCurrentStep(0);
+  };
+  const goToAuditResultStep = () => {
+    setCurrentStep(1);
+  };
+  const goToCreateResultStep = () => {
+    setCurrentStep(2);
+  };
+
+  return {
+    isAtFormStep,
+    isAtAuditResultStep,
+    isAtCreateResultStep,
+    goToFormStep,
+    goToAuditResultStep,
+    goToCreateResultStep
+  };
+};
+
+export default useCreateWorkflowSteps;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useSharedStepDetail.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/hooks/useSharedStepDetail.ts
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+import { IInstanceConnectionResV1 } from '@actiontech/shared/lib/api/sqle/service/common';
+import { omit } from 'lodash';
+import { SharedStepDetails, DataSourceSchemaCollection } from '../index.type';
+
+const DEFAULT_DB_SOURCE_INFO = { '0': {} };
+
+const useSharedStepDetail = (): SharedStepDetails => {
+  const [isAuditing, setIsAuditing] = useState(false);
+
+  const [isSupportFileModeExecuteSQL, setIsSupportFileModeExecuteSQL] =
+    useState(false);
+
+  const [isDisabledForDifferenceSql, setIsDisabledForDifferenceSql] =
+    useState(false);
+
+  const [instanceTestConnectResults, setInstanceTestConnectResults] = useState<
+    IInstanceConnectionResV1[]
+  >([]);
+
+  const [sqlStatementTabActiveKey, setActiveSqlStatementTabKey] =
+    useState<string>('');
+
+  const [dbSourceInfoCollection, setDbSourceInfoCollection] =
+    useState<DataSourceSchemaCollection>(DEFAULT_DB_SOURCE_INFO);
+
+  const updateInstanceRecordInfo = useCallback(
+    (key: string, info?: DataSourceSchemaCollection[string]) => {
+      //remove
+      if (!info) {
+        setDbSourceInfoCollection((v) => {
+          return omit(v, key);
+        });
+        return;
+      }
+
+      setDbSourceInfoCollection((v) => {
+        //add
+        if (!v) {
+          return {
+            [key]: info
+          };
+        }
+
+        // clear
+        if (Object.keys(info).length === 0) {
+          return { ...v, [key]: {} };
+        }
+
+        // merge
+        return {
+          ...v,
+          [key]: {
+            ...v[key],
+            ...info
+          }
+        };
+      });
+    },
+    []
+  );
+
+  const resetAllSharedData = () => {
+    setIsAuditing(false);
+    setIsSupportFileModeExecuteSQL(false);
+    setDbSourceInfoCollection(DEFAULT_DB_SOURCE_INFO);
+    setInstanceTestConnectResults([]);
+    setIsDisabledForDifferenceSql(false);
+    setActiveSqlStatementTabKey('');
+  };
+
+  return {
+    isAuditing: {
+      value: isAuditing,
+      set: setIsAuditing
+    },
+    isSupportFileModeExecuteSQL: {
+      value: isSupportFileModeExecuteSQL,
+      set: setIsSupportFileModeExecuteSQL
+    },
+    dbSourceInfoCollection: {
+      value: dbSourceInfoCollection,
+      set: updateInstanceRecordInfo
+    },
+    instanceTestConnectResults: {
+      value: instanceTestConnectResults,
+      set: setInstanceTestConnectResults
+    },
+    isDisabledForDifferenceSql: {
+      value: isDisabledForDifferenceSql,
+      set: setIsDisabledForDifferenceSql
+    },
+    sqlStatementTabActiveKey: {
+      value: sqlStatementTabActiveKey,
+      set: setActiveSqlStatementTabKey
+    },
+
+    resetAllSharedData
+  };
+};
+
+export default useSharedStepDetail;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/index.tsx
@@ -1,0 +1,176 @@
+import { Spin, message } from 'antd';
+import { useForm } from 'antd/es/form/Form';
+import {
+  SqlAuditInfoFormFields,
+  WorkflowBaseInfoFormFields
+} from './index.type';
+import useCreateWorkflowSteps from './hooks/useCreateWorkflowSteps';
+import CreateResultStep from './components/CreateResultStep';
+import FormStep from './components/FormStep';
+import useSharedStepDetail from './hooks/useSharedStepDetail';
+import useAuditWorkflow from './hooks/useAuditWorkflow';
+import { useCallback, useRef, useState } from 'react';
+import AuditResultStep from './components/AuditResultStep';
+import { usePrompt } from '@actiontech/shared/lib/hooks';
+import { useTranslation } from 'react-i18next';
+import workflow from '@actiontech/shared/lib/api/sqle/service/workflow';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { ICreateWorkflowV2Params } from '@actiontech/shared/lib/api/sqle/service/workflow/index.d';
+
+const CreateSqlExecWorkflow: React.FC = () => {
+  const { t } = useTranslation();
+  const [baseInfoForm] = useForm<WorkflowBaseInfoFormFields>();
+  const [sqlAuditInfoForm] = useForm<SqlAuditInfoFormFields>();
+  const [messageApi, messageContextHolder] = message.useMessage();
+  const { projectName } = useCurrentProject();
+  const createdWorkflowID = useRef('');
+  const [taskSqlCountRecord, setTaskSqlCountRecord] = useState<
+    Record<string, number>
+  >({});
+
+  const updateTaskRecordTotalNum = useCallback(
+    (taskId: string, count: number) => {
+      setTaskSqlCountRecord((v) => ({
+        ...v,
+        [taskId]: count
+      }));
+    },
+    []
+  );
+
+  const {
+    isAtFormStep,
+    isAtAuditResultStep,
+    isAtCreateResultStep,
+    goToAuditResultStep,
+    goToCreateResultStep
+  } = useCreateWorkflowSteps();
+
+  const { isAuditing, ...sharedStepDetail } = useSharedStepDetail();
+
+  const {
+    taskInfos,
+    auditWorkflowWithSameSql,
+    auditWorkflowWthDifferenceSql,
+    isDisableFinallySubmitButton,
+    disabledOperatorWorkflowBtnTips
+  } = useAuditWorkflow();
+
+  const auditAction = useCallback(
+    async (
+      values: SqlAuditInfoFormFields,
+      baseInfo?: WorkflowBaseInfoFormFields
+    ) => {
+      //虽然审核不需要 baseInfo 数据，但还是需要进行校验
+      await baseInfoForm.validateFields();
+
+      const finallyFunc = () => {
+        if (baseInfo) {
+          baseInfoForm.setFieldsValue(baseInfo);
+        } else {
+          goToAuditResultStep();
+        }
+        isAuditing.set(false);
+      };
+
+      isAuditing.set(true);
+
+      if (values.isSameSqlForAll) {
+        auditWorkflowWithSameSql(values).finally(finallyFunc);
+      } else {
+        auditWorkflowWthDifferenceSql(
+          values,
+          sharedStepDetail.dbSourceInfoCollection.value
+        ).finally(finallyFunc);
+      }
+    },
+    [
+      auditWorkflowWithSameSql,
+      auditWorkflowWthDifferenceSql,
+      baseInfoForm,
+      goToAuditResultStep,
+      isAuditing,
+      sharedStepDetail.dbSourceInfoCollection.value
+    ]
+  );
+
+  const createAction = useCallback(async () => {
+    const baseInfo = await baseInfoForm.validateFields();
+
+    if (!taskInfos?.length) {
+      messageApi.error(t('execWorkflow.create.mustAuditTips'));
+      return;
+    }
+
+    if (
+      Object.keys(taskSqlCountRecord).some(
+        (key) =>
+          taskSqlCountRecord[key] === 0 &&
+          taskInfos.some((v) => v.task_id?.toString() === key)
+      )
+    ) {
+      messageApi.error(t('execWorkflow.create.mustHaveAuditResultTips'));
+      return;
+    }
+
+    const createWorkflowParam: ICreateWorkflowV2Params = {
+      task_ids: taskInfos.map((v) => v.task_id!),
+      desc: baseInfo?.desc,
+      workflow_subject: baseInfo?.workflow_subject,
+      project_name: projectName
+    };
+    return workflow.createWorkflowV2(createWorkflowParam).then((res) => {
+      if (res.data.code === ResponseCode.SUCCESS) {
+        goToCreateResultStep();
+        createdWorkflowID.current = res.data.data?.workflow_id ?? '';
+      }
+    });
+  }, [
+    baseInfoForm,
+    goToCreateResultStep,
+    messageApi,
+    projectName,
+    t,
+    taskInfos,
+    taskSqlCountRecord
+  ]);
+
+  usePrompt(t('execWorkflow.create.auditResult.leaveTip'), isAtAuditResultStep);
+  return (
+    <Spin spinning={isAuditing.value}>
+      {messageContextHolder}
+      <div hidden={!isAtFormStep}>
+        <FormStep
+          baseInfoForm={baseInfoForm}
+          sqlAuditInfoForm={sqlAuditInfoForm}
+          isAuditing={isAuditing}
+          auditAction={auditAction}
+          {...sharedStepDetail}
+        />
+      </div>
+      <div hidden={!isAtAuditResultStep}>
+        <AuditResultStep
+          isAuditing={isAuditing}
+          baseFormValues={baseInfoForm.getFieldsValue()}
+          sqlAuditInfoFormValues={sqlAuditInfoForm.getFieldsValue()}
+          tasks={taskInfos}
+          isDisableFinallySubmitButton={isDisableFinallySubmitButton}
+          disabledOperatorOrderBtnTips={disabledOperatorWorkflowBtnTips}
+          auditAction={auditAction}
+          createAction={createAction}
+          updateTaskRecordCount={updateTaskRecordTotalNum}
+          {...sharedStepDetail}
+        />
+      </div>
+      <div hidden={!isAtCreateResultStep}>
+        <CreateResultStep
+          desc={baseInfoForm.getFieldValue('desc')}
+          workflowID={createdWorkflowID.current}
+        />
+      </div>
+    </Spin>
+  );
+};
+
+export default CreateSqlExecWorkflow;

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/index.type.ts
@@ -1,0 +1,68 @@
+import { ICreateWorkflowV2Params } from '@actiontech/shared/lib/api/sqle/service/workflow/index.d';
+import { DatabaseSelectionFields } from './components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/index.type';
+import {
+  AuditTaskResV1SqlSourceEnum,
+  CreateAuditTasksGroupReqV1ExecModeEnum
+} from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import {
+  IInstanceConnectionResV1,
+  IRuleTemplateV2
+} from '@actiontech/shared/lib/api/sqle/service/common';
+
+type Stateful<S> = {
+  value: S;
+  set: (newState: S | ((prevState: S) => S)) => void;
+};
+
+export type WorkflowBaseInfoFormFields = Pick<
+  ICreateWorkflowV2Params,
+  'desc' | 'workflow_subject'
+>;
+
+export type SqlStatementFields = Record<
+  keyof typeof AuditTaskResV1SqlSourceEnum,
+  string | any
+>;
+
+export type SqlAuditInfoFormFields = {
+  isSameSqlForAll: boolean;
+  databaseInfo: Array<DatabaseSelectionFields>;
+  executeMode: CreateAuditTasksGroupReqV1ExecModeEnum;
+  [key: string]:
+    | SqlStatementFields
+    | AuditTaskResV1SqlSourceEnum
+    | boolean
+    | Array<DatabaseSelectionFields>
+    | CreateAuditTasksGroupReqV1ExecModeEnum;
+};
+
+/**
+ * 由于 数据源信息没有 key 作为主键，并且添加数据源时可以选择重复的数据源，所以这里的 key 为 Form.List 中 field 提供的 key
+ */
+export type DataSourceSchemaCollection = Record<
+  string,
+  {
+    instanceName?: string;
+    schemaName?: string;
+    schemaList?: string[];
+    getSchemaLoading?: boolean;
+    dbType?: string;
+    ruleTemplate?: IRuleTemplateV2;
+    testConnectResult?: IInstanceConnectionResV1;
+    delete?: boolean;
+  }
+>;
+
+export type SharedStepDetails = {
+  isAuditing: Stateful<boolean>;
+  dbSourceInfoCollection: {
+    value: DataSourceSchemaCollection;
+    set: (key: string, value?: DataSourceSchemaCollection[string]) => void;
+  };
+  instanceTestConnectResults: Stateful<IInstanceConnectionResV1[]>;
+  isDisabledForDifferenceSql: Stateful<boolean>;
+  isSupportFileModeExecuteSQL: Stateful<boolean>;
+  sqlStatementTabActiveKey: Stateful<string>;
+
+  resetAllSharedData: () => void;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/List/column.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/column.tsx
@@ -1,0 +1,140 @@
+import { BasicTypographyEllipsis, AvatarCom } from '@actiontech/shared';
+import { IWorkflowDetailResV1 } from '@actiontech/shared/lib/api/sqle/service/common';
+import {
+  ActiontechTableColumn,
+  ActiontechTableFilterMeta,
+  ActiontechTableFilterMetaValue
+} from '@actiontech/shared/lib/components/ActiontechTable';
+import { TableColumnWithIconStyleWrapper } from '@actiontech/shared/lib/styleWrapper/element';
+import { formatTime } from '@actiontech/shared/lib/utils/Common';
+import { t } from '../../../locale';
+import WorkflowStatus from './components/WorkflowStatus';
+import { SqlExecWorkflowListTableFilterParam } from './index.type';
+import { IconWorkflowId } from '../../../icon/SqlExecWorkflow';
+import { WorkflowNameStyleWrapper } from './style';
+
+export const ExtraFilterMeta: () => ActiontechTableFilterMeta<
+  IWorkflowDetailResV1 & {
+    instance_name?: string;
+    execute_time?: string;
+  },
+  SqlExecWorkflowListTableFilterParam
+> = () => {
+  return new Map<
+    keyof (IWorkflowDetailResV1 & {
+      instance_name?: string;
+      execute_time?: string;
+    }),
+    ActiontechTableFilterMetaValue<SqlExecWorkflowListTableFilterParam>
+  >([
+    [
+      'execute_time',
+      {
+        filterCustomType: 'date-range',
+        filterKey: [
+          'filter_task_execute_start_time_from',
+          'filter_task_execute_start_time_to'
+        ],
+        filterLabel: t('execWorkflow.list.executeTime'),
+        checked: false
+      }
+    ],
+
+    [
+      'instance_name',
+      {
+        filterCustomType: 'select',
+        filterKey: 'filter_task_instance_name',
+        filterLabel: t('execWorkflow.list.dataSource'),
+        checked: false
+      }
+    ]
+  ]);
+};
+
+export const SqlExecWorkflowListColumn: (
+  projectID: string
+) => ActiontechTableColumn<
+  IWorkflowDetailResV1,
+  SqlExecWorkflowListTableFilterParam,
+  'address'
+> = (projectID) => {
+  return [
+    {
+      dataIndex: 'workflow_id',
+      title: () => t('execWorkflow.list.id'),
+      render: (id: string) => {
+        return (
+          <TableColumnWithIconStyleWrapper>
+            <IconWorkflowId />
+            <span>{id}</span>
+          </TableColumnWithIconStyleWrapper>
+        );
+      },
+      fixed: 'left'
+    },
+    {
+      dataIndex: 'workflow_name',
+      className: 'workflow-list-table-workflow-name-column',
+      title: () => t('execWorkflow.list.name'),
+      render: (name: string) => (
+        <WorkflowNameStyleWrapper ellipsis={true}>
+          {name}
+        </WorkflowNameStyleWrapper>
+      ),
+      fixed: 'left'
+    },
+    {
+      dataIndex: 'desc',
+      title: () => t('execWorkflow.list.desc'),
+      className: 'workflow-list-table-desc-column',
+      render: (desc: string, record: IWorkflowDetailResV1) =>
+        desc ? (
+          <BasicTypographyEllipsis
+            textCont={desc}
+            linkData={{
+              route: `/sqle/project/${projectID}/exec-workflow/${
+                record.workflow_id ?? ''
+              }`,
+              text: t('execWorkflow.create.createResult.viewWorkflowDetail')
+            }}
+          />
+        ) : (
+          '-'
+        )
+    },
+    {
+      dataIndex: 'create_time',
+      title: () => t('execWorkflow.list.createTime'),
+      render: (time) => {
+        return formatTime(time, '-');
+      },
+      filterCustomType: 'date-range',
+      filterKey: ['filter_create_time_from', 'filter_create_time_to']
+    },
+    {
+      dataIndex: 'create_user_name',
+      title: () => t('execWorkflow.list.createUser'),
+      filterCustomType: 'select',
+      filterKey: 'filter_create_user_id'
+    },
+    {
+      dataIndex: 'status',
+      title: () => t('execWorkflow.list.status'),
+      render: (status: IWorkflowDetailResV1['status']) => {
+        return <WorkflowStatus status={status} />;
+      }
+    },
+    {
+      dataIndex: 'current_step_assignee_user_name_list',
+      title: () => t('execWorkflow.list.assignee'),
+      filterCustomType: 'select',
+      filterKey: 'filter_current_step_assignee_user_id',
+      render: (list: string[]) => {
+        return list?.map((v) => {
+          return <AvatarCom key={v} name={v} />;
+        });
+      }
+    }
+  ];
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/List/components/ExportWorkflowButton/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/components/ExportWorkflowButton/index.tsx
@@ -1,0 +1,86 @@
+import { BasicButton } from '@actiontech/shared';
+import { IconDownload } from '@actiontech/shared/lib/Icon';
+import workflow from '@actiontech/shared/lib/api/sqle/service/workflow';
+import { IExportWorkflowV1Params } from '@actiontech/shared/lib/api/sqle/service/workflow/index.d';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import { useBoolean } from 'ahooks';
+import { message } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { ExportWorkflowButtonProps } from './index.type';
+
+const ExportWorkflowButton: React.FC<ExportWorkflowButtonProps> = ({
+  tableFilterInfo,
+  filterStatus,
+  searchKeyword
+}) => {
+  const { t } = useTranslation();
+  const { projectName } = useCurrentProject();
+  const [messageApi, messageContextHolder] = message.useMessage();
+
+  const [
+    exportButtonDisabled,
+    { setFalse: finishExport, setTrue: startExport }
+  ] = useBoolean(false);
+  const exportWorkflow = () => {
+    startExport();
+    const hideLoading = messageApi.loading(
+      t('execWorkflow.list.exportWorkflow.exporting')
+    );
+
+    const {
+      filter_create_time_from,
+      filter_create_time_to,
+      filter_task_execute_start_time_from,
+      filter_task_execute_start_time_to,
+      filter_create_user_id,
+      filter_current_step_assignee_user_id,
+      filter_subject,
+      filter_task_instance_name
+    } = tableFilterInfo;
+
+    const params: IExportWorkflowV1Params = {
+      ...tableFilterInfo,
+      project_name: projectName,
+      filter_create_user_id,
+      filter_current_step_assignee_user_id,
+      filter_status: filterStatus,
+      filter_subject,
+      filter_task_instance_name,
+      filter_create_time_from,
+      filter_create_time_to,
+      filter_task_execute_start_time_from,
+      filter_task_execute_start_time_to,
+      fuzzy_keyword: searchKeyword
+    };
+
+    workflow
+      .exportWorkflowV1(params, { responseType: 'blob' })
+      .then((res) => {
+        if (res.data.code === ResponseCode.SUCCESS) {
+          messageApi.success(
+            t('execWorkflow.list.exportWorkflow.exportSuccessTips')
+          );
+        }
+      })
+      .finally(() => {
+        hideLoading();
+        finishExport();
+      });
+  };
+
+  return (
+    <>
+      {messageContextHolder}
+      <BasicButton
+        onClick={exportWorkflow}
+        disabled={exportButtonDisabled}
+        icon={<IconDownload />}
+      >
+        {t('execWorkflow.list.exportWorkflow.buttonText')}
+      </BasicButton>
+    </>
+  );
+};
+
+export default ExportWorkflowButton;

--- a/packages/sqle/src/page/SqlExecWorkflow/List/components/ExportWorkflowButton/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/components/ExportWorkflowButton/index.type.ts
@@ -1,0 +1,8 @@
+import { exportWorkflowV1FilterStatusEnum } from '@actiontech/shared/lib/api/sqle/service/workflow/index.enum';
+import { SqlExecWorkflowListTableFilterParam } from '../../index.type';
+
+export type ExportWorkflowButtonProps = {
+  tableFilterInfo: SqlExecWorkflowListTableFilterParam;
+  filterStatus?: exportWorkflowV1FilterStatusEnum;
+  searchKeyword?: string;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/List/components/WorkflowStatus/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/components/WorkflowStatus/index.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react';
+import {
+  IconWorkflowStatusIsCanceled,
+  IconWorkflowStatusIsExecuting,
+  IconWorkflowStatusIsFailed,
+  IconWorkflowStatusIsFinished,
+  IconWorkflowStatusIsRejected,
+  IconWorkflowStatusIsWaitAudit,
+  IconWorkflowStatusIsWaitExecution
+} from '../../../../../icon/SqlExecWorkflow';
+import { WorkflowStatusStyleWrapper } from './style';
+import { WorkflowDetailResV1StatusEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { t } from '../../../../../locale';
+
+const WorkflowStatusMap = () => {
+  return new Map<WorkflowDetailResV1StatusEnum, ReactNode>([
+    [
+      WorkflowDetailResV1StatusEnum.canceled,
+      <>
+        <IconWorkflowStatusIsCanceled />
+        <span>{t('execWorkflow.common.workflowStatus.canceled')}</span>
+      </>
+    ],
+    [
+      WorkflowDetailResV1StatusEnum.executing,
+      <>
+        <IconWorkflowStatusIsExecuting />
+        <span>{t('execWorkflow.common.workflowStatus.executing')}</span>
+      </>
+    ],
+    [
+      WorkflowDetailResV1StatusEnum.finished,
+      <>
+        <IconWorkflowStatusIsFinished />
+        <span>{t('execWorkflow.common.workflowStatus.finished')}</span>
+      </>
+    ],
+    [
+      WorkflowDetailResV1StatusEnum.exec_failed,
+      <>
+        <IconWorkflowStatusIsFailed />
+        <span>{t('execWorkflow.common.workflowStatus.execFailed')}</span>
+      </>
+    ],
+    [
+      WorkflowDetailResV1StatusEnum.wait_for_audit,
+      <>
+        <IconWorkflowStatusIsWaitAudit />
+        <span>{t('execWorkflow.common.workflowStatus.waitForAudit')}</span>
+      </>
+    ],
+    [
+      WorkflowDetailResV1StatusEnum.wait_for_execution,
+      <>
+        <IconWorkflowStatusIsWaitExecution />
+        <span>{t('execWorkflow.common.workflowStatus.waitForExecution')}</span>
+      </>
+    ],
+    [
+      WorkflowDetailResV1StatusEnum.rejected,
+      <>
+        <IconWorkflowStatusIsRejected />
+        <span>{t('execWorkflow.common.workflowStatus.reject')}</span>
+      </>
+    ]
+  ]);
+};
+
+const WorkflowStatus: React.FC<{ status?: WorkflowDetailResV1StatusEnum }> = ({
+  status
+}) => {
+  //todo unknown
+  return (
+    <>
+      {status ? (
+        <WorkflowStatusStyleWrapper>
+          {WorkflowStatusMap().get(status)}
+        </WorkflowStatusStyleWrapper>
+      ) : (
+        'unknown'
+      )}
+    </>
+  );
+};
+
+export default WorkflowStatus;

--- a/packages/sqle/src/page/SqlExecWorkflow/List/components/WorkflowStatus/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/components/WorkflowStatus/style.ts
@@ -1,0 +1,12 @@
+import { styled } from '@mui/material/styles';
+
+export const WorkflowStatusStyleWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+
+  span {
+    &:last-of-type {
+      margin-left: 8px;
+    }
+  }
+`;

--- a/packages/sqle/src/page/SqlExecWorkflow/List/index.data.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/index.data.ts
@@ -1,0 +1,29 @@
+import { t } from '../../../locale';
+import { getWorkflowsV1FilterStatusEnum } from '@actiontech/shared/lib/api/sqle/service/workflow/index.enum';
+
+export const WorkflowStatusDictionary: Record<
+  keyof typeof getWorkflowsV1FilterStatusEnum,
+  string
+> = {
+  [getWorkflowsV1FilterStatusEnum.wait_for_audit]: t(
+    'execWorkflow.common.workflowStatus.waitForAudit'
+  ),
+  [getWorkflowsV1FilterStatusEnum.wait_for_execution]: t(
+    'execWorkflow.common.workflowStatus.waitForExecution'
+  ),
+  [getWorkflowsV1FilterStatusEnum.canceled]: t(
+    'execWorkflow.common.workflowStatus.canceled'
+  ),
+  [getWorkflowsV1FilterStatusEnum.rejected]: t(
+    'execWorkflow.common.workflowStatus.reject'
+  ),
+  [getWorkflowsV1FilterStatusEnum.exec_failed]: t(
+    'execWorkflow.common.workflowStatus.reject'
+  ),
+  [getWorkflowsV1FilterStatusEnum.finished]: t(
+    'execWorkflow.common.workflowStatus.finished'
+  ),
+  [getWorkflowsV1FilterStatusEnum.executing]: t(
+    'execWorkflow.common.workflowStatus.executing'
+  )
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/List/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/index.tsx
@@ -1,0 +1,308 @@
+import {
+  ActiontechTable,
+  ColumnsSettingProps,
+  FilterCustomProps,
+  TableFilterContainer,
+  TableToolbar,
+  useTableFilterContainer,
+  useTableRequestError,
+  useTableRequestParams
+} from '@actiontech/shared/lib/components/ActiontechTable';
+import { SqlExecWorkflowListStyleWrapper } from './style';
+import {
+  PageHeader,
+  BasicButton,
+  EmptyBox,
+  CustomSegmentedFilter
+} from '@actiontech/shared';
+import { IconAdd } from '@actiontech/shared/lib/Icon';
+import { Space, message } from 'antd';
+import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  useCurrentProject,
+  useCurrentUser
+} from '@actiontech/shared/lib/global';
+import ExportWorkflowButton from './components/ExportWorkflowButton';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  exportWorkflowV1FilterStatusEnum,
+  getWorkflowsV1FilterStatusEnum
+} from '@actiontech/shared/lib/api/sqle/service/workflow/index.enum';
+import useUsername from '../../../hooks/useUsername';
+import useInstance from '../../../hooks/useInstance';
+import { useRequest } from 'ahooks';
+import workflow from '@actiontech/shared/lib/api/sqle/service/workflow';
+import { IGetWorkflowsV1Params } from '@actiontech/shared/lib/api/sqle/service/workflow/index.d';
+import { IWorkflowDetailResV1 } from '@actiontech/shared/lib/api/sqle/service/common';
+import { ExtraFilterMeta, SqlExecWorkflowListColumn } from './column';
+import { WorkflowDetailResV1StatusEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { TableRowSelection } from 'antd/es/table/interface';
+import { SqlExecWorkflowListTableFilterParam } from './index.type';
+import { WorkflowStatusDictionary } from './index.data';
+import { IconMinus } from '../../../icon/SqlExecWorkflow';
+
+const SqlExecWorkflowList: React.FC = () => {
+  const { t } = useTranslation();
+  const [messageApi, messageContextHolder] = message.useMessage();
+  const { projectID, projectArchive, projectName } = useCurrentProject();
+  const navigate = useNavigate();
+  const [filterStatus, setFilterStatus] =
+    useState<getWorkflowsV1FilterStatusEnum>();
+  const { usernameOptions, updateUsernameList } = useUsername();
+  const { instanceOptions, updateInstanceList } = useInstance();
+  const { isAdmin, username } = useCurrentUser();
+
+  const {
+    tableFilterInfo,
+    updateTableFilterInfo,
+    tableChange,
+    pagination,
+    searchKeyword,
+    setSearchKeyword,
+    refreshBySearchKeyword
+  } = useTableRequestParams<
+    IWorkflowDetailResV1,
+    SqlExecWorkflowListTableFilterParam
+  >();
+
+  const {
+    data: workflowList,
+    loading,
+    refresh
+  } = useRequest(
+    () => {
+      const params: IGetWorkflowsV1Params = {
+        ...tableFilterInfo,
+        ...pagination,
+        filter_status: filterStatus,
+        project_name: projectName,
+        fuzzy_keyword: searchKeyword
+      };
+      return handleTableRequestError(workflow.getWorkflowsV1(params));
+    },
+    {
+      refreshDeps: [tableFilterInfo, pagination, filterStatus]
+    }
+  );
+
+  const columns = useMemo(
+    () => SqlExecWorkflowListColumn(projectID),
+    [projectID]
+  );
+  const tableSetting = useMemo<ColumnsSettingProps>(
+    () => ({
+      tableName: 'sql_exec_workflow_list',
+      username: username
+    }),
+    [username]
+  );
+
+  const { filterButtonMeta, filterContainerMeta, updateAllSelectedFilterItem } =
+    useTableFilterContainer(columns, updateTableFilterInfo, ExtraFilterMeta());
+
+  const filterCustomProps = useMemo(() => {
+    return new Map<
+      keyof (IWorkflowDetailResV1 & {
+        instance_name?: string;
+        execute_time?: string;
+      }),
+      FilterCustomProps
+    >([
+      ['create_user_name', { options: usernameOptions }],
+      ['current_step_assignee_user_name_list', { options: usernameOptions }],
+      [
+        'instance_name',
+        {
+          options: instanceOptions
+        }
+      ],
+      [
+        'create_time',
+        {
+          showTime: true
+        }
+      ],
+      [
+        'execute_time',
+        {
+          showTime: true
+        }
+      ]
+    ]);
+  }, [instanceOptions, usernameOptions]);
+
+  const { requestErrorMessage, handleTableRequestError } =
+    useTableRequestError();
+
+  const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([]);
+  const [confirmLoading, setConfirmLoading] = useState<boolean>(false);
+  const rowSelection = {
+    selectedRowKeys,
+    onChange: (keys: string[]) => {
+      setSelectedRowKeys(keys);
+    }
+  };
+
+  const batchCloseAction = useCallback(() => {
+    const canCancel: boolean = selectedRowKeys.every((e) => {
+      const status = workflowList?.list?.filter(
+        (data) => `${data.workflow_id}` === e
+      )[0]?.status;
+      return (
+        status === WorkflowDetailResV1StatusEnum.wait_for_audit ||
+        status === WorkflowDetailResV1StatusEnum.wait_for_execution ||
+        status === WorkflowDetailResV1StatusEnum.rejected
+      );
+    });
+    if (canCancel) {
+      setConfirmLoading(true);
+      workflow
+        .batchCancelWorkflowsV2({
+          workflow_id_list: selectedRowKeys,
+          project_name: projectName
+        })
+        .then((res) => {
+          if (res.data.code === ResponseCode.SUCCESS) {
+            setSelectedRowKeys([]);
+            refresh();
+          }
+        })
+        .finally(() => {
+          setConfirmLoading(false);
+        });
+    } else {
+      messageApi.warning(
+        t('execWorkflow.list.batchClose.messageWarn', {
+          process: t('execWorkflow.common.workflowStatus.process'),
+          reject: t('execWorkflow.common.workflowStatus.reject')
+        })
+      );
+    }
+  }, [
+    selectedRowKeys,
+    workflowList?.list,
+    projectName,
+    refresh,
+    messageApi,
+    t
+  ]);
+
+  useEffect(() => {
+    updateUsernameList({ filter_project: projectName });
+    updateInstanceList({
+      project_name: projectName
+    });
+  }, [projectName, updateInstanceList, updateUsernameList]);
+
+  return (
+    <SqlExecWorkflowListStyleWrapper>
+      {messageContextHolder}
+      <PageHeader
+        title={t('execWorkflow.list.pageTitle')}
+        extra={
+          <Space size={12}>
+            {/* #if [ee] */}
+            <ExportWorkflowButton
+              filterStatus={
+                filterStatus as unknown as exportWorkflowV1FilterStatusEnum
+              }
+              tableFilterInfo={tableFilterInfo}
+              searchKeyword={searchKeyword}
+            />
+            {/* #endif */}
+
+            <EmptyBox if={!projectArchive}>
+              <Link to={`/sqle/project/${projectID}/exec-workflow/create`}>
+                <BasicButton type="primary" icon={<IconAdd />}>
+                  {t('execWorkflow.list.createButtonText')}
+                </BasicButton>
+              </Link>
+            </EmptyBox>
+          </Space>
+        }
+      />
+      <TableToolbar
+        refreshButton={{ refresh, disabled: loading }}
+        setting={tableSetting}
+        actions={[
+          {
+            key: 'close',
+            text: t('execWorkflow.list.batchClose.buttonText'),
+            buttonProps: {
+              icon: <IconMinus />,
+              disabled: selectedRowKeys?.length === 0
+            },
+            permissions: !!isAdmin,
+            confirm: {
+              onConfirm: batchCloseAction,
+              title: t('execWorkflow.list.batchClose.closePopTitle'),
+              okButtonProps: {
+                disabled: confirmLoading
+              }
+            }
+          }
+        ]}
+        filterButton={{
+          filterButtonMeta,
+          updateAllSelectedFilterItem
+        }}
+        searchInput={{
+          onChange: setSearchKeyword,
+          onSearch: () => {
+            refreshBySearchKeyword();
+          }
+        }}
+        loading={loading}
+      >
+        <CustomSegmentedFilter
+          value={filterStatus}
+          onChange={setFilterStatus}
+          labelDictionary={WorkflowStatusDictionary}
+          options={Object.keys(getWorkflowsV1FilterStatusEnum)}
+          withAll
+        />
+      </TableToolbar>
+
+      <TableFilterContainer
+        filterContainerMeta={filterContainerMeta}
+        updateTableFilterInfo={updateTableFilterInfo}
+        disabled={loading}
+        filterCustomProps={filterCustomProps}
+      />
+      <ActiontechTable
+        className="table-row-cursor"
+        setting={tableSetting}
+        dataSource={workflowList?.list}
+        rowKey={(record: IWorkflowDetailResV1) => {
+          return `${record?.workflow_id}`;
+        }}
+        rowSelection={
+          isAdmin
+            ? (rowSelection as TableRowSelection<IWorkflowDetailResV1>)
+            : undefined
+        }
+        pagination={{
+          total: workflowList?.total ?? 0,
+          current: pagination.page_index
+        }}
+        loading={loading}
+        columns={columns}
+        errorMessage={requestErrorMessage}
+        onChange={tableChange}
+        onRow={(record) => {
+          return {
+            onClick() {
+              navigate(
+                `/sqle/project/${projectID}/exec-workflow/${record.workflow_id}`
+              );
+            }
+          };
+        }}
+      />
+    </SqlExecWorkflowListStyleWrapper>
+  );
+};
+
+export default SqlExecWorkflowList;

--- a/packages/sqle/src/page/SqlExecWorkflow/List/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/index.type.ts
@@ -1,0 +1,7 @@
+import { IGetWorkflowsV1Params } from '@actiontech/shared/lib/api/sqle/service/workflow/index.d';
+import { PageInfoWithoutIndexAndSize } from '@actiontech/shared/lib/components/ActiontechTable';
+
+export type SqlExecWorkflowListTableFilterParam = PageInfoWithoutIndexAndSize<
+  IGetWorkflowsV1Params,
+  'project_name'
+>;

--- a/packages/sqle/src/page/SqlExecWorkflow/List/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/List/style.ts
@@ -1,0 +1,20 @@
+import { styled } from '@mui/material/styles';
+import { Typography } from 'antd';
+
+export const SqlExecWorkflowListStyleWrapper = styled('section')`
+  .workflow-list-table-desc-column {
+    max-width: 400px;
+  }
+
+  .workflow-list-table-name-column {
+    max-width: 300px;
+  }
+`;
+
+export const WorkflowNameStyleWrapper = styled(Typography.Paragraph)`
+  max-width: 100%;
+
+  &.ant-typography.ant-typography-ellipsis {
+    margin-bottom: 0;
+  }
+`;

--- a/packages/sqle/src/router/config.tsx
+++ b/packages/sqle/src/router/config.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import {
-  PieChartOutlined,
-  AuditOutlined,
-  ConsoleSqlOutlined,
-  ProfileOutlined,
-  CiCircleOutlined,
-  ProjectOutlined
-} from '@ant-design/icons';
 import { SystemRole } from '../data/common';
 import { PROJECT_ROUTER_PARAM } from '@actiontech/shared/lib/data/common';
 import { RouterConfigItem } from '@actiontech/shared/lib/types/common.type';
@@ -172,6 +164,14 @@ const SQLFileStatementOverview = React.lazy(
 );
 // #endif
 
+//workflow
+const SQLExecWorkflowList = React.lazy(
+  () => import('../page/SqlExecWorkflow/List')
+);
+const CreateSQLExecWorkflow = React.lazy(
+  () => import('../page/SqlExecWorkflow/Create')
+);
+
 //sqle global page
 const Rule = React.lazy(() => import('../page/Rule'));
 const RuleManager = React.lazy(() => import('../page/RuleManager'));
@@ -197,16 +197,45 @@ const ReportStatistics = React.lazy(() => import('../page/ReportStatistics'));
 
 export const projectDetailRouterConfig: RouterConfigItem[] = [
   {
-    label: 'menu.projectOverview',
     key: 'projectOverview',
-    icon: <ProjectOutlined />,
     path: `${PROJECT_ROUTER_PARAM}/overview`,
     element: <ProjectOverview />
   },
   {
-    label: 'menu.order',
+    key: 'sqlExecWorkflow',
+    path: `${PROJECT_ROUTER_PARAM}/exec-workflow`,
+    children: [
+      {
+        index: true,
+        element: <SQLExecWorkflowList />,
+        key: 'sqlExecWorkflowList'
+      },
+      {
+        path: 'create',
+        element: <CreateSQLExecWorkflow />,
+        key: 'createSQLExecWorkflow'
+      },
+      {
+        path: ':taskId/:sqlNum/analyze',
+        element: <OrderSqlAnalyze />,
+        key: 'orderAnalyze'
+      },
+      {
+        path: ':orderId',
+        element: <OrderDetail />,
+        key: 'orderDetail'
+      },
+      // #if [ee]
+      {
+        path: ':taskId/files/:fileId/sqls',
+        element: <SQLFileStatementOverview />,
+        key: 'SQLFileStatementOverview'
+      }
+      // #endif
+    ]
+  },
+  {
     key: 'order',
-    icon: <ConsoleSqlOutlined />,
     path: `${PROJECT_ROUTER_PARAM}/order`,
     children: [
       {
@@ -261,15 +290,11 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
   },
   {
     path: `${PROJECT_ROUTER_PARAM}/dashboard`,
-    label: 'menu.dashboard',
     element: <Home />,
-    icon: <PieChartOutlined />,
     key: 'dashboard'
   },
   {
     key: 'plane',
-    label: 'menu.auditPlane',
-    icon: <CiCircleOutlined />,
     path: `${PROJECT_ROUTER_PARAM}/audit-plan`,
     children: [
       {
@@ -307,8 +332,6 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
   {
     path: `${PROJECT_ROUTER_PARAM}/rule/template`,
     key: 'ruleTemplate',
-    label: 'menu.ruleTemplate',
-    icon: <AuditOutlined />,
     element: <RuleTemplate />,
     children: [
       {
@@ -364,20 +387,16 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
   {
     path: `${PROJECT_ROUTER_PARAM}/whitelist`,
     key: 'Whitelist',
-    label: 'menu.whitelist',
-    element: <Whitelist />,
-    icon: <ProfileOutlined />
+    element: <Whitelist />
   },
   {
     path: `${PROJECT_ROUTER_PARAM}/operation-record`,
-    label: 'menu.operationRecord',
     key: 'operationRecord',
     element: <OperationRecord />,
     role: [SystemRole.admin]
   },
   {
     path: `${PROJECT_ROUTER_PARAM}/sql-management`,
-    label: 'menu.sqlManagement',
     key: 'sqlManagement',
     children: [
       {
@@ -397,7 +416,6 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
   },
   {
     path: `${PROJECT_ROUTER_PARAM}/plugin-audit`,
-    label: 'menu.pluginAudit',
     key: 'pluginAudit',
     children: [
       {
@@ -409,7 +427,6 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
   },
   {
     path: `${PROJECT_ROUTER_PARAM}/sql-optimization`,
-    label: 'menu.sqlOptimization',
     key: 'sqlOptimization',
     element: <SqlOptimization />,
     // #if [ee]
@@ -441,8 +458,7 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
   {
     path: '*',
     key: 'projectRedirect',
-    element: <Navigate to="/" />,
-    label: 'menu.projectOverview'
+    element: <Navigate to="/" />
   }
 ];
 


### PR DESCRIPTION
重构 SQL上线工单的 List 与 Create 模块

放弃了 redux，还是使用了 props 来处理数据流

暂时还没走单元测试。后面补。

重构相关的变更后面会在重构结束后补充文档。修复了一些 bug 以及想要优化一些操作，待和产品沟通确认

assign in @Rain-1214 