### PR TITLE
[fix]: Adjust button permissions for enhanced access control

### DIFF
--- a/packages/sqle/src/page/SqlManagementConf/List/column.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/List/column.tsx
@@ -147,12 +147,14 @@ export const SqlManagementConfColumnAction: (params: {
     opPermissionType: OpPermissionItemOpPermissionTypeEnum,
     serviceID?: string
   ) => boolean;
+  operationPermission: boolean;
 }) => ActiontechTableProps<IInstanceAuditPlanResV1>['actions'] = ({
   editAction,
   disabledAction,
   enabledAction,
   deleteAction,
-  isHaveServicePermission
+  isHaveServicePermission,
+  operationPermission
 }) => {
   return {
     buttons: [
@@ -170,14 +172,14 @@ export const SqlManagementConfColumnAction: (params: {
           isHaveServicePermission(
             OpPermissionItemOpPermissionTypeEnum.save_audit_plan,
             record?.instance_id
-          )
+          ) || operationPermission
       }
     ],
     moreButtons: (record) =>
       isHaveServicePermission(
         OpPermissionItemOpPermissionTypeEnum.save_audit_plan,
         record?.instance_id
-      )
+      ) || operationPermission
         ? [
             {
               key: 'disabled',

--- a/packages/sqle/src/page/SqlManagementConf/List/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/List/index.tsx
@@ -50,10 +50,11 @@ import useAuditPlanTypes from '../../../hooks/useAuditPlanTypes';
 const List: React.FC = () => {
   const { t } = useTranslation();
   const { projectArchive, projectName, projectID } = useCurrentProject();
-  const { username } = useCurrentUser();
+  const { username, isAdmin, isProjectManager } = useCurrentUser();
   const { requestErrorMessage, handleTableRequestError } =
     useTableRequestError();
   const [messageApi, contextMessageHolder] = message.useMessage();
+  const operationPermission = isAdmin || isProjectManager(projectName);
 
   const { getLogoUrlByDbType } = useDbServiceDriver();
 
@@ -248,7 +249,8 @@ const List: React.FC = () => {
             deleteAction,
             disabledAction,
             enabledAction,
-            isHaveServicePermission
+            isHaveServicePermission,
+            operationPermission
           })}
         />
       </Spin>

--- a/packages/sqle/src/page/SqlManagementConf/List/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/List/index.tsx
@@ -46,7 +46,6 @@ import {
   BookMarkTagOutlined
 } from '@actiontech/icons';
 import useAuditPlanTypes from '../../../hooks/useAuditPlanTypes';
-import { OpPermissionItemOpPermissionTypeEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
 
 const List: React.FC = () => {
   const { t } = useTranslation();
@@ -163,14 +162,7 @@ const List: React.FC = () => {
       <PageHeader
         title={t('managementConf.list.pageTitle')}
         extra={
-          <EmptyBox
-            if={
-              !projectArchive &&
-              isHaveServicePermission(
-                OpPermissionItemOpPermissionTypeEnum.save_audit_plan
-              )
-            }
-          >
+          <EmptyBox if={!projectArchive}>
             <Link to={`/sqle/project/${projectID}/sql-management-conf/create`}>
               <BasicButton type="primary">
                 {t('managementConf.list.pageAction.enableAuditPlan')}


### PR DESCRIPTION
https://github.com/actiontech/sqle/issues/2599

相关 issue：https://github.com/actiontech/sqle/issues/2672

临时调整创建扫描任务按钮的权限，由于已通过创建页面获取数据源的数据做了权限筛选，故这里只需要项目未冻结时，便能进入创建页面。

优先级：高