### PR TITLE
[feature](usePermission、DataSource): Refactor permissions for table operation column buttons  [skip ci]

### DIFF
--- a/packages/base/src/page/DataSource/components/List/columns.tsx
+++ b/packages/base/src/page/DataSource/components/List/columns.tsx
@@ -5,15 +5,15 @@ import {
   IAuditPlanTypes,
   IListDBService
 } from '@actiontech/shared/lib/api/base/service/common';
-import {
-  ActiontechTableActionMeta,
-  ActiontechTableColumn,
-  InlineActiontechTableMoreActionsButtonMeta
-} from '@actiontech/shared/lib/components/ActiontechTable';
+import { ActiontechTableColumn } from '@actiontech/shared/lib/components/ActiontechTable';
 import BasicTypographyEllipsis from '@actiontech/shared/lib/components/BasicTypographyEllipsis';
 import { IListDBServicesParams } from '@actiontech/shared/lib/api/base/service/DBService/index.d';
 import { DatabaseTypeLogo } from '@actiontech/shared';
 import ScanTypeTagsCell from 'sqle/src/page/SqlManagementConf/List/ScanTypeTagsCell';
+import {
+  ActiontechTableActionsWithConstantPermissions,
+  PERMISSIONS
+} from '@actiontech/shared/lib/global';
 
 /*
  *PS：
@@ -134,77 +134,71 @@ export const DataSourceListActions = (
     name: string,
     business: string,
     instanceAuditPlanId?: string
-  ) => void,
-  isArchive: boolean,
-  actionPermission: boolean
-): {
-  title?: ActiontechTableColumn<IListDBService>[0]['title'];
-  moreButtons?: InlineActiontechTableMoreActionsButtonMeta<IListDBService>[];
-  buttons: ActiontechTableActionMeta<IListDBService>[];
-} => {
-  return !isArchive && actionPermission
-    ? {
-        buttons: [
-          {
-            key: 'edit-DataSource',
-            text: t('common.edit'),
-            buttonProps: (record) => ({
-              onClick: onNavigateUpdateDataSource.bind(null, record?.uid ?? '')
-            })
-          },
-          {
-            key: 'remove-DataSource',
-            text: t('common.delete'),
-            buttonProps: () => ({ danger: true }),
-            confirm: (record) => ({
-              title: t('dmsDataSource.deleteDatabase.confirmMessage', {
-                name: record?.name
-              }),
-              onConfirm: onDeleteDataSource.bind(
-                null,
-                record?.uid ?? '',
-                record?.name ?? ''
-              )
-            })
-          }
-        ],
-        moreButtons: [
-          {
-            key: 'dataSource-test-connection',
-            text: t('common.testDatabaseConnectButton.testDatabaseConnection'),
-            onClick: (record) =>
-              onTestConnection(record?.uid ?? '', record?.name ?? '')
-          },
-          // #if [sqle]
-          {
-            key: 'enabled-audit-plan',
-            text: t('dmsDataSource.enabledAuditPlan.text'),
-            onClick: (record) => {
-              navigateToSqlManagementConf(
-                record?.uid ?? '',
-                record?.business ?? '',
-                record?.instance_audit_plan_id?.toString()
-              );
-            }
-          }
-          // #endif
-        ]
+  ) => void
+): ActiontechTableActionsWithConstantPermissions<IListDBService> => {
+  return {
+    buttons: [
+      {
+        key: 'edit-db-service',
+        text: t('common.edit'),
+        buttonProps: (record) => ({
+          onClick: onNavigateUpdateDataSource.bind(null, record?.uid ?? '')
+        }),
+        permissions: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.EDIT
+      },
+      {
+        key: 'delete-db-service',
+        text: t('common.delete'),
+        buttonProps: () => ({ danger: true }),
+        confirm: (record) => ({
+          title: t('dmsDataSource.deleteDatabase.confirmMessage', {
+            name: record?.name
+          }),
+          onConfirm: onDeleteDataSource.bind(
+            null,
+            record?.uid ?? '',
+            record?.name ?? ''
+          )
+        }),
+        permissions: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.DELETE
+      },
+      {
+        key: 'test-db-service-connection',
+        text: t('common.testDatabaseConnectButton.testDatabaseConnection'),
+        permissions: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.TEST,
+        buttonProps: (record) => ({
+          onClick: onTestConnection.bind(
+            null,
+            record?.uid ?? '',
+            record?.name ?? ''
+          )
+        })
       }
-    : {
-        buttons: [
-          {
-            key: 'dataSource-test-connection',
-            text: t('common.testDatabaseConnectButton.testDatabaseConnection'),
-            buttonProps: (record) => ({
-              onClick: onTestConnection.bind(
-                null,
-                record?.uid ?? '',
-                record?.name ?? ''
-              )
-            })
-          }
-        ]
-      };
+    ],
+    moreButtons: [
+      {
+        key: 'test-db-service-connection',
+        text: t('common.testDatabaseConnectButton.testDatabaseConnection'),
+        permissions: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.TEST_IN_MORE_BUTTON,
+        onClick: (record) =>
+          onTestConnection(record?.uid ?? '', record?.name ?? '')
+      },
+      // #if [ee]
+      {
+        key: 'create-audit-plan',
+        text: t('dmsDataSource.enabledAuditPlan.text'),
+        permissions: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.CREATE_AUDIT_PLAN,
+        onClick: (record) => {
+          navigateToSqlManagementConf(
+            record?.uid ?? '',
+            record?.business ?? '',
+            record?.instance_audit_plan_id?.toString()
+          );
+        }
+      }
+      // #endif
+    ]
+  };
 };
 
 export enum DataMaskingFilterTypeEnum {

--- a/packages/base/src/page/DataSource/components/List/index.tsx
+++ b/packages/base/src/page/DataSource/components/List/index.tsx
@@ -31,6 +31,7 @@ import {
   filterDataMaskOptions
 } from './columns';
 import { PlusOutlined } from '@actiontech/icons';
+import usePermission from '@actiontech/shared/lib/global/usePermission/usePermission';
 
 const DataSourceList = () => {
   const { t } = useTranslation();
@@ -39,7 +40,7 @@ const DataSourceList = () => {
   const [searchParams] = useSearchParams();
   const [modalApi, modalContextHolder] = Modal.useModal();
   const [messageApi, messageContextHolder] = message.useMessage();
-
+  const { parse2TableActionPermissions } = usePermission();
   const { projectID, projectArchive, projectName } = useCurrentProject();
   const { isAdmin, isProjectManager } = useCurrentUser();
 
@@ -241,21 +242,20 @@ const DataSourceList = () => {
   ]);
 
   const actions = useMemo(() => {
-    return DataSourceListActions(
-      navigateToUpdatePage,
-      deleteDatabase,
-      testDatabaseConnection,
-      navigateToSqlManagementConf,
-      projectArchive,
-      actionPermission
+    return parse2TableActionPermissions(
+      DataSourceListActions(
+        navigateToUpdatePage,
+        deleteDatabase,
+        testDatabaseConnection,
+        navigateToSqlManagementConf
+      )
     );
   }, [
+    parse2TableActionPermissions,
     navigateToUpdatePage,
     deleteDatabase,
     testDatabaseConnection,
-    navigateToSqlManagementConf,
-    projectArchive,
-    actionPermission
+    navigateToSqlManagementConf
   ]);
 
   useEffect(() => {

--- a/packages/shared/lib/components/ActiontechTable/index.type.ts
+++ b/packages/shared/lib/components/ActiontechTable/index.type.ts
@@ -324,6 +324,23 @@ export type InlineActiontechTableMoreActionsButtonMeta<
 >;
 
 /**
+ * 表格操作集合类型
+ */
+export type ActiontechTableActionsConfig<
+  T = Record<string, any>,
+  F = Record<string, any>,
+  OtherColumnKeys extends string = never
+> = {
+  title?: ActiontechTableColumn<T, F, OtherColumnKeys>[0]['title'];
+  moreButtons?:
+    | InlineActiontechTableMoreActionsButtonMeta<T>[]
+    | ((record: T) => InlineActiontechTableMoreActionsButtonMeta<T>[]);
+  buttons: ActiontechTableActionMeta<T>[];
+  fixed?: ActiontechTableColumn<T, F, OtherColumnKeys>[0]['fixed'];
+  width?: ActiontechTableColumn<T, F, OtherColumnKeys>[0]['width'];
+};
+
+/**
  * todo: 如何控制 筛选项的顺序
  * 表格 columns props, 当配置 filterCustomType 和 filterKey 启用该列的筛选功能, 通过 useTableFilterContainer 来生成 筛选项的元数据
  * 当需要添加表格列以外的筛选列时, 可以使用 useTableFilterContainer 的第三个参数: extraFilterMeta
@@ -356,22 +373,14 @@ export type ActiontechTableColumn<
 export interface ActiontechTableProps<
   T = Record<string, any>,
   F = Record<string, any>,
-  OtherColumnKeys extends string = ''
+  OtherColumnKeys extends string = never
 > extends Omit<TableProps<T>, 'columns'> {
   setting?: ColumnsSettingProps | false;
   /**
    * 生成表格操作列
    */
   actions?:
