### PR TITLE
[feature]: Refactor page-level permission handling [skip ci]

### DIFF
--- a/packages/base/src/page/DataSourceManagement/index.tsx
+++ b/packages/base/src/page/DataSourceManagement/index.tsx
@@ -22,6 +22,11 @@ import { PlusOutlined } from '@actiontech/icons/src/outlined';
 import GlobalDataSource from '../GlobalDataSource';
 import SyncDataSource from '../SyncDataSource';
 import { SegmentedTabsProps } from '@actiontech/shared/lib/components/SegmentedTabs/index.type';
+import {
+  PERMISSIONS,
+  PermissionsConstantType
+} from '@actiontech/shared/lib/global';
+import usePermission from '@actiontech/shared/lib/global/usePermission/usePermission';
 
 const DataSourceManagement: React.FC = () => {
   const { t } = useTranslation();
@@ -29,8 +34,8 @@ const DataSourceManagement: React.FC = () => {
     DataSourceManagerSegmentedKey.GlobalDataSource
   );
 
-  const { isAdmin, isCertainProjectManager, hasGlobalViewingPermission } =
-    useCurrentUser();
+  const { isAdmin, isCertainProjectManager } = useCurrentUser();
+  const { checkPagePermission } = usePermission();
 
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -45,30 +50,27 @@ const DataSourceManagement: React.FC = () => {
   };
 
   const tabItems = useMemo<SegmentedTabsProps['items']>(() => {
-    const globalDataSourceItem: SegmentedTabsProps['items'][0] = {
-      label: t('dmsGlobalDataSource.pageTitle'),
-      value: DataSourceManagerSegmentedKey.GlobalDataSource,
-      children: <GlobalDataSource />,
-      destroyInactivePane: true
-    };
-    if (isAdmin || hasGlobalViewingPermission) {
-      return [
-        globalDataSourceItem,
-        {
-          label: t('dmsSyncDataSource.pageTitle'),
-          value: DataSourceManagerSegmentedKey.SyncDataSource,
-          children: <SyncDataSource />,
-          destroyInactivePane: true
-        }
-      ];
-    }
+    const items: Array<
+      SegmentedTabsProps['items'][0] & { permission: PermissionsConstantType }
+    > = [
+      {
+        label: t('dmsGlobalDataSource.pageTitle'),
+        value: DataSourceManagerSegmentedKey.GlobalDataSource,
+        children: <GlobalDataSource />,
+        destroyInactivePane: true,
+        permission: PERMISSIONS.PAGES.BASE.GLOBAL_DATA_SOURCE
+      },
+      {
+        label: t('dmsSyncDataSource.pageTitle'),
+        value: DataSourceManagerSegmentedKey.SyncDataSource,
+        children: <SyncDataSource />,
+        destroyInactivePane: true,
+        permission: PERMISSIONS.PAGES.BASE.SYNC_DATA_SOURCE
+      }
+    ];
 
-    if (isCertainProjectManager) {
-      return [globalDataSourceItem];
-    }
-
-    return [];
-  }, [hasGlobalViewingPermission, isAdmin, isCertainProjectManager, t]);
+    return items.filter((item) => checkPagePermission(item.permission));
+  }, [checkPagePermission, t]);
 
   // #if [ee]
   const renderExtra = () => {

--- a/packages/base/src/page/Nav/SideMenu/MenuList/index.type.ts
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/index.type.ts
@@ -1,6 +1,0 @@
-import { UserRolesType } from '@actiontech/shared/lib/enum';
-
-export type MenuListProps = {
-  projectID: string;
-  userRoles: UserRolesType;
-};

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/common.ts
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/common.ts
@@ -1,5 +1,3 @@
-import { UserRolesType } from '@actiontech/shared/lib/enum';
-
 import {
   CustomMenuItemType,
   GenerateMenuItemType,
@@ -12,19 +10,12 @@ export const SIDE_MENU_DATA_PLACEHOLDER_KEY = 'projectID';
 export const genMenuItemsWithMenuStructTree = (
   projectID: string,
   allMenuItems: GenerateMenuItemType[],
-  menuStructTree: MenuStructTreeType,
-  userRoles: UserRolesType
+  menuStructTree: MenuStructTreeType
 ): CustomMenuItemType[] => {
   const getMenuItemWithKey = (key: MenuStructTreeKey): CustomMenuItemType => {
     return (
-      allMenuItems.find((v) => {
-        const menu = v(projectID);
-        if (menu?.role) {
-          return (
-            menu.role.some((role) => userRoles[role]) && menu.structKey === key
-          );
-        }
-
+      allMenuItems.find((item) => {
+        const menu = item(projectID);
         return menu?.structKey === key;
       })?.(projectID) ?? null
     );
@@ -42,6 +33,7 @@ export const genMenuItemsWithMenuStructTree = (
       }
       return {
         type: 'group',
+        permission: item.permission,
         label: item.label,
         children
       } as CustomMenuItemType;

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/index.type.ts
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/index.type.ts
@@ -1,16 +1,21 @@
-import { SystemRole } from '@actiontech/shared/lib/enum';
+import { PermissionsConstantType } from '@actiontech/shared/lib/global';
 import { ItemType } from 'antd/es/menu/hooks/useItems';
 
 export type CustomMenuItemType =
   | (ItemType & {
       structKey: MenuStructTreeKey;
-      role?: Array<SystemRole>;
+      permission?: PermissionsConstantType;
     })
   | null;
 
 export type MenuStructTreeType = Array<
   | MenuStructTreeKey
-  | { type: 'group'; label: string; group: Array<MenuStructTreeKey> }
+  | {
+      type: 'group';
+      label: string;
+      group: Array<MenuStructTreeKey>;
+      permission?: PermissionsConstantType;
+    }
   | { type: 'divider' }
 >;
 

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/menu.data.dms.tsx
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/menu.data.dms.tsx
@@ -2,8 +2,6 @@
  * Do not modify this file in the dms-ui repository
  */
 
-import { UserRolesType } from '@actiontech/shared/lib/enum';
-
-export const dmsSideMenuData = (_: string, __: UserRolesType) => {
+export const dmsSideMenuData = (_: string) => {
   return [];
 };

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/menu.data.tsx
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/menu.data.tsx
@@ -1,44 +1,26 @@
-import { UserRolesType } from '@actiontech/shared/lib/enum';
 import { t } from '../../../../../locale';
-import { MenuStructTreeType, MenuStructTreeKey } from './index.type';
+import { MenuStructTreeType } from './index.type';
 import { genMenuItemsWithMenuStructTree } from './common';
 import baseMenusCollection from './base';
 import sqleMenusCollection from './sqle';
+import { PERMISSIONS } from '@actiontech/shared/lib/global';
 
-export const sideMenuData = (
-  projectID: string,
-  userRoles: UserRolesType,
-  sqlOptimizationIsSupport: boolean
-) => {
-  const sqlDevGroup: MenuStructTreeKey[] = [
-    'cloud-beaver',
-    'data-export',
-    'sql-audit',
-    'plugin-audit'
-  ];
-
-  // 现状: SQL优化页面在CE中会展示预览引导页面 但是在EE中需要根据 sqlOptimizationIsSupport（接口查询返回）权限来决定是否展示 没有任何提示信息 会导致用户无法感知此功能的存在 不太合理
-  // todo: 下一期需求周期把此问题给产品抛出 希望解决此问题
+export const sideMenuData = (projectID: string) => {
   const menuStruct: MenuStructTreeType = [
     'project-overview',
     'dashboard',
     { type: 'divider' },
-    // #if [ce]
     {
       type: 'group',
       label: t('dmsMenu.groupLabel.SQLDev'),
-      group: [...sqlDevGroup, 'sql-optimization']
+      group: [
+        'cloud-beaver',
+        'data-export',
+        'sql-audit',
+        'plugin-audit',
+        'sql-optimization'
+      ]
     },
-    // #endif
-    // #if [ee]
-    {
-      type: 'group',
-      label: t('dmsMenu.groupLabel.SQLDev'),
-      group: sqlOptimizationIsSupport
-        ? [...sqlDevGroup, 'sql-optimization']
-        : sqlDevGroup
-    },
-    // #endif
     {
       type: 'group',
       label: t('dmsMenu.groupLabel.SQLExecute'),
@@ -71,6 +53,7 @@ export const sideMenuData = (
     { type: 'divider' },
     {
       type: 'group',
+      permission: PERMISSIONS.PAGES.SQLE.OPERATION_RECORD,
       label: t('dmsMenu.groupLabel.operateAndAudit'),
       group: ['sqle-log']
     }
@@ -79,7 +62,6 @@ export const sideMenuData = (
   return genMenuItemsWithMenuStructTree(
     projectID,
     [...sqleMenusCollection, ...baseMenusCollection],
-    menuStruct,
-    userRoles
+    menuStruct
   );
 };

--- a/packages/base/src/page/Nav/SideMenu/MenuList/menus/sqle.tsx
+++ b/packages/base/src/page/Nav/SideMenu/MenuList/menus/sqle.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
 import { SIDE_MENU_DATA_PLACEHOLDER_KEY } from './common';
 import { t } from '../../../../../locale';
-import { SystemRole } from '@actiontech/shared/lib/enum';
 import { GenerateMenuItemType } from './index.type';
 import {
   ManagementFilled,
@@ -21,6 +20,7 @@ import {
   GearFilled,
   PipelineOutlined
 } from '@actiontech/icons';
+import { PERMISSIONS } from '@actiontech/shared/lib/global';
 
 const projectOverviewMenuItem: GenerateMenuItemType = (projectID) => ({
   label: (
@@ -78,7 +78,10 @@ const sqlOptimizationMenuItem: GenerateMenuItemType = (projectID) => ({
   ),
   icon: <RiseSquareOutlined width={18} height={18} />,
   key: `sqle/project/${SIDE_MENU_DATA_PLACEHOLDER_KEY}/sql-optimization`,
-  structKey: 'sql-optimization'
+  structKey: 'sql-optimization',
+  // #if [ee]
+  permission: PERMISSIONS.PAGES.SQLE.SQL_OPTIMIZATION
+  // #endif
 });
 
 const sqlExecWorkflowMenuItem: GenerateMenuItemType = (projectID) => ({
@@ -156,7 +159,7 @@ const sqleOperationRecordMenuItem: GenerateMenuItemType = (projectID) => ({
   icon: <OperateAuditFilled width={18} height={18} />,
   key: `sqle/project/${SIDE_MENU_DATA_PLACEHOLDER_KEY}/operation-record`,
   structKey: 'sqle-log',
-  role: [SystemRole.admin, SystemRole.globalViewing]
+  permission: PERMISSIONS.PAGES.SQLE.OPERATION_RECORD
 });
 
 const sqlManagementConf: GenerateMenuItemType = (projectID) => ({

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/components/ContextMenu/index.tsx
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/components/ContextMenu/index.tsx
@@ -35,9 +35,6 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
           {header && <div className="header">{header}</div>}
           <div className="content">
             {items.map((menu) => {
-              if (menu.hidden) {
-                return null;
-              }
               return (
                 <div
                   key={menu.key}

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/components/ContextMenu/index.type.ts
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/components/ContextMenu/index.type.ts
@@ -7,7 +7,6 @@ export type ContextMenuItem = {
   text: ReactNode;
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   keepOpenOnClick?: boolean;
-  hidden?: boolean;
   disabled?: boolean;
 };
 

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/index.tsx
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/index.tsx
@@ -5,13 +5,7 @@ import { UserMenuProps } from './index.type';
 import CompanyNoticeModal from './Modal/CompanyNoticeModal';
 import VersionModal from './Modal/VersionModal';
 
-const UserMenu: React.FC<UserMenuProps> = ({
-  language,
-  username,
-  isAdmin,
-  isCertainProjectManager,
-  hasGlobalViewingPermission
-}) => {
+const UserMenu: React.FC<UserMenuProps> = ({ language, username }) => {
   const [
     versionModalOpen,
     { setTrue: setVersionModalOpen, setFalse: setVersionModalClose }
@@ -25,11 +19,7 @@ const UserMenu: React.FC<UserMenuProps> = ({
           username={username}
           onOpenVersionModal={setVersionModalOpen}
         />
-        <GlobalSetting
-          isAdmin={isAdmin}
-          isCertainProjectManager={isCertainProjectManager}
-          hasGlobalViewingPermission={hasGlobalViewingPermission}
-        />
+        <GlobalSetting />
       </div>
       <VersionModal
         open={versionModalOpen}

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/index.type.ts
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/index.type.ts
@@ -6,9 +6,6 @@ export type UserMenuProps = {
   language: SupportLanguage;
   theme: SupportTheme;
   updateTheme: (theme: SupportTheme) => void;
-  isAdmin: boolean;
-  isCertainProjectManager: boolean;
-  hasGlobalViewingPermission: boolean;
 };
 
 export type BasicVersionModalProps = {

--- a/packages/base/src/page/Nav/SideMenu/index.ce.tsx
+++ b/packages/base/src/page/Nav/SideMenu/index.ce.tsx
@@ -12,16 +12,7 @@ import MenuList from './MenuList';
 import { FlagFilled } from '@actiontech/icons';
 
 const CESideMenu = () => {
-  const {
-    username,
-    theme,
-    updateTheme,
-    isAdmin,
-    userRoles,
-    language,
-    isCertainProjectManager,
-    hasGlobalViewingPermission
-  } = useCurrentUser();
+  const { username, theme, updateTheme, language } = useCurrentUser();
 
   return (
     <SideMenuStyleWrapper className="dms-layout-side">
@@ -35,17 +26,14 @@ const CESideMenu = () => {
           </Typography.Text>
         </CEModeProjectWrapperStyleWrapper>
 
-        <MenuList projectID={DEFAULT_PROJECT_ID} userRoles={userRoles} />
+        <MenuList projectID={DEFAULT_PROJECT_ID} />
       </div>
 
       <UserMenu
-        hasGlobalViewingPermission={hasGlobalViewingPermission}
         language={language}
         username={username}
         updateTheme={updateTheme}
-        isAdmin={isAdmin}
         theme={theme}
-        isCertainProjectManager={isCertainProjectManager}
       />
     </SideMenuStyleWrapper>
   );

--- a/packages/base/src/page/Nav/SideMenu/index.tsx
+++ b/packages/base/src/page/Nav/SideMenu/index.tsx
@@ -23,17 +23,8 @@ const SideMenu: React.FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  const {
-    username,
-    theme,
-    updateTheme,
-    isAdmin,
-    bindProjects,
-    userRoles,
-    isCertainProjectManager,
-    language,
-    hasGlobalViewingPermission
-  } = useCurrentUser();
+  const { username, theme, updateTheme, bindProjects, language } =
+    useCurrentUser();
 
   const { recentlyProjects, currentProjectID } = useRecentlyOpenedProjects();
 
@@ -148,17 +139,14 @@ const SideMenu: React.FC = () => {
           />
         </Spin>
 
-        <MenuList projectID={currentProjectID ?? ''} userRoles={userRoles} />
+        <MenuList projectID={currentProjectID ?? ''} />
       </div>
 
       <UserMenu
         username={username}
         updateTheme={updateTheme}
-        isAdmin={isAdmin}
         theme={theme}
         language={language}
-        isCertainProjectManager={isCertainProjectManager}
-        hasGlobalViewingPermission={hasGlobalViewingPermission}
       />
     </SideMenuStyleWrapper>
   );

--- a/packages/base/src/router/router.base.tsx
+++ b/packages/base/src/router/router.base.tsx
@@ -1,5 +1,5 @@
 import { PROJECT_ROUTER_PARAM } from '@actiontech/shared/lib/data/common';
-import { SystemRole } from '@actiontech/shared/lib/enum';
+import { PERMISSIONS } from '@actiontech/shared/lib/global';
 import { RouterConfigItem } from '@actiontech/shared/lib/types/common.type';
 import { lazy } from 'react';
 
@@ -62,13 +62,13 @@ export const BaseRouterConfig: RouterConfigItem[] = [
     path: 'user-center',
     key: 'userCenter',
     element: <UserCenter />,
-    role: [SystemRole.admin, SystemRole.globalViewing]
+    permission: PERMISSIONS.PAGES.BASE.USER_CENTER
   },
   {
     path: 'system',
     key: 'system',
     element: <System />,
-    role: [SystemRole.admin, SystemRole.globalViewing]
+    permission: PERMISSIONS.PAGES.BASE.SYSTEM_SETTING
   },
   {
     path: 'account',
@@ -79,11 +79,7 @@ export const BaseRouterConfig: RouterConfigItem[] = [
   {
     path: 'data-source-management',
     key: 'dataSourceManagement',
-    role: [
-      SystemRole.admin,
-      SystemRole.certainProjectManager,
-      SystemRole.globalViewing
-    ],
+    permission: PERMISSIONS.PAGES.BASE.DATA_SOURCE_MANAGEMENT,
     element: <DataSourceManagement />
   },
 
@@ -91,11 +87,7 @@ export const BaseRouterConfig: RouterConfigItem[] = [
   {
     path: 'global-data-source',
     key: 'globalDataSource',
-    role: [
-      SystemRole.admin,
-      SystemRole.certainProjectManager,
-      SystemRole.globalViewing
-    ],
+    permission: PERMISSIONS.PAGES.BASE.GLOBAL_DATA_SOURCE,
     children: [
       {
         path: 'batch-import',
@@ -112,7 +104,7 @@ export const BaseRouterConfig: RouterConfigItem[] = [
   {
     path: `sync-data-source`,
     key: 'syncDataSource',
-    role: [SystemRole.admin, SystemRole.globalViewing],
+    permission: PERMISSIONS.PAGES.BASE.SYNC_DATA_SOURCE,
     children: [
       {
         path: 'create',

--- a/packages/shared/lib/enum/index.ts
+++ b/packages/shared/lib/enum/index.ts
@@ -22,11 +22,20 @@ export enum SupportTheme {
 export enum SystemRole {
   admin = 'admin',
   certainProjectManager = 'certainProjectManager',
-  globalViewing = 'globalViewing'
+  globalViewing = 'globalViewing',
+  globalManager = 'globalManager'
 }
 
 export type UserRolesType = {
   [key in SystemRole]: boolean;
+};
+
+export enum SystemModuleSupported {
+  sqlOptimization = 'sqlOptimization'
+}
+
+export type ModuleFeatureSupportStatus = {
+  [key in SystemModuleSupported]: boolean;
 };
 
 export enum ModalSize {

--- a/packages/shared/lib/global/index.ts
+++ b/packages/shared/lib/global/index.ts
@@ -6,3 +6,4 @@ export { default as useFeaturePermission } from './useFeaturePermission';
 export { default as useCurrentPermission } from './useCurrentPermission';
 export { default as useProjectBusinessTips } from './useProjectBusinessTips';
 export { default as useUserOperationPermission } from './useUserOperationPermission';
+export * from './usePermission';

--- a/packages/shared/lib/global/useCurrentPermission/index.tsx
+++ b/packages/shared/lib/global/useCurrentPermission/index.tsx
@@ -1,14 +1,20 @@
 import { useSelector } from 'react-redux';
 import { IReduxState } from '../../../../base/src/store';
-import { PermissionReduxState } from '../../types/common.type';
+import { ModuleFeatureSupportStatus } from '../../enum';
 
-const useCurrentPermission = (): PermissionReduxState => {
+const useCurrentPermission = () => {
+  // todo 重构完成后删除冗余的导出以及调整 hooks 名称
   const { sqlOptimizationIsSupported } = useSelector((state: IReduxState) => ({
     sqlOptimizationIsSupported: state.permission.sqlOptimizationIsSupported
   }));
 
+  const moduleSupportedStatus: ModuleFeatureSupportStatus = {
+    sqlOptimization: true
+  };
+
   return {
-    sqlOptimizationIsSupported
+    sqlOptimizationIsSupported,
+    moduleSupportedStatus
   };
 };
 

--- a/packages/shared/lib/global/useCurrentUser/index.ts
+++ b/packages/shared/lib/global/useCurrentUser/index.ts
@@ -37,6 +37,7 @@ const useCurrentUser = () => {
     };
   });
 
+  // todo 暂时保留 全局管理员 == admin 的逻辑，等权限全部重构完成后，移除该逻辑
   const isAdmin =
     role === SystemRole.admin ||
     managementPermissions.some(
@@ -77,9 +78,17 @@ const useCurrentUser = () => {
     return {
       [SystemRole.admin]: isAdmin,
       [SystemRole.certainProjectManager]: isCertainProjectManager,
-      [SystemRole.globalViewing]: hasGlobalViewingPermission
+      [SystemRole.globalViewing]: hasGlobalViewingPermission,
+      [SystemRole.globalManager]: managementPermissions.some(
+        (v) => v.uid === OpPermissionTypeUid.global_management
+      )
     };
-  }, [hasGlobalViewingPermission, isAdmin, isCertainProjectManager]);
+  }, [
+    hasGlobalViewingPermission,
+    isAdmin,
+    isCertainProjectManager,
+    managementPermissions
+  ]);
 
   return {
     isAdmin,

--- a/packages/shared/lib/global/usePermission/index.ts
+++ b/packages/shared/lib/global/usePermission/index.ts
@@ -1,0 +1,3 @@
+export * from './permissions';
+export * from './usePermission';
+export * from './permissionManifest';

--- a/packages/shared/lib/global/usePermission/permissionManifest.ts
+++ b/packages/shared/lib/global/usePermission/permissionManifest.ts
@@ -1,0 +1,72 @@
+import { SystemModuleSupported, SystemRole } from '../../enum';
+import { PERMISSIONS, PermissionsConstantType } from './permissions';
+
+type PermissionDetail = {
+  id: PermissionsConstantType;
+  name?: string;
+  description?: string;
+  type: 'page' | 'action';
+  role?: readonly SystemRole[];
+  featureSupport?: readonly SystemModuleSupported[];
+};
+
+export const PERMISSION_MANIFEST: Record<
+  PermissionsConstantType,
+  PermissionDetail
+> = {
+  [PERMISSIONS.PAGES.BASE.USER_CENTER]: {
+    id: PERMISSIONS.PAGES.BASE.USER_CENTER,
+    type: 'page',
+    role: [SystemRole.admin, SystemRole.globalManager, SystemRole.globalViewing]
+  },
+  [PERMISSIONS.PAGES.BASE.DATA_SOURCE_MANAGEMENT]: {
+    id: PERMISSIONS.PAGES.BASE.DATA_SOURCE_MANAGEMENT,
+    type: 'page',
+    role: [
+      SystemRole.admin,
+      SystemRole.globalManager,
+      SystemRole.globalViewing,
+      SystemRole.certainProjectManager
+    ]
+  },
+  [PERMISSIONS.PAGES.BASE.GLOBAL_DATA_SOURCE]: {
+    id: PERMISSIONS.PAGES.BASE.GLOBAL_DATA_SOURCE,
+    type: 'page',
+    role: [
+      SystemRole.admin,
+      SystemRole.globalManager,
+      SystemRole.globalViewing,
+      SystemRole.certainProjectManager
+    ]
+  },
+  [PERMISSIONS.PAGES.BASE.SYNC_DATA_SOURCE]: {
+    id: PERMISSIONS.PAGES.BASE.SYNC_DATA_SOURCE,
+    type: 'page',
+    role: [SystemRole.admin, SystemRole.globalManager, SystemRole.globalViewing]
+  },
+  [PERMISSIONS.PAGES.SQLE.REPORT_STATISTICS]: {
+    id: PERMISSIONS.PAGES.SQLE.REPORT_STATISTICS,
+    type: 'page',
+    role: [SystemRole.admin, SystemRole.globalManager, SystemRole.globalViewing]
+  },
+  [PERMISSIONS.PAGES.SQLE.RULE_MANAGEMENT]: {
+    id: PERMISSIONS.PAGES.SQLE.RULE_MANAGEMENT,
+    type: 'page',
+    role: [SystemRole.admin, SystemRole.globalManager, SystemRole.globalViewing]
+  },
+  [PERMISSIONS.PAGES.BASE.SYSTEM_SETTING]: {
+    id: PERMISSIONS.PAGES.BASE.SYSTEM_SETTING,
+    type: 'page',
+    role: [SystemRole.admin, SystemRole.globalManager, SystemRole.globalViewing]
+  },
+  [PERMISSIONS.PAGES.SQLE.OPERATION_RECORD]: {
+    id: PERMISSIONS.PAGES.SQLE.OPERATION_RECORD,
+    type: 'page',
+    role: [SystemRole.admin, SystemRole.globalManager, SystemRole.globalViewing]
+  },
+  [PERMISSIONS.PAGES.SQLE.SQL_OPTIMIZATION]: {
+    id: PERMISSIONS.PAGES.SQLE.SQL_OPTIMIZATION,
+    type: 'page',
+    featureSupport: [SystemModuleSupported.sqlOptimization]
+  }
+} as const;

--- a/packages/shared/lib/global/usePermission/permissions.ts
+++ b/packages/shared/lib/global/usePermission/permissions.ts
@@ -1,0 +1,31 @@
+export const PERMISSIONS = {
+  PAGES: {
+    BASE: {
+      USER_CENTER: 'page:user_center',
+      DATA_SOURCE_MANAGEMENT: 'page:data_source_management',
+      GLOBAL_DATA_SOURCE: 'page:global_data_source',
+      SYNC_DATA_SOURCE: 'page:sync_data_source',
+      SYSTEM_SETTING: 'page:system_setting'
+    },
+    SQLE: {
+      OPERATION_RECORD: 'page:operation_record',
+      SQL_OPTIMIZATION: 'page:sql_optimization',
+      REPORT_STATISTICS: 'page:report_statistics',
+      RULE_MANAGEMENT: 'page:rule_management'
+    }
+  }
+  // ACTIONS: {
+  //   CREATE_WORK_ORDER: 'action:create_work_order',
+  //   EDIT_USER: 'action:edit_user'
+  // }
+} as const;
+
+type ValueOf<T> = T[keyof T];
+
+type PermissionValueType<T> = T extends string
+  ? T
+  : T extends object
+  ? PermissionValueType<ValueOf<T>>
+  : never;
+
+export type PermissionsConstantType = PermissionValueType<typeof PERMISSIONS>;

--- a/packages/shared/lib/global/usePermission/usePermission.ts
+++ b/packages/shared/lib/global/usePermission/usePermission.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import useCurrentUser from '../useCurrentUser';
+import { PERMISSION_MANIFEST } from './permissionManifest';
+import { PermissionsConstantType } from './permissions';
+import useCurrentPermission from '../useCurrentPermission';
+
+const usePermission = () => {
+  const { userRoles } = useCurrentUser();
+  const { moduleSupportedStatus } = useCurrentPermission();
+
+  const checkPagePermission = useCallback(
+    (requiredPermission: PermissionsConstantType): boolean => {
+      const manifest = PERMISSION_MANIFEST[requiredPermission];
+      return (
+        !!manifest.role?.some((role) => userRoles[role]) ||
+        !!manifest.featureSupport?.some(
+          (module) => moduleSupportedStatus[module]
+        )
+      );
+    },
+    [moduleSupportedStatus, userRoles]
+  );
+
+  return {
+    checkPagePermission
+  };
+};
+
+export default usePermission;

--- a/packages/shared/lib/types/common.type.ts
+++ b/packages/shared/lib/types/common.type.ts
@@ -2,6 +2,7 @@ import { RuleObject } from 'antd/es/form';
 import { ReactNode } from 'react';
 import { RouteObject } from 'react-router-dom';
 import { SystemRole } from '../enum';
+import { PermissionsConstantType } from '../global';
 
 export type Dictionary = {
   [key: string]: string | number | boolean | Dictionary | string[] | undefined;
@@ -39,8 +40,7 @@ export type RouterConfigItem = RouteObject & {
   hideInMenu?: boolean;
   key: string;
   children?: RouterConfigItem[];
-  role?: Array<SystemRole>;
-  permission?: Array<keyof PermissionReduxState>;
+  permission?: PermissionsConstantType;
 };
 
 export enum RuleUrlParamKey {

--- a/packages/sqle/src/router/config.tsx
+++ b/packages/sqle/src/router/config.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { SystemRole } from '../data/common';
 import { PROJECT_ROUTER_PARAM } from '@actiontech/shared/lib/data/common';
 import { RouterConfigItem } from '@actiontech/shared/lib/types/common.type';
+import { PERMISSIONS } from '@actiontech/shared/lib/global';
 
 const Home = React.lazy(
   () => import(/* webpackChunkName: "Home" */ '../page/Home')
@@ -379,7 +379,7 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
     path: `${PROJECT_ROUTER_PARAM}/operation-record`,
     key: 'operationRecord',
     element: <OperationRecord />,
-    role: [SystemRole.admin, SystemRole.globalViewing]
+    permission: PERMISSIONS.PAGES.SQLE.OPERATION_RECORD
   },
   {
     path: `${PROJECT_ROUTER_PARAM}/plugin-audit`,
@@ -397,7 +397,7 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
     key: 'sqlOptimization',
     element: <SqlOptimization />,
     // #if [ee]
-    permission: ['sqlOptimizationIsSupported'],
+    permission: PERMISSIONS.PAGES.SQLE.SQL_OPTIMIZATION,
     children: [
       {
         index: true,
@@ -461,7 +461,7 @@ export const globalRouterConfig: RouterConfigItem[] = [
     label: 'menu.reportStatistics',
     element: <ReportStatistics />,
     key: 'reportStatistics',
-    role: [SystemRole.admin, SystemRole.globalViewing]
+    permission: PERMISSIONS.PAGES.SQLE.REPORT_STATISTICS
   },
   {
     path: 'sqle/rule',
@@ -472,7 +472,7 @@ export const globalRouterConfig: RouterConfigItem[] = [
   {
     key: 'ruleManager',
     path: 'sqle/rule-manager',
-    role: [SystemRole.admin, SystemRole.globalViewing],
+    permission: PERMISSIONS.PAGES.SQLE.RULE_MANAGEMENT,
     children: [
       {
         index: true,


### PR DESCRIPTION
1.  创建权限集合
2. 创建权限清单集合
3. 创建 usePermission, 实现处理页面级别相关权限的函数
4. 重构所有页面级别相关的权限，包括左侧菜单入口、全局设置相关菜单入口、路由

暂时先跳过 ci 检查，后续会新开 pr 处理 checker 错误以及单元测试