### PR TITLE
[fix]: (SqlAudit) adjust global rule template selection for static auditing

### DIFF
--- a/packages/sqle/src/page/SqlAudit/Create/SQLInfoForm/SQLInfoFormItem.tsx
+++ b/packages/sqle/src/page/SqlAudit/Create/SQLInfoForm/SQLInfoFormItem.tsx
@@ -120,27 +120,12 @@ const SQLInfoFormItem = ({
   };
 
   const ruleTemplateOptions: SelectProps['options'] = useMemo(() => {
-    const dbTypeDefaultRuleTemplateName = globalRuleTemplateList.find(
-      (v) => v.is_default_rule_template
-    )?.rule_template_name;
-
-    const ruleTemplateTipsOptions: SelectProps['options'] =
-      ruleTemplateList.map((v) => ({
-        label: v.rule_template_name,
-        value: v.rule_template_name
-      }));
-
-    if (!dbTypeDefaultRuleTemplateName) {
-      return ruleTemplateTipsOptions;
-    }
-
-    return [
-      ...(ruleTemplateTipsOptions ?? []),
-      {
-        label: dbTypeDefaultRuleTemplateName,
-        value: dbTypeDefaultRuleTemplateName
-      }
-    ];
+    return [...ruleTemplateList, ...globalRuleTemplateList].map((item) => {
+      return {
+        label: item.rule_template_name,
+        value: item.rule_template_name
+      };
+    });
   }, [globalRuleTemplateList, ruleTemplateList]);
 
   return (

--- a/packages/sqle/src/page/SqlAudit/Create/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAudit/Create/__snapshots__/index.test.tsx.snap
@@ -1565,6 +1565,23 @@ exports[`sqle/SqlAudit/Create configure git repository 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
+                  title="custom_template"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    custom_template
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
                   title="custom_template_b"
                 >
                   <div
@@ -5732,6 +5749,23 @@ exports[`sqle/SqlAudit/Create select static audit type 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
+                  title="custom_template"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    custom_template
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
                   title="custom_template_b"
                 >
                   <div
@@ -7213,6 +7247,23 @@ exports[`sqle/SqlAudit/Create upload sql file 1`] = `
                     class="ant-select-item-option-content"
                   >
                     default_MySQL1
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
+                  title="custom_template"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    custom_template
                   </div>
                   <span
                     aria-hidden="true"
@@ -10419,6 +10470,23 @@ exports[`sqle/SqlAudit/Create upload zip file 1`] = `
                     class="ant-select-item-option-content"
                   >
                     default_MySQL1
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
+                  title="custom_template"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    custom_template
                   </div>
                   <span
                     aria-hidden="true"

--- a/packages/sqle/src/page/SqlAudit/Create/index.test.tsx
+++ b/packages/sqle/src/page/SqlAudit/Create/index.test.tsx
@@ -213,9 +213,7 @@ describe('sqle/SqlAudit/Create', () => {
 
     fireEvent.mouseDown(getBySelector('#ruleTemplate', baseElement));
     expect(baseElement).toMatchSnapshot();
-    fireEvent.click(
-      getBySelector('div[title="custom_template_b"]', baseElement)
-    );
+    fireEvent.click(getBySelector('div[title="custom_template"]', baseElement));
     await jest.advanceTimersByTime(0);
 
     const sqlValue = 'SELECT 1;';
@@ -242,7 +240,7 @@ describe('sqle/SqlAudit/Create', () => {
       instance_name: undefined,
       instance_schema: undefined,
       project_name: 'default',
-      rule_template_name: 'custom_template_b',
+      rule_template_name: 'custom_template',
       sqls: formatterSQL(sqlValue, instanceTipsMockData[0].instance_type)
     });
 


### PR DESCRIPTION
fix issue: https://github.com/actiontech/sqle/issues/2846

静态审核时全局规则模板选择范围由默认规则模板调整为当前数据源类型所对应的所有规则模板