-    | {
-        title?: ActiontechTableColumn<T, F, OtherColumnKeys>[0]['title'];
-        moreButtons?:
-          | InlineActiontechTableMoreActionsButtonMeta<T>[]
-          | ((record: T) => InlineActiontechTableMoreActionsButtonMeta<T>[]);
-        buttons: ActiontechTableActionMeta<T>[];
-        fixed?: ActiontechTableColumn<T, F, OtherColumnKeys>[0]['fixed'];
-        width?: ActiontechTableColumn<T, F, OtherColumnKeys>[0]['width'];
-      }
+    | ActiontechTableActionsConfig<T, F, OtherColumnKeys>
     | ActiontechTableActionMeta<T>[];
 
   /**

--- a/packages/shared/lib/global/useCurrentPermission/index.tsx
+++ b/packages/shared/lib/global/useCurrentPermission/index.tsx
@@ -8,13 +8,13 @@ const useCurrentPermission = () => {
     sqlOptimizationIsSupported: state.permission.sqlOptimizationIsSupported
   }));
 
-  const moduleSupportedStatus: ModuleFeatureSupportStatus = {
-    sqlOptimization: true
+  const moduleSupportStatus: ModuleFeatureSupportStatus = {
+    sqlOptimization: sqlOptimizationIsSupported
   };
 
   return {
     sqlOptimizationIsSupported,
-    moduleSupportedStatus
+    moduleSupportStatus
   };
 };
 

--- a/packages/shared/lib/global/usePermission/index.ts
+++ b/packages/shared/lib/global/usePermission/index.ts
@@ -1,3 +1,4 @@
 export * from './permissions';
 export * from './usePermission';
 export * from './permissionManifest';
+export type * from './index.type';

--- a/packages/shared/lib/global/usePermission/index.type.ts
+++ b/packages/shared/lib/global/usePermission/index.type.ts
@@ -1,0 +1,38 @@
+import {
+  ActiontechTableActionMeta,
+  ActiontechTableActionsConfig
+} from '../../components/ActiontechTable/index.type';
+import { PermissionsConstantType } from './permissions';
+
+type ReplacePermissions<T> = Omit<T, 'permissions'> & {
+  permissions?: PermissionsConstantType;
+};
+
+type ReplaceButtonsPermissions<T> = T extends (...args: any[]) => any
+  ? (
+      ...args: Parameters<T>
+    ) => ReturnType<T> extends Array<infer K>
+      ? Array<ReplacePermissions<K>>
+      : ReturnType<T>
+  : T extends Array<infer K>
+  ? Array<ReplacePermissions<K>>
+  : T;
+
+// 根据 ActiontechTableActionsConfig 调整内部 permissions 的类型
+export type ActiontechTableActionsWithConstantPermissions<
+  T = Record<string, any>,
+  F = Record<string, any>,
+  OtherColumnKeys extends string = never
+> =
+  | {
+      [K in keyof ActiontechTableActionsConfig<
+        T,
+        F,
+        OtherColumnKeys
+      >]: K extends 'buttons' | 'moreButtons'
+        ? ReplaceButtonsPermissions<
+            ActiontechTableActionsConfig<T, F, OtherColumnKeys>[K]
+          >
+        : ActiontechTableActionsConfig<T, F, OtherColumnKeys>[K];
+    }
+  | ReplacePermissions<ActiontechTableActionMeta<T>>[];

--- a/packages/shared/lib/global/usePermission/permissionManifest.ts
+++ b/packages/shared/lib/global/usePermission/permissionManifest.ts
@@ -1,19 +1,25 @@
+import { OpPermissionItemOpPermissionTypeEnum } from '../../api/base/service/common.enum';
 import { SystemModuleSupported, SystemRole } from '../../enum';
 import { PERMISSIONS, PermissionsConstantType } from './permissions';
 
-type PermissionDetail = {
+export type PermissionDetail = {
   id: PermissionsConstantType;
-  name?: string;
-  description?: string;
   type: 'page' | 'action';
   role?: readonly SystemRole[];
-  featureSupport?: readonly SystemModuleSupported[];
+  moduleSupport?: readonly SystemModuleSupported[];
+  projectManager?: boolean;
+  projectArchived?: boolean;
+  dbServicePermission?: {
+    fieldName: string;
+    opType: OpPermissionItemOpPermissionTypeEnum;
+  };
 };
 
 export const PERMISSION_MANIFEST: Record<
   PermissionsConstantType,
   PermissionDetail
 > = {
+  //page
   [PERMISSIONS.PAGES.BASE.USER_CENTER]: {
     id: PERMISSIONS.PAGES.BASE.USER_CENTER,
     type: 'page',
@@ -67,6 +73,42 @@ export const PERMISSION_MANIFEST: Record<
   [PERMISSIONS.PAGES.SQLE.SQL_OPTIMIZATION]: {
     id: PERMISSIONS.PAGES.SQLE.SQL_OPTIMIZATION,
     type: 'page',
-    featureSupport: [SystemModuleSupported.sqlOptimization]
+    moduleSupport: [SystemModuleSupported.sqlOptimization]
+  },
+  // action
+  [PERMISSIONS.ACTIONS.BASE.DB_SERVICE.CREATE_AUDIT_PLAN]: {
+    id: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.CREATE_AUDIT_PLAN,
+    type: 'action',
+    role: [SystemRole.admin, SystemRole.globalManager],
+    projectManager: true,
+    projectArchived: false,
+    dbServicePermission: {
+      fieldName: 'uid',
+      opType: OpPermissionItemOpPermissionTypeEnum.save_audit_plan
+    }
+  },
+  [PERMISSIONS.ACTIONS.BASE.DB_SERVICE.EDIT]: {
+    id: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.EDIT,
+    type: 'action',
+    role: [SystemRole.admin, SystemRole.globalManager],
+    projectManager: true,
+    projectArchived: false
+  },
+  [PERMISSIONS.ACTIONS.BASE.DB_SERVICE.DELETE]: {
+    id: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.DELETE,
+    type: 'action',
+    role: [SystemRole.admin, SystemRole.globalManager],
+    projectManager: true,
+    projectArchived: false
+  },
+  [PERMISSIONS.ACTIONS.BASE.DB_SERVICE.TEST]: {
+    id: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.TEST,
+    type: 'action',
+    projectArchived: true
+  },
+  [PERMISSIONS.ACTIONS.BASE.DB_SERVICE.TEST_IN_MORE_BUTTON]: {
+    id: PERMISSIONS.ACTIONS.BASE.DB_SERVICE.TEST_IN_MORE_BUTTON,
+    type: 'action',
+    projectArchived: false
   }
 } as const;

--- a/packages/shared/lib/global/usePermission/permissions.ts
+++ b/packages/shared/lib/global/usePermission/permissions.ts
@@ -13,11 +13,18 @@ export const PERMISSIONS = {
       REPORT_STATISTICS: 'page:report_statistics',
       RULE_MANAGEMENT: 'page:rule_management'
     }
+  },
+  ACTIONS: {
+    BASE: {
+      DB_SERVICE: {
+        EDIT: 'action:edit_db_service',
+        DELETE: 'action:delete_db_service',
+        TEST: 'action:test_db_service',
+        TEST_IN_MORE_BUTTON: 'action:test_db_service_in_more_button',
+        CREATE_AUDIT_PLAN: 'action:db_service_create_audit_plan'
+      }
+    }
   }
-  // ACTIONS: {
-  //   CREATE_WORK_ORDER: 'action:create_work_order',
-  //   EDIT_USER: 'action:edit_user'
-  // }
 } as const;
 
 type ValueOf<T> = T[keyof T];

--- a/packages/shared/lib/global/usePermission/usePermission.ts
+++ b/packages/shared/lib/global/usePermission/usePermission.ts
@@ -1,28 +1,172 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import useCurrentUser from '../useCurrentUser';
-import { PERMISSION_MANIFEST } from './permissionManifest';
+import { PERMISSION_MANIFEST, PermissionDetail } from './permissionManifest';
 import { PermissionsConstantType } from './permissions';
 import useCurrentPermission from '../useCurrentPermission';
+import useCurrentProject from '../useCurrentProject';
+import { ActiontechTableActionsWithConstantPermissions } from './index.type';
+import { ActiontechTableProps } from '../../components/ActiontechTable';
+import { ActiontechTableActionsConfig } from '../../components/ActiontechTable/index.type';
+import useUserOperationPermission from '../useUserOperationPermission';
 
 const usePermission = () => {
-  const { userRoles } = useCurrentUser();
-  const { moduleSupportedStatus } = useCurrentPermission();
+  const { userRoles, bindProjects } = useCurrentUser();
+  const { moduleSupportStatus } = useCurrentPermission();
+  const { projectID } = useCurrentProject();
+  const { updateUserOperationPermission, isHaveServicePermission } =
+    useUserOperationPermission();
+
+  const projectAttributesStatus = useMemo(() => {
+    const isArchived = !!bindProjects.find(
+      (project) => project.project_id === projectID
+    )?.archived;
+
+    return {
+      isManager: !!bindProjects.find(
+        (project) => project.project_id === projectID
+      )?.is_manager,
+      isArchived
+    };
+  }, [bindProjects, projectID]);
+
+  const checkRoles = useCallback(
+    (permissionDetails: PermissionDetail) => {
+      if (!permissionDetails.role) {
+        return true;
+      }
+      return permissionDetails.role.some((role) => userRoles[role]);
+    },
+    [userRoles]
+  );
+
+  const checkModuleSupport = useCallback(
+    (permissionDetails: PermissionDetail) => {
+      if (!permissionDetails.moduleSupport) {
+        return true;
+      }
+      return permissionDetails.moduleSupport.some(
+        (role) => moduleSupportStatus[role]
+      );
+    },
+    [moduleSupportStatus]
+  );
 
   const checkPagePermission = useCallback(
     (requiredPermission: PermissionsConstantType): boolean => {
-      const manifest = PERMISSION_MANIFEST[requiredPermission];
+      const permissionDetails = PERMISSION_MANIFEST[requiredPermission];
       return (
-        !!manifest.role?.some((role) => userRoles[role]) ||
-        !!manifest.featureSupport?.some(
-          (module) => moduleSupportedStatus[module]
-        )
+        checkRoles(permissionDetails) || checkModuleSupport(permissionDetails)
       );
     },
-    [moduleSupportedStatus, userRoles]
+    [checkModuleSupport, checkRoles]
   );
 
+  const checkActionPermission = useCallback(
+    <T = Record<string, string>>(
+      requiredPermission: PermissionsConstantType,
+      record?: T
+    ): boolean => {
+      const permissionDetails = PERMISSION_MANIFEST[requiredPermission];
+
+      // 检查项目是否已冻结
+      if (
+        permissionDetails.projectArchived !== undefined &&
+        permissionDetails.projectArchived !== projectAttributesStatus.isArchived
+      ) {
+        return false;
+      }
+
+      // 检查角色或项目管理员权限
+      const hasRoleOrManagerPermission =
+        checkRoles(permissionDetails) ||
+        (permissionDetails.projectManager === true &&
+          projectAttributesStatus.isManager);
+
+      if (permissionDetails.dbServicePermission) {
+        const { fieldName, opType } = permissionDetails.dbServicePermission;
+        return (
+          hasRoleOrManagerPermission ||
+          isHaveServicePermission(
+            opType,
+            (record as Record<string, string>)?.[fieldName]
+          )
+        );
+      }
+
+      return hasRoleOrManagerPermission;
+    },
+    [
+      checkRoles,
+      isHaveServicePermission,
+      projectAttributesStatus.isArchived,
+      projectAttributesStatus.isManager
+    ]
+  );
+
+  const parse2TableActionPermissions = useCallback(
+    <
+      T = Record<string, any>,
+      F = Record<string, any>,
+      OtherColumnKeys extends string = never
+    >(
+      actions: ActiontechTableActionsWithConstantPermissions<
+        T,
+        F,
+        OtherColumnKeys
+      >
+    ): ActiontechTableProps<T, F, OtherColumnKeys>['actions'] => {
+      if (Array.isArray(actions)) {
+        return actions.map((item) => ({
+          ...item,
+          permissions: item.permissions
+            ? (record) => checkActionPermission(item.permissions!, record)
+            : undefined
+        }));
+      }
+
+      const parseActionMoreButtons = (
+        moreButtons: typeof actions.moreButtons
+      ): ActiontechTableActionsConfig<T, F, OtherColumnKeys>['moreButtons'] => {
+        if (typeof moreButtons === 'function') {
+          return (record: T) =>
+            moreButtons(record).map((item) => ({
+              ...item,
+              permissions: item.permissions
+                ? (data) => checkActionPermission(item.permissions!, data)
+                : undefined
+            }));
+        }
+
+        return moreButtons?.map((item) => ({
+          ...item,
+          permissions: item.permissions
+            ? (record) => checkActionPermission(item.permissions!, record)
+            : undefined
+        }));
+      };
+
+      return {
+        ...actions,
+        buttons: actions.buttons.map((item) => ({
+          ...item,
+          permissions: item.permissions
+            ? (record) => checkActionPermission(item.permissions!, record)
+            : undefined
+        })),
+        moreButtons: parseActionMoreButtons(actions.moreButtons)
+      };
+    },
+    [checkActionPermission]
+  );
+
+  useEffect(() => {
+    updateUserOperationPermission();
+  }, [updateUserOperationPermission]);
+
   return {
-    checkPagePermission
+    checkPagePermission,
+    checkActionPermission,
+    parse2TableActionPermissions
   };
 };
 

--- a/packages/shared/lib/global/useUserOperationPermission/index.ts
+++ b/packages/shared/lib/global/useUserOperationPermission/index.ts
@@ -9,6 +9,7 @@ import {
   OpPermissionItemRangeTypeEnum
 } from '../../api/base/service/common.enum';
 
+// todo 后续需要整合下获取权限相关数据的 hooks，统一移动至 App.tsx， 存放在 redux 中。
 const useUserOperationPermission = () => {
   const { uid } = useCurrentUser();
 
@@ -28,7 +29,8 @@ const useUserOperationPermission = () => {
         }
       ),
     {
-      manual: true
+      manual: true,
+      ready: !!projectID
     }
   );
 
@@ -64,7 +66,6 @@ const useUserOperationPermission = () => {
           }
           return false;
         });
-
         if (is_admin || haveProjectPermission || haveServicePermission) {
           return true;
         }


### PR DESCRIPTION
重构了数据源列表 操作列的权限相关的代码。

主要包含了以下几种情况：
1. 前端自定义角色控制权限
2. 是否为当前项目管理员
3. 当前项目是否冻结
4. 当前用户在当前项目内对当前数据源是否拥有某些权限。权限设置路径：成员与权限页面添加成员时设置在角色中心预设置的角色。