### PR TITLE
Fix/custom segemented filter issue

### DIFF
--- a/packages/shared/lib/components/CustomSegmentedFilter/__tests__/index.test.tsx
+++ b/packages/shared/lib/components/CustomSegmentedFilter/__tests__/index.test.tsx
@@ -1,14 +1,8 @@
 import { fireEvent, screen } from '@testing-library/dom';
 import CustomSegmentedFilter from '..';
 import { superRender } from '../../../testUtil/customRender';
-import {
-  UtilsConsoleErrorStringsEnum,
-  ignoreConsoleErrors
-} from '../../../testUtil/common';
 
 describe('test CustomSegmentedFilter', () => {
-  ignoreConsoleErrors([UtilsConsoleErrorStringsEnum.UNIQUE_KEY_REQUIRED]);
-
   it('renders CustomSegmentedFilter component', () => {
     const { container } = superRender(
       <CustomSegmentedFilter
@@ -68,26 +62,10 @@ describe('test CustomSegmentedFilter', () => {
 
     fireEvent.click(screen.getByText('全部'));
     expect(handleChange).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledWith(undefined);
+    expect(handleChange).toHaveBeenCalledWith(null);
     expect(screen.getByText('全部').parentNode).toHaveClass(
       'ant-segmented-item-selected'
     );
-  });
-
-  it('includes "all" option when withAll is string', () => {
-    const handleChange = jest.fn();
-    superRender(
-      <CustomSegmentedFilter
-        options={['option1']}
-        withAll="全部2"
-        onChange={handleChange}
-        defaultValue="option1"
-      />
-    );
-    expect(screen.getByText('全部2')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('全部2'));
-    expect(handleChange).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledWith('全部2');
   });
 
   it('includes "all" option when withAll is object', () => {

--- a/packages/shared/lib/components/CustomSegmentedFilter/index.tsx
+++ b/packages/shared/lib/components/CustomSegmentedFilter/index.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import {
+  CustomSegmentedFilterBaseValue,
   CustomSegmentedFilterDefaultOptionsType,
   CustomSegmentedFilterProps
 } from './index.type';
@@ -8,8 +9,11 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SegmentedProps } from 'antd';
 import BasicSegmented from '../BasicSegmented';
+import { SegmentedValue } from 'antd/es/segmented';
 
-const CustomSegmentedFilter = <V extends string | number | undefined = string>(
+const CustomSegmentedFilter = <
+  V extends CustomSegmentedFilterBaseValue = string
+>(
   props: CustomSegmentedFilterProps<V>
 ) => {
   const { t } = useTranslation();
@@ -65,20 +69,18 @@ const CustomSegmentedFilter = <V extends string | number | undefined = string>(
         }
       });
 
-    if (withAll === undefined || withAll === false) {
+    if (!withAll) {
       return transformOptions;
     }
 
     if (withAll === true) {
-      // Segmented 组件会将 value 设置为 each 组件时的 key，当 value 为 undefined 时 key 设置失败。
       return [
-        { label: t('common.all'), value: undefined as V },
+        {
+          label: t('common.all'),
+          value: null as V
+        },
         ...transformOptions
       ];
-    }
-
-    if (typeof withAll === 'string') {
-      return [{ label: withAll, value: withAll as V }, ...transformOptions];
     }
 
     return [withAll, ...transformOptions];
@@ -114,8 +116,8 @@ const CustomSegmentedFilter = <V extends string | number | undefined = string>(
     return (
       <BasicSegmented
         className={mergeClassNames}
-        value={value}
-        defaultValue={props.defaultValue}
+        value={value as SegmentedValue}
+        defaultValue={props.defaultValue as SegmentedValue}
         onChange={(val) => {
           onChange(val as V);
         }}

--- a/packages/shared/lib/components/CustomSegmentedFilter/index.type.ts
+++ b/packages/shared/lib/components/CustomSegmentedFilter/index.type.ts
@@ -1,11 +1,20 @@
 import { CSSProperties, ReactNode } from 'react';
 
+export type CustomSegmentedFilterBaseValue = string | number | null;
+
+export type CustomSegmentedFilterWithAllConfig<
+  V extends CustomSegmentedFilterBaseValue = string
+> = {
+  label: ReactNode;
+  value: V;
+};
+
 export type CustomSegmentedFilterDefaultOptionsType<
-  V extends string | number | undefined = string
+  V extends CustomSegmentedFilterBaseValue = string
 > = Array<{ label: ReactNode; value: V }>;
 
 export type CustomSegmentedFilterProps<
-  V extends string | number | undefined = string
+  V extends CustomSegmentedFilterBaseValue = string
 > = {
   value?: V;
 
@@ -41,14 +50,12 @@ export type CustomSegmentedFilterProps<
   options: CustomSegmentedFilterDefaultOptionsType<V> | string[];
 
   /**
-   * 是否自动添加 “全部” 项作为筛选项
-   * 默认值： false
-   *
-   * 当为 true 时，默认添加的 “全部” 筛选项对应的 option 为 {label:'全部', value: undefined}
-   * 当为 string 类型数据 时，默认添加的 “全部” 筛选项对应的 option 为 {label: `${withAll}`, value: `${withAll}`}
-   * 当为 Record 时，会将该对象合并进入 options
+   * 是否添加"全部"选项
+   * - true: 使用默认配置，label为"全部"，value为 null
+   * - WithAllConfig: 自定义配置
+   * - false: 不显示全部选项
    */
-  withAll?: boolean | CustomSegmentedFilterDefaultOptionsType<V>[0] | string;
+  withAll?: boolean | CustomSegmentedFilterWithAllConfig<V>;
 
   /**
    * 是否清空样式

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.tsx
@@ -8,9 +8,10 @@ import classNames from 'classnames';
 import { floatToPercent } from '@actiontech/shared/lib/utils/Math';
 import { floatRound } from '@actiontech/shared/lib/utils/Math';
 import { useTranslation } from 'react-i18next';
+import { CustomSegmentedFilterBaseValue } from '@actiontech/shared/lib/components/CustomSegmentedFilter/index.type';
 
 const AuditResultFilterContainer = <
-  T extends string | number | undefined = string
+  T extends CustomSegmentedFilterBaseValue = string
 >(
   props: AuditResultFilterContainerProps<T>
 ) => {

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/index.type.ts
@@ -1,8 +1,11 @@
 import { AuditTaskResV1AuditLevelEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
-import { CustomSegmentedFilterProps } from '@actiontech/shared/lib/components/CustomSegmentedFilter/index.type';
+import {
+  CustomSegmentedFilterBaseValue,
+  CustomSegmentedFilterProps
+} from '@actiontech/shared/lib/components/CustomSegmentedFilter/index.type';
 
 export type AuditResultFilterContainerProps<
-  T extends string | number | undefined = string
+  T extends CustomSegmentedFilterBaseValue = string
 > = {
   className?: string;
   passRate?: number;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/useAuditResultFilterParams.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultFilterContainer/useAuditResultFilterParams.ts
@@ -7,9 +7,9 @@ import { useState } from 'react';
 const useAuditResultFilterParams = () => {
   const [noDuplicate, setNoDuplicate] = useState(false);
   const [auditLevelFilterValue, setAuditLevelFilterValue] =
-    useState<getAuditTaskSQLsV2FilterAuditLevelEnum>();
+    useState<getAuditTaskSQLsV2FilterAuditLevelEnum | null>(null);
   const [execStatusFilterValue, setExecStatusFilterValue] =
-    useState<getAuditTaskSQLsV2FilterExecStatusEnum>();
+    useState<getAuditTaskSQLsV2FilterExecStatusEnum | null>(null);
 
   return {
     noDuplicate,

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/__tests__/index.ce.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/__tests__/index.ce.test.tsx
@@ -56,7 +56,7 @@ describe('sqle/ExecWorkflow/Common/AuditResultList', () => {
     const { baseElement } = customRender({
       noDuplicate: true,
       projectID: 'projectID',
-      auditLevelFilterValue: undefined
+      auditLevelFilterValue: null
     });
     expect(baseElement).toMatchSnapshot();
   });

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/__tests__/index.test.tsx
@@ -20,6 +20,7 @@ import {
 } from '@actiontech/shared/lib/api/sqle/service/common.enum';
 import EventEmitter from '../../../../../../utils/EventEmitter';
 import EmitterKey from '../../../../../../data/EmitterKey';
+import task from '../../../../../../testUtils/mockApi/task';
 
 jest.mock('react-redux', () => {
   return {
@@ -45,6 +46,7 @@ describe('sqle/ExecWorkflow/Common/AuditResultList/List', () => {
     requestUpdateAuditTaskSQLs = execWorkflow.updateAuditTaskSQLs();
     requestGetAuditTaskSQLs = execWorkflow.getAuditTaskSQLs();
     updateSqlBackupStrategySpy = execWorkflow.updateSqlBackupStrategy();
+    task.getTaskSQLRewritten();
     execWorkflow.mockAllApi();
     rule_template.getRuleList();
     (useSelector as jest.Mock).mockImplementation((e) =>
@@ -69,7 +71,7 @@ describe('sqle/ExecWorkflow/Common/AuditResultList/List', () => {
     const { baseElement } = customRender({
       noDuplicate: true,
       projectID: 'projectID',
-      auditLevelFilterValue: undefined
+      auditLevelFilterValue: null
     });
     expect(baseElement).toMatchSnapshot();
   });

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/index.tsx
@@ -87,7 +87,7 @@ const AuditResultTable: React.FC<AuditResultTableProps> = ({
       handleTableRequestError(
         task.getAuditTaskSQLsV2({
           task_id: taskID!,
-          filter_audit_level: auditLevelFilterValue,
+          filter_audit_level: auditLevelFilterValue ?? undefined,
           page_index: pagination.page_index.toString(),
           page_size: pagination.page_size.toString(),
           no_duplicate: noDuplicate
@@ -97,7 +97,7 @@ const AuditResultTable: React.FC<AuditResultTableProps> = ({
       ready: typeof taskID === 'string',
       refreshDeps: [pagination, taskID],
       onSuccess(res) {
-        if (auditLevelFilterValue === undefined) {
+        if (auditLevelFilterValue === null) {
           updateTaskRecordCount?.(taskID ?? '', res.total ?? 0);
         }
       },

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/index.type.ts
@@ -5,7 +5,7 @@ import { InstanceTipResV1SupportedBackupStrategyEnum } from '@actiontech/shared/
 export type AuditResultTableProps = {
   noDuplicate: boolean;
   taskID?: string;
-  auditLevelFilterValue?: getAuditTaskSQLsV2FilterAuditLevelEnum;
+  auditLevelFilterValue: getAuditTaskSQLsV2FilterAuditLevelEnum | null;
   projectID: string;
   updateTaskRecordCount?: (taskId: string, sqlNumber: number) => void;
   dbType?: string;

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/index.tsx
@@ -124,9 +124,7 @@ const AuditResultList: React.FC<AuditResultListProps> = ({
         </Space>
       </SegmentedRowStyleWrapper>
       {/* todo: options 中部分数据需要后端接口支持 http://10.186.18.11/jira/browse/DMS-424*/}
-      <AuditResultFilterContainer<
-        getAuditTaskSQLsV2FilterAuditLevelEnum | undefined
-      >
+      <AuditResultFilterContainer
         passRate={currentTask?.pass_rate}
         score={currentTask?.score}
         instanceSchemaName={currentTask?.instance_schema}
@@ -136,7 +134,7 @@ const AuditResultList: React.FC<AuditResultListProps> = ({
         options={Object.keys(getAuditTaskSQLsV2FilterAuditLevelEnum)}
         withAll={{
           label: t('execWorkflow.create.auditResult.allLevel'),
-          value: undefined
+          value: null
         }}
         labelDictionary={translateDictionaryI18nLabel(auditLevelDictionary)}
       />

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/FileExecuteMode/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/FileExecuteMode/__tests__/index.test.tsx
@@ -15,6 +15,7 @@ describe('test PaginationList/FileExecuteMode', () => {
     const _params: FileExecuteModeProps = {
       taskId: '123',
       currentListLayout: TaskResultListLayoutEnum.pagination,
+      execStatusFilterValue: null,
       auditResultActiveKey: '123',
       noDuplicate: false,
       pagination: { page_index: 1, page_size: 20 },

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/__tests__/index.test.tsx
@@ -19,7 +19,8 @@ describe('test PaginationList/SQLExecuteMode', () => {
       tableFilterInfo: {},
       pagination: { page_index: 1, page_size: 20 },
       tableChange: jest.fn(),
-      assigneeUserNames: [mockCurrentUserReturn.username]
+      assigneeUserNames: [mockCurrentUserReturn.username],
+      execStatusFilterValue: null
     };
     return superRender(<SQLExecuteMode {...{ ..._params, ...params }} />);
   };

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/index.tsx
@@ -41,7 +41,7 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
           page_index: pagination.page_index.toString(),
           page_size: pagination.page_size.toString(),
           no_duplicate: noDuplicate,
-          filter_exec_status: execStatusFilterValue
+          filter_exec_status: execStatusFilterValue ?? undefined
         })
         .then((res) => {
           return {

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/__tests__/__snapshots__/index.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`test ExecWorkflow/TaskResultList/PaginationList should match snapshot 1
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         pagination={
           {
@@ -36,6 +37,7 @@ exports[`test ExecWorkflow/TaskResultList/PaginationList should match snapshot 1
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         pagination={
           {
@@ -67,6 +69,7 @@ exports[`test ExecWorkflow/TaskResultList/PaginationList should match snapshot 2
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         pagination={
           {
@@ -88,6 +91,7 @@ exports[`test ExecWorkflow/TaskResultList/PaginationList should match snapshot 2
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         pagination={
           {

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/__tests__/index.test.tsx
@@ -16,7 +16,8 @@ describe('test ExecWorkflow/TaskResultList/PaginationList', () => {
       noDuplicate: false,
       tableFilterInfo: {},
       pagination: { page_index: 1, page_size: 10 },
-      assigneeUserNames: [mockCurrentUserReturn.username]
+      assigneeUserNames: [mockCurrentUserReturn.username],
+      execStatusFilterValue: null
     };
 
     expect(

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/SqlFileStatementOverview/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/SqlFileStatementOverview/index.tsx
@@ -85,7 +85,7 @@ const SqlFileStatementOverview: React.FC = () => {
           page_index: pagination.page_index.toString(),
           page_size: pagination.page_size.toString(),
           filter_audit_level: tableFilterInfo.filter_audit_level,
-          filter_exec_status: execStatusFilterValue,
+          filter_exec_status: execStatusFilterValue ?? undefined,
           no_duplicate: noDuplicate
         })
       ),
@@ -122,15 +122,13 @@ const SqlFileStatementOverview: React.FC = () => {
 
       <SegmentedRowStyleWrapper justify="space-between">
         <AuditResultFilterContainerStyleWrapper className="audit-result-filter-container-borderless clear-padding">
-          <CustomSegmentedFilter<
-            getAuditTaskSQLsV2FilterExecStatusEnum | undefined
-          >
+          <CustomSegmentedFilter
             noStyle
             className="audit-result-filter-option"
             options={Object.keys(getAuditTaskSQLsV2FilterExecStatusEnum)}
             withAll={{
               label: t('audit.execStatus.allStatus'),
-              value: undefined
+              value: null
             }}
             labelDictionary={translateDictionaryI18nLabel(execStatusDictionary)}
             onChange={setExecStatusFilterValue}

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/FileExecuteMode/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/FileExecuteMode/__tests__/index.test.tsx
@@ -19,6 +19,7 @@ describe('test WaterfallList/FileExecuteMode', () => {
       noDuplicate: false,
       assigneeUserNames: [mockCurrentUserReturn.username],
       workflowStatus: WorkflowRecordResV2StatusEnum.wait_for_execution,
+      execStatusFilterValue: null,
       ...params
     };
     return superRender(<FileExecuteMode {..._params} />);

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/__tests__/index.test.tsx
@@ -38,7 +38,8 @@ describe('test WaterfallList/SQLExecuteMode', () => {
       auditResultActiveKey: '123',
       noDuplicate: false,
       tableFilterInfo: {},
-      assigneeUserNames: [mockCurrentUserReturn.username]
+      assigneeUserNames: [mockCurrentUserReturn.username],
+      execStatusFilterValue: null
     };
     return superRender(<SqlExecuteMode {...{ ..._params, ...params }} />);
   };

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/index.tsx
@@ -58,7 +58,7 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
           page_index: `${page}`,
           page_size: '20',
           no_duplicate: noDuplicate,
-          filter_exec_status: execStatusFilterValue
+          filter_exec_status: execStatusFilterValue ?? undefined
         })
         .then((res) => {
           return {
@@ -98,7 +98,7 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
           page_index: `${page}`,
           page_size: '20',
           no_duplicate: noDuplicate,
-          filter_exec_status: execStatusFilterValue
+          filter_exec_status: execStatusFilterValue ?? undefined
         })
         .then((res) => {
           const { data } = res.data;

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/__tests__/__snapshots__/index.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`test ExecWorkflow/TaskResultList/WaterfallList should match snapshot 1`
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         tableFilterInfo={{}}
         taskId="123"
@@ -29,6 +30,7 @@ exports[`test ExecWorkflow/TaskResultList/WaterfallList should match snapshot 1`
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         tableFilterInfo={{}}
         taskId="123"
@@ -53,6 +55,7 @@ exports[`test ExecWorkflow/TaskResultList/WaterfallList should match snapshot 2`
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         tableFilterInfo={{}}
         taskId="123"
@@ -67,6 +70,7 @@ exports[`test ExecWorkflow/TaskResultList/WaterfallList should match snapshot 2`
         }
         auditResultActiveKey="123"
         currentListLayout="pagination"
+        execStatusFilterValue={null}
         noDuplicate={false}
         tableFilterInfo={{}}
         taskId="123"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/__tests__/index.test.tsx
@@ -14,7 +14,8 @@ describe('test ExecWorkflow/TaskResultList/WaterfallList', () => {
       auditResultActiveKey: '123',
       noDuplicate: false,
       tableFilterInfo: {},
-      assigneeUserNames: [mockCurrentUserReturn.username]
+      assigneeUserNames: [mockCurrentUserReturn.username],
+      execStatusFilterValue: null
     };
 
     expect(

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/__tests__/__snapshots__/index.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`test ExecWorkflow/TaskResultList should match snapshot when currentList
   }
   auditResultActiveKey="123"
   currentListLayout="pagination"
+  execStatusFilterValue={null}
   executeMode="sqls"
   noDuplicate={false}
   pagination={
@@ -32,6 +33,7 @@ exports[`test ExecWorkflow/TaskResultList should match snapshot when currentList
   }
   auditResultActiveKey="123"
   currentListLayout="scroll"
+  execStatusFilterValue={null}
   executeMode="sqls"
   noDuplicate={false}
   pagination={

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/__tests__/index.test.tsx
@@ -18,6 +18,7 @@ describe('test ExecWorkflow/TaskResultList', () => {
         tableFilterInfo={{}}
         pagination={{ page_index: 1, page_size: 10 }}
         assigneeUserNames={[mockCurrentUserReturn.username]}
+        execStatusFilterValue={null}
       />
     );
 
@@ -36,6 +37,7 @@ describe('test ExecWorkflow/TaskResultList', () => {
         tableFilterInfo={{}}
         pagination={{ page_index: 1, page_size: 10 }}
         assigneeUserNames={[mockCurrentUserReturn.username]}
+        execStatusFilterValue={null}
       />
     );
 

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/index.type.ts
@@ -13,7 +13,7 @@ export type TasksResultListBaseProps = {
   auditResultActiveKey: string;
   noDuplicate: boolean;
   tableFilterInfo: GetAuditTaskSQLsPrams;
-  execStatusFilterValue?: getAuditTaskSQLsV2FilterExecStatusEnum;
+  execStatusFilterValue: getAuditTaskSQLsV2FilterExecStatusEnum | null;
   workflowStatus?: WorkflowRecordResV2StatusEnum;
   assigneeUserNames: string[];
   executeMode: WorkflowResV2ExecModeEnum;

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/index.tsx
@@ -166,9 +166,7 @@ const AuditExecResultPanel: React.FC<AuditExecResultPanelProps> = ({
             WorkflowResV2ExecModeEnum.sqls
           }
         >
-          <AuditResultFilterContainer<
-            getAuditTaskSQLsV2FilterExecStatusEnum | undefined
-          >
+          <AuditResultFilterContainer
             className="audit-result-filter-container-borderless"
             passRate={currentTask?.pass_rate}
             score={currentTask?.score}
@@ -179,7 +177,7 @@ const AuditExecResultPanel: React.FC<AuditExecResultPanelProps> = ({
             options={Object.keys(getAuditTaskSQLsV2FilterExecStatusEnum)}
             withAll={{
               label: t('audit.execStatus.allStatus'),
-              value: undefined
+              value: null
             }}
             labelDictionary={translateDictionaryI18nLabel(execStatusDictionary)}
           />


### PR DESCRIPTION
fix issue: https://github.com/actiontech/sqle/issues/2848

调整自定义分段筛选器中 “全部” 选项的值，使用 null 替换 undefined。解决以下问题：

1.  使用 null 作为默认的"全部"选项值，语义更清晰
2.  segmented 使用 items 生成组件时，默认会使用 value 作为遍历时的 key，使用 undefined 会导致 key 设置失效
3.  segmented 使用 undefined 作为 value 时，用户选中该项后不会更新对应的选中项，详情见关联的 issue