### PR TITLE
[feature]:(AddMember) add remote search for username tips

### DIFF
--- a/packages/base/src/page/Member/Modal/Member/__tests__/AddMember.test.tsx
+++ b/packages/base/src/page/Member/Modal/Member/__tests__/AddMember.test.tsx
@@ -9,7 +9,10 @@ import { ModalName } from '../../../../../data/ModalName';
 import AddMember from '../AddMember';
 import EventEmitter from '../../../../../utils/EventEmitter';
 import EmitterKey from '../../../../../data/EmitterKey';
-import { selectOptionByIndex } from '@actiontech/shared/lib/testUtil/customQuery';
+import {
+  getBySelector,
+  selectOptionByIndex
+} from '@actiontech/shared/lib/testUtil/customQuery';
 import { queryBySelector } from '@actiontech/shared/lib/testUtil/customQuery';
 import { mockUseCurrentProject } from '@actiontech/shared/lib/testUtil/mockHook/mockUseCurrentProject';
 import { mockProjectInfo } from '@actiontech/shared/lib/testUtil/mockHook/data';
@@ -56,6 +59,7 @@ describe('base/Member/Modal/AddMember', () => {
   it('should send add member request when click submit button', async () => {
     const eventEmitSpy = jest.spyOn(EventEmitter, 'emit');
     const { baseElement } = renderWithReduxAndTheme(<AddMember />);
+    await act(async () => jest.advanceTimersByTime(600));
     await act(async () => jest.advanceTimersByTime(3000));
     expect(listUsersSpy).toHaveBeenCalledTimes(1);
     expect(litDBServices).toHaveBeenCalledTimes(1);
@@ -106,6 +110,7 @@ describe('base/Member/Modal/AddMember', () => {
 
   it('should send add member request when click submit button with role', async () => {
     const { baseElement } = renderWithReduxAndTheme(<AddMember />);
+    await act(async () => jest.advanceTimersByTime(600));
     await act(async () => jest.advanceTimersByTime(3000));
     selectOptionByIndex('用户名称', userList[0].name ?? '', 0);
     fireEvent.click(queryBySelector('.member-form-add-button', baseElement)!);
@@ -160,6 +165,30 @@ describe('base/Member/Modal/AddMember', () => {
         modalName: ModalName.DMS_Add_Member,
         status: false
       }
+    });
+  });
+
+  it('should load options when searching', async () => {
+    renderWithReduxAndTheme(<AddMember />);
+
+    await act(async () => jest.advanceTimersByTime(600));
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(listUsersSpy).toHaveBeenCalledTimes(1);
+    expect(listUsersSpy).toHaveBeenNthCalledWith(1, {
+      page_size: 999,
+      filter_by_name_fuzzy: undefined
+    });
+
+    fireEvent.change(getBySelector('#userUid'), {
+      target: { value: 'search value' }
+    });
+
+    expect(listUsersSpy).toHaveBeenCalledTimes(1);
+    await act(async () => jest.advanceTimersByTime(600));
+    expect(listUsersSpy).toHaveBeenCalledTimes(2);
+    expect(listUsersSpy).toHaveBeenNthCalledWith(2, {
+      page_size: 999,
+      filter_by_name_fuzzy: 'search value'
     });
   });
 });

--- a/packages/base/src/page/Member/Modal/Member/__tests__/UpdateMember.test.tsx
+++ b/packages/base/src/page/Member/Modal/Member/__tests__/UpdateMember.test.tsx
@@ -53,6 +53,7 @@ describe('base/Member/Modal/UpdateMember', () => {
   it('should send update member request when click submit button', async () => {
     const eventEmitSpy = jest.spyOn(EventEmitter, 'emit');
     const { baseElement } = renderWithReduxAndTheme(<UpdateMember />);
+    await act(async () => jest.advanceTimersByTime(600));
     await act(async () => jest.advanceTimersByTime(3000));
     expect(listUsersSpy).toHaveBeenCalledTimes(1);
     expect(litDBServices).toHaveBeenCalledTimes(1);

--- a/packages/base/src/page/Member/Modal/Member/__tests__/__snapshots__/AddMember.test.tsx.snap
+++ b/packages/base/src/page/Member/Modal/Member/__tests__/__snapshots__/AddMember.test.tsx.snap
@@ -998,7 +998,6 @@ exports[`base/Member/Modal/AddMember should send add member request when click s
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
-                  label="test"
                   title="test"
                 >
                   <div
@@ -1016,7 +1015,6 @@ exports[`base/Member/Modal/AddMember should send add member request when click s
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
-                  label="test666"
                   title="test666"
                 >
                   <div
@@ -1034,7 +1032,6 @@ exports[`base/Member/Modal/AddMember should send add member request when click s
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
-                  label="admin"
                   title="admin"
                 >
                   <div

--- a/packages/shared/lib/api/base/service/User/index.d.ts
+++ b/packages/shared/lib/api/base/service/User/index.d.ts
@@ -26,6 +26,8 @@ export interface IListUsersParams {
   filter_by_uids?: string;
 
   filter_del_user?: boolean;
+
+  filter_by_name_fuzzy?: string;
 }
 
 export interface IListUsersReturn extends IListUserReply {}


### PR DESCRIPTION
解决浙江农信现场用户数量上万条导致接口加载时间过长的问题。

先临时解决 添加成员处 的问题，其他获取用户 tips 的接口的处理方案待定。

优先级：高