### PR TITLE
the description of language options should be in the corresponding la…

### DIFF
--- a/packages/base/src/locale/en-US/dmsMenu.ts
+++ b/packages/base/src/locale/en-US/dmsMenu.ts
@@ -53,7 +53,7 @@ export default {
     notice: 'Notice',
     language: {
       text: 'Language',
-      zhCN: 'Chinese',
+      zhCN: '中文',
       enUS: 'English'
     }
   },

--- a/packages/base/src/locale/zh-CN/dmsMenu.ts
+++ b/packages/base/src/locale/zh-CN/dmsMenu.ts
@@ -54,7 +54,7 @@ export default {
     language: {
       text: '语言',
       zhCN: '中文',
-      enUS: '英文'
+      enUS: 'English'
     }
   },
 

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/components/__tests__/UserNavigate.test.tsx
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/components/__tests__/UserNavigate.test.tsx
@@ -141,7 +141,7 @@ describe('base/page/Nav/SideMenu/UserNavigate-ee', () => {
 
     expect(requestUpdateCurrentUser).toHaveBeenCalledTimes(0);
 
-    fireEvent.click(screen.getByText('英文'));
+    fireEvent.click(screen.getByText('English'));
     expect(requestUpdateCurrentUser).toHaveBeenCalledTimes(1);
     expect(requestUpdateCurrentUser).toHaveBeenCalledWith({
       current_user: { language: SupportLanguage.enUS }

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/components/__tests__/__snapshots__/UserNavigate.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/components/__tests__/__snapshots__/UserNavigate.test.tsx.snap
@@ -528,7 +528,7 @@ exports[`base/page/Nav/SideMenu/UserNavigate-ee should update the user's languag
                                           />
                                         </span>
                                         <span>
-                                          英文
+                                          English
                                         </span>
                                       </label>
                                     </div>


### PR DESCRIPTION
https://github.com/actiontech/sqle/issues/2657
https://github.com/actiontech/sqle/issues/2626

修复问题：语言选项的描述应该是用对应的语言来描述

assign in @LZS911 