### PR TITLE
[fix]:(tests) ineffective mock date in unit tests

### DIFF
--- a/packages/base/src/page/DataExportManagement/Create/components/SubmitWorkflow/UpdateInfoDrawer/index.test.tsx
+++ b/packages/base/src/page/DataExportManagement/Create/components/SubmitWorkflow/UpdateInfoDrawer/index.test.tsx
@@ -59,6 +59,7 @@ describe('test base/DataExport/Create/UpdateInfoDrawer', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
+    MockDate.reset();
   });
 
   it('should match snapshot', () => {

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/OverviewList/index.test.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/OverviewList/index.test.tsx
@@ -14,8 +14,8 @@ import MockDate from 'mockdate';
 
 describe('test base/DataExport/Detail/OverviewList', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     MockDate.set('2024-01-30 10:00:00');
-    jest.useFakeTimers({ legacyFakeTimers: true });
     mockUseCurrentProject();
     mockUseCurrentUser({
       uid: mockDataExportDetailRedux.workflowInfo.create_user?.uid

--- a/packages/base/src/page/Login/index.test.tsx
+++ b/packages/base/src/page/Login/index.test.tsx
@@ -2,7 +2,6 @@ import { act, cleanup, fireEvent, screen } from '@testing-library/react';
 import { useDispatch } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import MockDate from 'mockdate';
-import dayjs from 'dayjs';
 import { superRender } from '../../testUtils/customRender';
 import dms from '../../testUtils/mockApi/global';
 import { UserInfo } from '../../testUtils/mockApi/global/data';
@@ -40,10 +39,10 @@ describe('page/Login-ee', () => {
   };
 
   beforeEach(() => {
-    MockDate.set(dayjs('2023-12-19 12:00:00').valueOf());
     (useDispatch as jest.Mock).mockImplementation(() => dispatchSpy);
     (useNavigate as jest.Mock).mockImplementation(() => navigateSpy);
     jest.useFakeTimers();
+    MockDate.set('2023-12-19 12:00:00');
     dms.mockAllApi();
   });
 
@@ -51,6 +50,7 @@ describe('page/Login-ee', () => {
     jest.useRealTimers();
     assignMock.mockClear();
     cleanup();
+    MockDate.reset();
   });
 
   it('render login snap', async () => {

--- a/packages/sqle/src/page/ReportStatistics/EEIndex/component/cardNumberShow/index.test.tsx
+++ b/packages/sqle/src/page/ReportStatistics/EEIndex/component/cardNumberShow/index.test.tsx
@@ -27,6 +27,7 @@ describe('ReportStatistics/CardNumberShow', () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
     cleanup();
+    MockDate.reset();
   });
 
   it('render snap loading', async () => {

--- a/packages/sqle/src/page/ReportStatistics/EEIndex/index.test.tsx
+++ b/packages/sqle/src/page/ReportStatistics/EEIndex/index.test.tsx
@@ -31,6 +31,7 @@ describe('sqle/ReportStatistics/EEIndex', () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
     cleanup();
+    MockDate.reset();
   });
 
   it('render report statics page', async () => {

--- a/packages/sqle/src/page/ReportStatistics/index.test.tsx
+++ b/packages/sqle/src/page/ReportStatistics/index.test.tsx
@@ -35,6 +35,7 @@ describe('sqle/ReportStatistics', () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
     cleanup();
+    MockDate.reset();
   });
 
   it('should match snap shot', async () => {

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/BaseInfoTag.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/BaseInfoTag.test.tsx
@@ -15,5 +15,6 @@ describe('test UpdateFormDrawer', () => {
     const wrapper = shallow(<BaseInfoTag />);
 
     expect(toJson(wrapper)).toMatchSnapshot();
+    MockDate.reset();
   });
 });

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/OverviewList/ScheduleTimeModal/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/OverviewList/ScheduleTimeModal/__tests__/index.test.tsx
@@ -195,6 +195,7 @@ describe('sqle/ExecWorkflow/AuditDetail/ScheduleTimeModal', () => {
     fireEvent.click(
       getBySelector('.ant-picker-date-panel td[title="2024-12-18"]')
     );
+    MockDate.reset();
   });
 
   it('render submit btn', async () => {

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/OverviewList/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/OverviewList/__tests__/index.test.tsx
@@ -16,7 +16,6 @@ import execWorkflow from '../../../../../../../testUtils/mockApi/execWorkflow';
 import { mockProjectInfo } from '@actiontech/shared/lib/testUtil/mockHook/data';
 import { act, cleanup } from '@testing-library/react';
 import MockDate from 'mockdate';
-import dayjs from 'dayjs';
 import { getBySelector } from '@actiontech/shared/lib/testUtil/customQuery';
 import {
   UtilsConsoleErrorStringsEnum,
@@ -52,8 +51,8 @@ describe('test OverviewList', () => {
   };
 
   beforeEach(() => {
-    MockDate.set(dayjs('2023-12-18 12:00:00').valueOf());
     jest.useFakeTimers();
+    MockDate.set('2023-12-18 12:00:00');
     mockUseCurrentProject();
     mockUseCurrentUser();
     executeOneTaskOnWorkflowSpy = execWorkflow.executeOneTaskOnWorkflow();
@@ -66,11 +65,11 @@ describe('test OverviewList', () => {
     jest.useRealTimers();
     jest.clearAllMocks();
     jest.clearAllTimers();
+    MockDate.reset();
   });
 
   it('matches the snapshot for the default task result setup', () => {
     const { container } = customRender();
-
     expect(container).toMatchSnapshot();
   });
 


### PR DESCRIPTION
1. 修复单元测试中部分未生效的 MockDate
2. 补充 MockData.reset()