### PR TITLE
Feature/sqle issue 2660

### DIFF
--- a/packages/base/src/App.test.tsx
+++ b/packages/base/src/App.test.tsx
@@ -138,8 +138,8 @@ describe('App', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('render App when "useInfoFetched" is equal false', () => {
-    mockUseCurrentUser({ useInfoFetched: false });
+  it('render App when "userInfoFetched" is equal false', () => {
+    mockUseCurrentUser({ userInfoFetched: false });
     const { container } = superRender(<App />);
     expect(container).toMatchSnapshot();
   });

--- a/packages/base/src/App.tsx
+++ b/packages/base/src/App.tsx
@@ -80,7 +80,7 @@ function App() {
   const { getUserBySession } = useSessionUser();
 
   const {
-    useInfoFetched,
+    userInfoFetched,
     theme,
     userRoles,
     language: currentLanguage
@@ -157,7 +157,7 @@ function App() {
   }, [theme]);
 
   const body = useMemo(() => {
-    if (!useInfoFetched || !driverInfoFetched || !featurePermissionFetched) {
+    if (!userInfoFetched || !driverInfoFetched || !featurePermissionFetched) {
       return <HeaderProgress />;
     }
 
@@ -166,7 +166,7 @@ function App() {
         <Suspense fallback={<HeaderProgress />}>{elements}</Suspense>
       </Nav>
     );
-  }, [useInfoFetched, driverInfoFetched, featurePermissionFetched, elements]);
+  }, [userInfoFetched, driverInfoFetched, featurePermissionFetched, elements]);
 
   useEffect(() => {
     if (token) {

--- a/packages/base/src/__snapshots__/App.test.tsx.snap
+++ b/packages/base/src/__snapshots__/App.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`App render App when "driverInfoFetched" is equal false 1`] = `<div />`;
 
-exports[`App render App when "useInfoFetched" is equal false 1`] = `<div />`;
+exports[`App render App when "userInfoFetched" is equal false 1`] = `<div />`;
 
 exports[`App render App when token is existed 1`] = `
 <div>

--- a/packages/base/src/locale/index.ts
+++ b/packages/base/src/locale/index.ts
@@ -11,6 +11,7 @@ import { TOptions } from 'i18next';
 import { LocalStorageWrapper } from '@actiontech/shared';
 import { TemplateKeyPath } from '@actiontech/shared/lib/types/common.type';
 import { findDuplicateKeys } from '../utils/findDuplicateKeys';
+import { DEFAULT_LANGUAGE } from '@actiontech/shared/lib/locale';
 
 // #if [DEV]
 const zh_dupKeys = findDuplicateKeys([
@@ -62,7 +63,7 @@ const initReactI18n = () => {
     },
     lng: LocalStorageWrapper.getOrDefault(
       StorageKey.Language,
-      SupportLanguage.zhCN
+      DEFAULT_LANGUAGE
     ),
     fallbackLng: SupportLanguage.zhCN,
     interpolation: {

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/components/UserNavigate.tsx
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/components/UserNavigate.tsx
@@ -70,7 +70,7 @@ const UserNavigate: React.FC<Props> = ({
         }
       }).then((res) => {
         if (res.data.code === ResponseCode.SUCCESS) {
-          dispatch(updateReduxLanguage({ language }));
+          dispatch(updateReduxLanguage({ language, store: true }));
           window.location.reload();
         }
       }),

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/components/__tests__/UserNavigate.test.tsx
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/components/__tests__/UserNavigate.test.tsx
@@ -150,7 +150,7 @@ describe('base/page/Nav/SideMenu/UserNavigate-ee', () => {
     await act(async () => jest.advanceTimersByTime(3000));
     expect(scopeDispatch).toHaveBeenCalledTimes(1);
     expect(scopeDispatch).toHaveBeenCalledWith({
-      payload: { language: SupportLanguage.enUS },
+      payload: { language: SupportLanguage.enUS, store: true },
       type: 'user/updateLanguage'
     });
     expect(window.location.reload).toHaveBeenCalledTimes(1);

--- a/packages/base/src/store/user/index.test.ts
+++ b/packages/base/src/store/user/index.test.ts
@@ -29,7 +29,7 @@ describe('store user', () => {
     bindProjects: [],
     managementPermissions: [],
     role: '',
-    useInfoFetched: false,
+    userInfoFetched: false,
     language: SupportLanguage.zhCN
   };
 
@@ -50,7 +50,7 @@ describe('store user', () => {
       bindProjects: [],
       managementPermissions: [],
       role: '',
-      useInfoFetched: false
+      userInfoFetched: false
     });
   });
 
@@ -71,7 +71,7 @@ describe('store user', () => {
       bindProjects: [],
       managementPermissions: [],
       role: '',
-      useInfoFetched: false
+      userInfoFetched: false
     });
   });
 
@@ -79,7 +79,8 @@ describe('store user', () => {
     const newState = reducers(
       state,
       updateLanguage({
-        language: SupportLanguage.enUS
+        language: SupportLanguage.enUS,
+        store: true
       })
     );
     expect(newState).not.toBe(state);
@@ -92,7 +93,7 @@ describe('store user', () => {
       bindProjects: [],
       managementPermissions: [],
       role: '',
-      useInfoFetched: false
+      userInfoFetched: false
     });
   });
 
@@ -114,7 +115,7 @@ describe('store user', () => {
       bindProjects: [],
       managementPermissions: [],
       role: SystemRole.admin,
-      useInfoFetched: false
+      userInfoFetched: false
     });
   });
 
@@ -135,11 +136,11 @@ describe('store user', () => {
       bindProjects: [],
       managementPermissions: [],
       role: '',
-      useInfoFetched: false
+      userInfoFetched: false
     });
   });
 
-  it('should update user useInfoFetched when dispatch updateUserInfoFetchStatus action', () => {
+  it('should update user userInfoFetched when dispatch updateUserInfoFetchStatus action', () => {
     const newState = reducers(state, updateUserInfoFetchStatus(true));
     expect(newState).not.toBe(state);
     expect(newState).toEqual({
@@ -151,7 +152,7 @@ describe('store user', () => {
       bindProjects: [],
       managementPermissions: [],
       role: '',
-      useInfoFetched: true
+      userInfoFetched: true
     });
   });
 
@@ -180,7 +181,7 @@ describe('store user', () => {
       bindProjects: mockBindProjects,
       managementPermissions: [],
       role: '',
-      useInfoFetched: false
+      userInfoFetched: false
     });
   });
 
@@ -202,7 +203,7 @@ describe('store user', () => {
       bindProjects: [],
       managementPermissions: mockManagementPermissions,
       role: '',
-      useInfoFetched: false
+      userInfoFetched: false
     });
   });
 });

--- a/packages/base/src/store/user/index.ts
+++ b/packages/base/src/store/user/index.ts
@@ -10,6 +10,7 @@ import {
   IUidWithName,
   IUserBindProject
 } from '@actiontech/shared/lib/api/base/service/common';
+import { DEFAULT_LANGUAGE } from '@actiontech/shared/lib/locale';
 
 export type IBindProject = { archived?: boolean } & IUserBindProject;
 
@@ -21,7 +22,7 @@ type UserReduxState = {
   bindProjects: Array<IBindProject>;
   managementPermissions: IUidWithName[];
   uid: string;
-  useInfoFetched: boolean;
+  userInfoFetched: boolean;
   language: SupportLanguage;
 };
 
@@ -36,10 +37,10 @@ const initialState: UserReduxState = {
   bindProjects: [],
   managementPermissions: [],
   uid: LocalStorageWrapper.getOrDefault(StorageKey.USER_UID, ''),
-  useInfoFetched: false,
+  userInfoFetched: false,
   language: LocalStorageWrapper.getOrDefault(
     StorageKey.Language,
-    SupportLanguage.zhCN
+    DEFAULT_LANGUAGE
   ) as SupportLanguage
 };
 
@@ -65,10 +66,14 @@ const user = createSlice({
     },
     updateLanguage: (
       state,
-      { payload: { language } }: PayloadAction<{ language: SupportLanguage }>
+      {
+        payload: { language, store }
+      }: PayloadAction<{ language: SupportLanguage; store: boolean }>
     ) => {
       state.language = language;
-      LocalStorageWrapper.set(StorageKey.Language, language);
+      if (store) {
+        LocalStorageWrapper.set(StorageKey.Language, language);
+      }
     },
     updateToken: (
       state,
@@ -101,7 +106,7 @@ const user = createSlice({
       LocalStorageWrapper.set(StorageKey.USER_UID, uid);
     },
     updateUserInfoFetchStatus: (state, { payload }: PayloadAction<boolean>) => {
-      state.useInfoFetched = payload;
+      state.userInfoFetched = payload;
     }
   }
 });

--- a/packages/shared/lib/global/useCurrentUser/index.test.ts
+++ b/packages/shared/lib/global/useCurrentUser/index.test.ts
@@ -140,7 +140,7 @@ describe('hooks/useCurrentUser', () => {
     result.current.updateLanguage(SupportLanguage.zhCN);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     expect(dispatchSpy).toHaveBeenCalledWith({
-      payload: { language: SupportLanguage.zhCN },
+      payload: { language: SupportLanguage.zhCN, store: true },
       type: 'user/updateLanguage'
     });
   });

--- a/packages/shared/lib/global/useCurrentUser/index.ts
+++ b/packages/shared/lib/global/useCurrentUser/index.ts
@@ -21,7 +21,7 @@ const useCurrentUser = () => {
     managementPermissions,
     username,
     theme,
-    useInfoFetched,
+    userInfoFetched,
     uid,
     language
   } = useSelector((state: IReduxState) => {
@@ -31,7 +31,7 @@ const useCurrentUser = () => {
       bindProjects: state.user.bindProjects,
       managementPermissions: state.user.managementPermissions,
       theme: state.user.theme,
-      useInfoFetched: state.user.useInfoFetched,
+      userInfoFetched: state.user.userInfoFetched,
       uid: state.user.uid,
       language: state.user.language
     };
@@ -58,7 +58,9 @@ const useCurrentUser = () => {
   );
   const updateLanguage = useCallback(
     (selectedLanguage: SupportLanguage) => {
-      dispatch(updateReduxLanguage({ language: selectedLanguage }));
+      dispatch(
+        updateReduxLanguage({ language: selectedLanguage, store: true })
+      );
     },
     [dispatch]
   );
@@ -90,7 +92,7 @@ const useCurrentUser = () => {
     role,
     theme,
     updateTheme,
-    useInfoFetched,
+    userInfoFetched,
     uid,
     isCertainProjectManager,
     userRoles,

--- a/packages/shared/lib/global/useUserInfo/index.test.ts
+++ b/packages/shared/lib/global/useUserInfo/index.test.ts
@@ -63,7 +63,7 @@ describe('useUserInfo', () => {
     });
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      payload: { language: GetUserPayload.language },
+      payload: { language: GetUserPayload.language, store: true },
       type: 'user/updateLanguage'
     });
 

--- a/packages/shared/lib/global/useUserInfo/index.ts
+++ b/packages/shared/lib/global/useUserInfo/index.ts
@@ -15,6 +15,7 @@ import {
 import { ResponseCode, SupportLanguage, SystemRole } from '../../enum';
 import User from '../../api/base/service/User';
 import { DMS_REDIRECT_KEY_PARAMS_NAME } from '../../data/common';
+import { DEFAULT_LANGUAGE } from '../../locale';
 
 const useUserInfo = () => {
   const dispatch = useDispatch();
@@ -65,6 +66,14 @@ const useUserInfo = () => {
       onSuccess: (res) => {
         if (res.data.code === ResponseCode.SUCCESS) {
           const { data } = res.data;
+          let language = DEFAULT_LANGUAGE;
+          if (
+            data?.language === SupportLanguage.enUS ||
+            data?.language === SupportLanguage.zhCN
+          ) {
+            language = data.language;
+          }
+
           dispatch(
             updateUser({
               username: data?.name ?? '',
@@ -73,10 +82,8 @@ const useUserInfo = () => {
           );
           dispatch(
             updateLanguage({
-              language:
-                data?.language === SupportLanguage.enUS
-                  ? SupportLanguage.enUS
-                  : SupportLanguage.zhCN
+              language,
+              store: !!data?.language
             })
           );
 

--- a/packages/shared/lib/locale/index.ts
+++ b/packages/shared/lib/locale/index.ts
@@ -1,4 +1,16 @@
+import { SupportLanguage } from '../enum';
 import { TemplateKeyPath } from '../types/common.type';
 import commonZhCN from './zh-CN';
+
+const getPreferredLanguage = () => {
+  if (navigator.languages && navigator.languages.length) {
+    return Array.from(navigator.languages);
+  }
+  return [navigator.language];
+};
+
+export const DEFAULT_LANGUAGE = getPreferredLanguage()[0].startsWith('en')
+  ? SupportLanguage.enUS
+  : SupportLanguage.zhCN;
 
 export type I18nKey = TemplateKeyPath<typeof commonZhCN.translation>;

--- a/packages/shared/lib/testUtil/mockHook/data.tsx
+++ b/packages/shared/lib/testUtil/mockHook/data.tsx
@@ -39,7 +39,7 @@ export const mockCurrentUserReturn = {
   updateLanguage: jest.fn(),
   role: SystemRole.admin,
   updateTheme: jest.fn(),
-  useInfoFetched: true,
+  userInfoFetched: true,
   uid: '500300',
   isCertainProjectManager: true,
   userRoles: {

--- a/packages/sqle/src/locale/index.ts
+++ b/packages/sqle/src/locale/index.ts
@@ -12,6 +12,7 @@ import {
   TemplateKeyPath
 } from '@actiontech/shared/lib/types/common.type';
 import { findDuplicateKeys } from '../../../base/src/utils/findDuplicateKeys';
+import { DEFAULT_LANGUAGE } from '@actiontech/shared/lib/locale';
 
 // #if [DEV]
 const zh_dupKeys = findDuplicateKeys([
@@ -53,7 +54,7 @@ export const initReactI18n = () => {
     },
     lng: LocalStorageWrapper.getOrDefault(
       StorageKey.Language,
-      SupportLanguage.zhCN
+      DEFAULT_LANGUAGE
     ),
     fallbackLng: SupportLanguage.zhCN,
     interpolation: {

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangePriority/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangePriority/__snapshots__/index.test.tsx.snap
@@ -81,10 +81,11 @@ exports[`page/SqlManagement/ChangePriority change priority and submit data 1`] =
                             >
                               <div
                                 class="ant-space-item"
-                                style="margin-bottom: 8px;"
+                                style="margin-bottom: 0px;"
                               >
                                 <label
                                   class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-in-form-item css-dev-only-do-not-override-txh9fw"
+                                  style="line-height: 32px;"
                                 >
                                   <span
                                     class="ant-radio ant-radio-checked"
@@ -108,6 +109,7 @@ exports[`page/SqlManagement/ChangePriority change priority and submit data 1`] =
                               >
                                 <label
                                   class="ant-radio-wrapper ant-radio-wrapper-in-form-item css-dev-only-do-not-override-txh9fw"
+                                  style="line-height: 32px;"
                                 >
                                   <span
                                     class="ant-radio"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangePriority/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangePriority/index.tsx
@@ -120,13 +120,31 @@ const ChangePriority: React.FC = () => {
             rules={[{ required: true }]}
           >
             <Radio.Group>
-              <Space direction="vertical">
-                <Radio value={SqlManagePriority.high}>
-                  {t('sqlManagement.table.action.single.updatePriority.high')}
-                </Radio>
-                <Radio value={SqlManagePriority.low}>
-                  {t('sqlManagement.table.action.single.updatePriority.low')}
-                </Radio>
+              <Space direction="vertical" size={0}>
+                {[
+                  {
+                    label: t(
+                      'sqlManagement.table.action.single.updatePriority.high'
+                    ),
+                    value: SqlManagePriority.high
+                  },
+                  {
+                    label: t(
+                      'sqlManagement.table.action.single.updatePriority.low'
+                    ),
+                    value: SqlManagePriority.low
+                  }
+                ].map((item) => {
+                  return (
+                    <Radio
+                      key={item.value}
+                      style={{ lineHeight: '32px' }}
+                      value={item.value}
+                    >
+                      {item.label}
+                    </Radio>
+                  );
+                })}
               </Space>
             </Radio.Group>
           </FormItemLabelStyleWrapper>

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangeStatus/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangeStatus/__snapshots__/index.test.tsx.snap
@@ -81,10 +81,11 @@ exports[`page/SqlManagement/ChangeStatus change status and submit data 1`] = `
                             >
                               <div
                                 class="ant-space-item"
-                                style="margin-bottom: 8px;"
+                                style="margin-bottom: 0px;"
                               >
                                 <label
                                   class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-in-form-item css-dev-only-do-not-override-txh9fw"
+                                  style="line-height: 32px;"
                                 >
                                   <span
                                     class="ant-radio ant-radio-checked"
@@ -106,10 +107,11 @@ exports[`page/SqlManagement/ChangeStatus change status and submit data 1`] = `
                               </div>
                               <div
                                 class="ant-space-item"
-                                style="margin-bottom: 8px;"
+                                style="margin-bottom: 0px;"
                               >
                                 <label
                                   class="ant-radio-wrapper ant-radio-wrapper-in-form-item css-dev-only-do-not-override-txh9fw"
+                                  style="line-height: 32px;"
                                 >
                                   <span
                                     class="ant-radio"
@@ -133,6 +135,7 @@ exports[`page/SqlManagement/ChangeStatus change status and submit data 1`] = `
                               >
                                 <label
                                   class="ant-radio-wrapper ant-radio-wrapper-in-form-item css-dev-only-do-not-override-txh9fw"
+                                  style="line-height: 32px;"
                                 >
                                   <span
                                     class="ant-radio"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangeStatus/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/ChangeStatus/index.tsx
@@ -103,18 +103,37 @@ const ChangeStatus = () => {
             initialValue={BatchUpdateSqlManageReqStatusEnum.solved}
           >
             <Radio.Group>
-              <Space direction="vertical">
-                <Radio value={BatchUpdateSqlManageReqStatusEnum.solved}>
-                  {t('sqlManagement.table.action.single.updateStatus.solve')}
-                </Radio>
-                <Radio value={BatchUpdateSqlManageReqStatusEnum.ignored}>
-                  {t('sqlManagement.table.action.single.updateStatus.ignore')}
-                </Radio>
-                <Radio value={BatchUpdateSqlManageReqStatusEnum.manual_audited}>
-                  {t(
-                    'sqlManagement.table.action.single.updateStatus.manualAudit'
-                  )}
-                </Radio>
+              <Space direction="vertical" size={0}>
+                {[
+                  {
+                    label: t(
+                      'sqlManagement.table.action.single.updateStatus.solve'
+                    ),
+                    value: BatchUpdateSqlManageReqStatusEnum.solved
+                  },
+                  {
+                    label: t(
+                      'sqlManagement.table.action.single.updateStatus.ignore'
+                    ),
+                    value: BatchUpdateSqlManageReqStatusEnum.ignored
+                  },
+                  {
+                    label: t(
+                      'sqlManagement.table.action.single.updateStatus.manualAudit'
+                    ),
+                    value: BatchUpdateSqlManageReqStatusEnum.manual_audited
+                  }
+                ].map((item) => {
+                  return (
+                    <Radio
+                      key={item.value}
+                      style={{ lineHeight: '32px' }}
+                      value={item.value}
+                    >
+                      {item.label}
+                    </Radio>
+                  );
+                })}
               </Space>
             </Radio.Group>
           </FormItemLabelStyleWrapper>


### PR DESCRIPTION
fix issue: https://github.com/actiontech/sqle/issues/2660

当用户未设置语言默认读取浏览器的语言偏好时不会将 lang 存储在 local storage 中。

主要为了解决 部分被 useMemo 缓存的数据在切换浏览器语言偏好并且刷新页面后数据未更新的问题

原因：
切换浏览器语言后下次刷新页面后会先读取 local storage 中缓存的数据进行 change language。然后在用户信息获取结束后（未获取到用户的语言偏好）使用浏览器语言偏好再次进行更新。而此时由于缓存，部分数据不会更新语言包。

为什么没有在用户信息获取结束后在进行语言切换：
由于 组件的 render 时机也是在用户信息获取结束后，在不额外添加 state 的情况下，没法保证 change language 与 组件 render 的执行顺序。