### PR TITLE
[fix]:(SQLE/DataSourceComparison) disable diff-only button when no differences found and fix SQL parameter generation issue

### DIFF
--- a/packages/sqle/src/locale/zh-CN/dataSourceComparison.ts
+++ b/packages/sqle/src/locale/zh-CN/dataSourceComparison.ts
@@ -20,6 +20,7 @@ export default {
     generateSQLErrorTips:
       '当前选中的节点中包含对比结果一致的对象，请修改选择对象后重试！',
     generateSQLDisabledTips: '请先选择数据对象',
+    noDifferencesFound: '当前对比结果暂无差异',
     comparisonDetail: {
       title: '查看对比详情',
       generateSQL: '生成变更SQL',

--- a/packages/sqle/src/page/DataSourceComparison/ComparisonEntry/index.tsx
+++ b/packages/sqle/src/page/DataSourceComparison/ComparisonEntry/index.tsx
@@ -17,6 +17,7 @@ import {
   filterSchemasInDatabase,
   filteredWithoutParentNodeKey,
   getComparisonResultByNodeKey,
+  isValidChildNodeKey,
   parseTreeNodeKey
 } from './utils/TreeNode';
 import {
@@ -143,7 +144,9 @@ const ComparisonEntry: React.FC = () => {
                 keys: []
               };
             }
-            acc[key].keys.push(curr.key);
+            if (isValidChildNodeKey(curr.key)) {
+              acc[key].keys.push(curr.key);
+            }
             return acc;
           },
           {} as Record<
@@ -235,6 +238,13 @@ const ComparisonEntry: React.FC = () => {
       generateModifiedSqlInfoApi();
     }
   };
+
+  const noDifferencesFound = useMemo(() => {
+    return filteredComparisonResultsWithoutSame.every(
+      (item) => item.comparison_result === SchemaObjectComparisonResultEnum.same
+    );
+  }, [filteredComparisonResultsWithoutSame]);
+
   return (
     <ComparisonEntryStyleWrapper>
       {messageContextHolder}
@@ -266,15 +276,32 @@ const ComparisonEntry: React.FC = () => {
         }
       >
         <ComparisonActionStyleWrapper size={12}>
-          <ToggleButtonStyleWrapper
-            active={showDifferencesOnly}
-            onClick={() => {
-              toggleShowDifferencesOnly();
-              setCheckedObjectNodeKeys([]);
-            }}
-          >
-            {t('dataSourceComparison.entry.showDifferencesOnly')}
-          </ToggleButtonStyleWrapper>
+          {noDifferencesFound ? (
+            <BasicToolTip
+              title={t('dataSourceComparison.entry.noDifferencesFound')}
+            >
+              <ToggleButtonStyleWrapper
+                disabled={true}
+                active={showDifferencesOnly}
+                onClick={() => {
+                  toggleShowDifferencesOnly();
+                  setCheckedObjectNodeKeys([]);
+                }}
+              >
+                {t('dataSourceComparison.entry.showDifferencesOnly')}
+              </ToggleButtonStyleWrapper>
+            </BasicToolTip>
+          ) : (
+            <ToggleButtonStyleWrapper
+              active={showDifferencesOnly}
+              onClick={() => {
+                toggleShowDifferencesOnly();
+                setCheckedObjectNodeKeys([]);
+              }}
+            >
+              {t('dataSourceComparison.entry.showDifferencesOnly')}
+            </ToggleButtonStyleWrapper>
+          )}
 
           {/* <BasicButton disabled={executeComparisonPending}>
           {t('dataSourceComparison.entry.modifyMappings')}

--- a/packages/sqle/src/page/DataSourceComparison/ComparisonEntry/utils/TreeNode.tsx
+++ b/packages/sqle/src/page/DataSourceComparison/ComparisonEntry/utils/TreeNode.tsx
@@ -91,6 +91,10 @@ export const generateTreeNodeKey = (...args: string[]) => {
   return args.join(TREE_NODE_KEY_SEPARATOR);
 };
 
+export const isValidChildNodeKey = (key: string) => {
+  return key.split(TREE_NODE_KEY_SEPARATOR).length === 3;
+};
+
 export const parseTreeNodeKey = (
   key: string,
   comparisonResults: ISchemaObject[]
@@ -109,6 +113,7 @@ export const parseTreeNodeKey = (
   }
 
   const [index, objectType, objectName] = key.split(TREE_NODE_KEY_SEPARATOR);
+
   return {
     baselineSchemaName: getComparisonResultSchemaName(
       comparisonResults[Number(index)],


### PR DESCRIPTION
https://github.com/actiontech/sqle-ee/issues/2243

1. 当对比结果没有差异是禁用仅看差异按钮
2. 修复生成变更SQL参数异常问题（当全选树节点时额外包含了 parent 节点的value，需要过滤掉）