### PR TITLE
[fix]: remove redundant ConfigProvider instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "packageManager": "pnpm@10.7.0",
+  "packageManager": "pnpm@10.7.1",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "start": "pnpm --filter base start",

--- a/packages/base/src/App.tsx
+++ b/packages/base/src/App.tsx
@@ -42,6 +42,7 @@ import { updateModuleFeatureSupport } from './store/permission';
 import { ROUTE_PATHS } from '@actiontech/shared/lib/data/routePaths';
 import useSyncDmsCloudBeaverChannel from './hooks/useSyncDmsCloudBeaverChannel';
 import { getSystemModuleStatusModuleNameEnum } from '@actiontech/shared/lib/api/sqle/service/system/index.enum';
+import { ComponentControlHeight } from '@actiontech/shared/lib/data/common';
 
 import './index.less';
 
@@ -226,6 +227,35 @@ function App() {
         <ConfigProvider
           locale={antdLanguage}
           theme={{
+            components: {
+              Input: {
+                controlHeight: ComponentControlHeight.default,
+                controlHeightLG: ComponentControlHeight.lg,
+                controlHeightSM: ComponentControlHeight.sm
+              },
+              Button: {
+                controlHeight: 32,
+                controlHeightLG: 36,
+                controlHeightSM: 28
+              },
+              DatePicker: {
+                controlHeight: ComponentControlHeight.default,
+                controlHeightLG: ComponentControlHeight.lg,
+                controlHeightSM: ComponentControlHeight.sm
+              },
+              Select: {
+                controlHeight: ComponentControlHeight.default,
+                controlHeightLG: ComponentControlHeight.lg,
+                controlHeightSM: ComponentControlHeight.sm
+              },
+              Pagination: {
+                itemSize: 28
+              },
+              Table: {
+                fontSize: 13,
+                fontWeightStrong: 500
+              }
+            },
             algorithm:
               theme === SupportTheme.DARK
                 ? antdTheme.darkAlgorithm

--- a/packages/base/src/page/Home/DefaultScene/components/GuidanceButton/index.tsx
+++ b/packages/base/src/page/Home/DefaultScene/components/GuidanceButton/index.tsx
@@ -1,27 +1,17 @@
 import { GuidanceButtonStyleWrapper } from './style';
-import { ButtonProps, ConfigProvider, Space } from 'antd';
+import { ButtonProps, Space } from 'antd';
 
 const GuidanceButton = (props: ButtonProps) => {
   const { children, ...otherProps } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Button: {
-            controlHeightSM: 28
-          }
-        }
-      }}
+    <GuidanceButtonStyleWrapper
+      className="guidance-button-wrapper"
+      size="small"
+      {...otherProps}
     >
-      <GuidanceButtonStyleWrapper
-        className="guidance-button-wrapper"
-        size="small"
-        {...otherProps}
-      >
-        <Space size={0}>{children}</Space>
-      </GuidanceButtonStyleWrapper>
-    </ConfigProvider>
+      <Space size={0}>{children}</Space>
+    </GuidanceButtonStyleWrapper>
   );
 };
 

--- a/packages/base/src/page/Home/DefaultScene/components/GuidanceButton/style.ts
+++ b/packages/base/src/page/Home/DefaultScene/components/GuidanceButton/style.ts
@@ -4,6 +4,7 @@ import { Button } from 'antd';
 export const GuidanceButtonStyleWrapper = styled(Button)`
   &.guidance-button-wrapper.ant-btn.ant-btn-sm {
     padding: 0 10px;
+    height: 28px;
   }
 
   /* default */

--- a/packages/base/src/testUtils/customRender.tsx
+++ b/packages/base/src/testUtils/customRender.tsx
@@ -6,6 +6,8 @@ import { MemoryRouter, MemoryRouterProps } from 'react-router-dom';
 import { storeFactory } from '@actiontech/shared/lib/testUtil/mockRedux';
 import lightTheme from '@actiontech/shared/lib/theme/light';
 import basePackageTheme from '../theme/light';
+import { ConfigProvider, theme as antdTheme } from 'antd';
+import zhCN from 'antd/locale/zh_CN';
 
 export type RenderParams = Parameters<typeof render>;
 
@@ -19,9 +21,14 @@ export const renderWithReduxAndTheme = (
 ) => {
   return render(ui, {
     wrapper: ({ children }) => (
-      <ThemeProvider theme={themeData}>
-        <Provider store={storeFactory(initStore)}>{children}</Provider>
-      </ThemeProvider>
+      <ConfigProvider
+        locale={zhCN}
+        theme={{ algorithm: antdTheme.defaultAlgorithm, hashed: false }}
+      >
+        <ThemeProvider theme={themeData}>
+          <Provider store={storeFactory(initStore)}>{children}</Provider>
+        </ThemeProvider>
+      </ConfigProvider>
     ),
     ...option
   });
@@ -39,11 +46,16 @@ export const superRender = (
   const renderReturn = render(ui, {
     wrapper: ({ children }) => {
       return (
-        <Provider store={storeFactory(otherProps?.initStore)}>
-          <MemoryRouter {...otherProps?.routerProps}>
-            <ThemeProvider theme={themeData}>{children}</ThemeProvider>
-          </MemoryRouter>
-        </Provider>
+        <ConfigProvider
+          locale={zhCN}
+          theme={{ algorithm: antdTheme.defaultAlgorithm, hashed: false }}
+        >
+          <Provider store={storeFactory(otherProps?.initStore)}>
+            <MemoryRouter {...otherProps?.routerProps}>
+              <ThemeProvider theme={themeData}>{children}</ThemeProvider>
+            </MemoryRouter>
+          </Provider>
+        </ConfigProvider>
       );
     },
     ...option

--- a/packages/base/vite.config.mts
+++ b/packages/base/vite.config.mts
@@ -6,7 +6,7 @@ import { createHtmlPlugin } from 'vite-plugin-html';
 import * as path from 'path';
 
 // https://vitejs.dev/config/
-export default defineConfig((config) => {
+export default defineConfig(() => {
   const buildTypes = process.env.buildType?.split(',') ?? [];
   /*
    * ee and ce mode used to support sqle

--- a/packages/shared/lib/components/ActiontechTable/Table.tsx
+++ b/packages/shared/lib/components/ActiontechTable/Table.tsx
@@ -1,9 +1,9 @@
-import { Result, ConfigProvider } from 'antd';
+import { Result } from 'antd';
 import { ActiontechTableColumn, ActiontechTableProps } from './index.type';
 import ToolBar from './components/Toolbar';
 import FilterContainer from './components/FilterContainer';
 import { useTranslation } from 'react-i18next';
-import { ActiontechTableStyleWrapper, tableToken } from './style';
+import { ActiontechTableStyleWrapper } from './style';
 import useTableAction from './hooks/useTableAction';
 import classnames from 'classnames';
 import { useEffect, useMemo, useContext } from 'react';
@@ -79,44 +79,42 @@ const ActiontechTable = <
 
       {!!filterContainerProps && <FilterContainer {...filterContainerProps} />}
 
-      <ConfigProvider theme={tableToken}>
-        <ActiontechTableStyleWrapper
-          className={classnames('actiontech-table-namespace', className)}
-          locale={{
-            emptyText: errorMessage ? (
-              <Result
-                status="error"
-                title={t('common.request.noticeFailTitle')}
-                subTitle={errorMessage}
-              />
-            ) : undefined
-          }}
-          scroll={{
-            x: 'max-content'
-          }}
-          {...props}
-          columns={innerColumns}
-          pagination={
-            !props.pagination
-              ? false
-              : {
-                  defaultPageSize: 20,
-                  showSizeChanger: true,
-                  showTotal: (total) => (
-                    <span>
-                      {t('common.actiontechTable.pagination.total', {
-                        total
-                      })}
-                    </span>
-                  ),
-                  className: classnames('actiontech-table-pagination', {
-                    'actiontech-table-pagination-fixed': isPaginationFixed
-                  }),
-                  ...props.pagination
-                }
-          }
-        />
-      </ConfigProvider>
+      <ActiontechTableStyleWrapper
+        className={classnames('actiontech-table-namespace', className)}
+        locale={{
+          emptyText: errorMessage ? (
+            <Result
+              status="error"
+              title={t('common.request.noticeFailTitle')}
+              subTitle={errorMessage}
+            />
+          ) : undefined
+        }}
+        scroll={{
+          x: 'max-content'
+        }}
+        {...props}
+        columns={innerColumns}
+        pagination={
+          !props.pagination
+            ? false
+            : {
+                defaultPageSize: 20,
+                showSizeChanger: true,
+                showTotal: (total) => (
+                  <span>
+                    {t('common.actiontechTable.pagination.total', {
+                      total
+                    })}
+                  </span>
+                ),
+                className: classnames('actiontech-table-pagination', {
+                  'actiontech-table-pagination-fixed': isPaginationFixed
+                }),
+                ...props.pagination
+              }
+        }
+      />
     </>
   );
 };

--- a/packages/shared/lib/components/ActiontechTable/components/FilterButton.tsx
+++ b/packages/shared/lib/components/ActiontechTable/components/FilterButton.tsx
@@ -33,9 +33,9 @@ const FilterButton = <T extends Record<string, any>>({
           : t('common.actiontechTable.filterButton.filter')}
 
         {hasSelectedFilter ? (
-          <UpOutlined color="currrentColor" width={14} height={14} />
+          <UpOutlined color="currentColor" width={14} height={14} />
         ) : (
-          <DownOutlined color="currrentColor" width={14} height={14} />
+          <DownOutlined color="currentColor" width={14} height={14} />
         )}
       </ColumnsSettingStyleWrapper>
     </BasicButton>

--- a/packages/shared/lib/components/ActiontechTable/components/FilterContainer.tsx
+++ b/packages/shared/lib/components/ActiontechTable/components/FilterContainer.tsx
@@ -1,4 +1,3 @@
-import { ConfigProvider } from 'antd';
 import { FilterCustomProps, TableFilterContainerProps } from '../index.type';
 import useCustomFilter from '../hooks/useCustomFilter';
 import { FilterContainerStyleWrapper } from './style';
@@ -22,71 +21,61 @@ const FilterContainer = <
   } = useCustomFilter();
 
   return (
-    <ConfigProvider
-      theme={{
-        token: {
-          fontSize: 13
-        }
-      }}
+    <FilterContainerStyleWrapper
+      size={12}
+      align="center"
+      className={classNames(
+        className,
+        'actiontech-table-filter-container-namespace full-width-element'
+      )}
+      wrap
+      hidden={filterContainerMeta.length === 0}
+      style={style}
     >
-      <FilterContainerStyleWrapper
-        size={12}
-        align="center"
-        className={classNames(
-          className,
-          'actiontech-table-filter-container-namespace full-width-element'
-        )}
-        wrap
-        hidden={filterContainerMeta.length === 0}
-        style={style}
-      >
-        {filterContainerMeta.map((value) => {
-          if (value.filterCustomType === 'select') {
-            return generateSelectFilter(
-              value,
-              updateTableFilterInfo,
-              (filterCustomProps as Map<
-                keyof T,
-                FilterCustomProps<'select'>
-              >) ?? new Map()
-            );
-          }
+      {filterContainerMeta.map((value) => {
+        if (value.filterCustomType === 'select') {
+          return generateSelectFilter(
+            value,
+            updateTableFilterInfo,
+            (filterCustomProps as Map<keyof T, FilterCustomProps<'select'>>) ??
+              new Map()
+          );
+        }
 
-          if (value.filterCustomType === 'date-range') {
-            return generateDataRangeFilter(
-              value,
-              updateTableFilterInfo,
-              (filterCustomProps as Map<
-                keyof T,
-                FilterCustomProps<'date-range'>
-              >) ?? new Map()
-            );
-          }
+        if (value.filterCustomType === 'date-range') {
+          return generateDataRangeFilter(
+            value,
+            updateTableFilterInfo,
+            (filterCustomProps as Map<
+              keyof T,
+              FilterCustomProps<'date-range'>
+            >) ?? new Map()
+          );
+        }
 
-          if (value.filterCustomType === 'input') {
-            return generateInputFilter(
-              value,
-              updateTableFilterInfo,
-              (filterCustomProps as Map<keyof T, FilterCustomProps<'input'>>) ??
-                new Map()
-            );
-          }
+        if (value.filterCustomType === 'input') {
+          return generateInputFilter(
+            value,
+            updateTableFilterInfo,
+            (filterCustomProps as Map<keyof T, FilterCustomProps<'input'>>) ??
+              new Map()
+          );
+        }
 
-          if (value.filterCustomType === 'search-input') {
-            return generateSearchInputFilter(
-              value,
-              updateTableFilterInfo,
-              (filterCustomProps as Map<
-                keyof T,
-                FilterCustomProps<'search-input'>
-              >) ?? new Map()
-            );
-          }
+        if (value.filterCustomType === 'search-input') {
+          return generateSearchInputFilter(
+            value,
+            updateTableFilterInfo,
+            (filterCustomProps as Map<
+              keyof T,
+              FilterCustomProps<'search-input'>
+            >) ?? new Map()
+          );
+        }
 
-          return null;
-        })}
-      </FilterContainerStyleWrapper>
-    </ConfigProvider>
+        return null;
+      })}
+    </FilterContainerStyleWrapper>
   );
 };
 

--- a/packages/shared/lib/components/ActiontechTable/components/TableWrapper.tsx
+++ b/packages/shared/lib/components/ActiontechTable/components/TableWrapper.tsx
@@ -17,7 +17,11 @@ const TableWrapper: React.FC<TableWrapperProps> = ({
 }) => {
   return (
     <ActiontechTableContextProvide value={restProps}>
-      <Spin spinning={loading}>{children}</Spin>
+      {typeof loading === 'boolean' ? (
+        <Spin spinning={loading}>{children}</Spin>
+      ) : (
+        children
+      )}
     </ActiontechTableContextProvide>
   );
 };

--- a/packages/shared/lib/components/ActiontechTable/components/Toolbar.tsx
+++ b/packages/shared/lib/components/ActiontechTable/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { TableToolbarProps } from '../index.type';
 import ColumnsSetting from './ColumnsSetting';
-import { Space, Spin, ConfigProvider } from 'antd';
+import { Space, Spin } from 'antd';
 import useTableAction from '../hooks/useTableAction';
 import FilterButton from './FilterButton';
 import RefreshButton from './RefreshButton';
@@ -20,7 +20,7 @@ const ToolBar = <T extends Record<string, any>>({
   className = '',
   noStyle = false,
   style,
-  loading = false
+  loading
 }: TableToolbarProps<T>) => {
   const { renderAction } = useTableAction();
 
@@ -28,37 +28,39 @@ const ToolBar = <T extends Record<string, any>>({
 
   const columnsSetting = tableContextValue?.setting ?? setting;
 
-  return (
-    <ConfigProvider
-      theme={{
-        token: {
-          fontSize: 13
-        }
-      }}
-    >
-      <Spin spinning={loading} delay={300}>
-        <ToolbarStyleWrapper
-          className={classnames(className, {
-            'full-width-element flex-space-between actiontech-table-toolbar-namespace':
-              !noStyle
-          })}
-          style={style}
-          wrap
-        >
-          <Space size={12}>
-            {children}
-            {searchInput && <SearchInput {...searchInput} />}
-            {filterButton && <FilterButton {...filterButton} />}
-          </Space>
+  const render = () => {
+    return (
+      <ToolbarStyleWrapper
+        className={classnames(className, {
+          'full-width-element flex-space-between actiontech-table-toolbar-namespace':
+            !noStyle
+        })}
+        style={style}
+        wrap
+      >
+        <Space size={12}>
+          {children}
+          {searchInput && <SearchInput {...searchInput} />}
+          {filterButton && <FilterButton {...filterButton} />}
+        </Space>
 
-          <Space size={12}>
-            {!!actions && renderAction(actions)}
-            {!!columnsSetting && <ColumnsSetting<T> {...columnsSetting} />}
-            {!!refreshButton && <RefreshButton {...refreshButton} />}
-          </Space>
-        </ToolbarStyleWrapper>
-      </Spin>
-    </ConfigProvider>
+        <Space size={12}>
+          {!!actions && renderAction(actions)}
+          {!!columnsSetting && <ColumnsSetting<T> {...columnsSetting} />}
+          {!!refreshButton && <RefreshButton {...refreshButton} />}
+        </Space>
+      </ToolbarStyleWrapper>
+    );
+  };
+
+  if (typeof loading !== 'boolean') {
+    return render();
+  }
+
+  return (
+    <Spin spinning={loading} delay={300}>
+      {render()}
+    </Spin>
   );
 };
 

--- a/packages/shared/lib/components/ActiontechTable/components/style.ts
+++ b/packages/shared/lib/components/ActiontechTable/components/style.ts
@@ -11,6 +11,17 @@ export const FilterContainerStyleWrapper = styled(Space)`
   padding: 10px 40px;
   margin-bottom: 0 !important;
 
+  & .ant-input,
+  .ant-select-selector {
+    font-size: 13px !important;
+  }
+
+  & .ant-picker-input {
+    input {
+      font-size: 13px !important;
+    }
+  }
+
   & .ant-space-item {
     padding-bottom: 0 !important;
   }
@@ -111,9 +122,25 @@ export const ToolbarStyleWrapper = styled(Space)`
     theme.sharedTheme.components.toolbar.backgroundColor};
   padding: 14px 40px;
   margin-bottom: 0 !important;
+  font-size: 13px !important;
 
   .ant-space-item {
     padding-bottom: 0 !important;
+  }
+
+  & * {
+    font-size: 13px !important;
+  }
+
+  & input,
+  & textarea,
+  & select {
+    font-size: 13px !important;
+  }
+
+  & button,
+  & .ant-btn {
+    font-size: 13px !important;
   }
 `;
 

--- a/packages/shared/lib/components/ActiontechTable/style.tsx
+++ b/packages/shared/lib/components/ActiontechTable/style.tsx
@@ -1,19 +1,6 @@
-import { ConfigProviderProps } from 'antd/es/config-provider';
 import { ACTIONTECH_TABLE_OPERATOR_COLUMN_CLS } from './hooks/useTableAction';
 import { styled } from '@mui/material/styles';
 import { Table } from 'antd';
-
-export const tableToken: ConfigProviderProps['theme'] = {
-  token: {
-    fontSize: 13,
-    fontWeightStrong: 500
-  },
-  components: {
-    Pagination: {
-      itemSize: 28
-    }
-  }
-};
 
 export const ActiontechTableStyleWrapper = styled(Table)`
   &.ant-table-wrapper.table-row-cursor {

--- a/packages/shared/lib/components/BasicButton/BasicButton.tsx
+++ b/packages/shared/lib/components/BasicButton/BasicButton.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { ConfigProvider } from 'antd';
 import { BasicButtonStyleWrapper } from './style';
 import { BasicButtonProps } from './BasicButton.types';
 
@@ -7,30 +6,18 @@ const BasicButton: React.FC<BasicButtonProps> = (props) => {
   const { children, className, noBorderIcon, ...otherParams } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Button: {
-            controlHeight: 32,
-            controlHeightLG: 36,
-            controlHeightSM: 28
-          }
-        }
-      }}
+    <BasicButtonStyleWrapper
+      className={classnames(
+        {
+          'btn-icon-no-border': noBorderIcon
+        },
+        className,
+        'basic-button-wrapper'
+      )}
+      {...otherParams}
     >
-      <BasicButtonStyleWrapper
-        className={classnames(
-          {
-            'btn-icon-no-border': noBorderIcon
-          },
-          className,
-          'basic-button-wrapper'
-        )}
-        {...otherParams}
-      >
-        {children}
-      </BasicButtonStyleWrapper>
-    </ConfigProvider>
+      {children}
+    </BasicButtonStyleWrapper>
   );
 };
 

--- a/packages/shared/lib/components/BasicDatePicker/BasicDatePicker.tsx
+++ b/packages/shared/lib/components/BasicDatePicker/BasicDatePicker.tsx
@@ -1,9 +1,8 @@
 import { useRef } from 'react';
 import { BasicDatePickerFieldStyleWrapper } from './style';
 import { useBoolean } from 'ahooks';
-import { DatePicker, ConfigProvider } from 'antd';
+import { DatePicker } from 'antd';
 import classnames from 'classnames';
-import { ComponentControlHeight } from '../../data/common';
 import {
   UpOutlined,
   ClockCircleFilled,
@@ -24,51 +23,39 @@ const BasicDatePicker: React.FC<BasicDatePickerProps> = ({
   const ref = useRef<HTMLDivElement | null>(null);
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          DatePicker: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
-        }
-      }}
+    <BasicDatePickerFieldStyleWrapper
+      ref={ref}
+      hideSuperIcon={hideSuperIcon}
+      className={classnames('basic-date-picker-wrapper', className)}
     >
-      <BasicDatePickerFieldStyleWrapper
-        ref={ref}
-        hideSuperIcon={hideSuperIcon}
-        className={classnames('basic-date-picker-wrapper', className)}
-      >
-        <ClockCircleFilled
-          fill="currentColor"
-          width={18}
-          height={18}
-          className="prefix-icon"
-        />
-        <DatePicker
-          {...otherProps}
-          suffixIcon={!open ? <DownOutlined /> : <UpOutlined />}
-          onOpenChange={(data: boolean) => {
-            set(data);
-            onOpenChange?.(data);
-          }}
-          getPopupContainer={() => {
-            return ref.current!;
-          }}
-          nextIcon={
-            <span className="next-icon">
-              <RightOutlined width={14} height={14} />
-            </span>
-          }
-          prevIcon={
-            <span className="prev-icon">
-              <LeftOutlined width={14} height={14} />
-            </span>
-          }
-        />
-      </BasicDatePickerFieldStyleWrapper>
-    </ConfigProvider>
+      <ClockCircleFilled
+        fill="currentColor"
+        width={18}
+        height={18}
+        className="prefix-icon"
+      />
+      <DatePicker
+        {...otherProps}
+        suffixIcon={!open ? <DownOutlined /> : <UpOutlined />}
+        onOpenChange={(data: boolean) => {
+          set(data);
+          onOpenChange?.(data);
+        }}
+        getPopupContainer={() => {
+          return ref.current!;
+        }}
+        nextIcon={
+          <span className="next-icon">
+            <RightOutlined width={14} height={14} />
+          </span>
+        }
+        prevIcon={
+          <span className="prev-icon">
+            <LeftOutlined width={14} height={14} />
+          </span>
+        }
+      />
+    </BasicDatePickerFieldStyleWrapper>
   );
 };
 

--- a/packages/shared/lib/components/BasicInput/Input.tsx
+++ b/packages/shared/lib/components/BasicInput/Input.tsx
@@ -1,10 +1,9 @@
-import { InputProps, ConfigProvider } from 'antd';
+import { InputProps } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { InputRef } from 'antd';
 import { forwardRef } from 'react';
 import classnames from 'classnames';
 import { StyleComponent } from './style';
-import { ComponentControlHeight } from '../../data/common';
 import { CloseOutlined } from '@actiontech/icons';
 
 const Wrapper = StyleComponent('Input');
@@ -17,33 +16,21 @@ const InternalInput: React.ForwardRefRenderFunction<InputRef, InputProps> = (
   const { className, allowClear, ...otherParams } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Input: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
-        }
-      }}
-    >
-      <Wrapper
-        className={classnames('basic-input-wrapper', className)}
-        ref={ref}
-        placeholder={t('common.form.placeholder.input')}
-        {...otherParams}
-        allowClear={
-          allowClear
-            ? {
-                clearIcon: (
-                  <CloseOutlined width={14} height={14} fill="currentColor" />
-                )
-              }
-            : false
-        }
-      />
-    </ConfigProvider>
+    <Wrapper
+      className={classnames('basic-input-wrapper', className)}
+      ref={ref}
+      placeholder={t('common.form.placeholder.input')}
+      {...otherParams}
+      allowClear={
+        allowClear
+          ? {
+              clearIcon: (
+                <CloseOutlined width={14} height={14} fill="currentColor" />
+              )
+            }
+          : false
+      }
+    />
   );
 };
 

--- a/packages/shared/lib/components/BasicInput/Password.tsx
+++ b/packages/shared/lib/components/BasicInput/Password.tsx
@@ -1,9 +1,7 @@
-import { ConfigProvider } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { forwardRef } from 'react';
 import classnames from 'classnames';
 import { StyleComponent } from './style';
-import { ComponentControlHeight } from '../../data/common';
 import { InputRef, PasswordProps } from 'antd/es/input';
 
 const Wrapper = StyleComponent('Password');
@@ -16,24 +14,12 @@ const InternalPassword: React.ForwardRefRenderFunction<
   const { className, ...otherParams } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Input: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
-        }
-      }}
-    >
-      <Wrapper
-        className={classnames('basic-input-wrapper', className)}
-        ref={ref}
-        placeholder={t('common.form.placeholder.input')}
-        {...otherParams}
-      />
-    </ConfigProvider>
+    <Wrapper
+      className={classnames('basic-input-wrapper', className)}
+      ref={ref}
+      placeholder={t('common.form.placeholder.input')}
+      {...otherParams}
+    />
   );
 };
 

--- a/packages/shared/lib/components/BasicInput/TextArea.tsx
+++ b/packages/shared/lib/components/BasicInput/TextArea.tsx
@@ -1,9 +1,7 @@
-import { ConfigProvider } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { forwardRef } from 'react';
 import classnames from 'classnames';
 import { StyleComponent } from './style';
-import { ComponentControlHeight } from '../../data/common';
 import { TextAreaProps } from 'antd/es/input';
 import { TextAreaRef } from 'antd/es/input/TextArea';
 
@@ -17,24 +15,12 @@ const InternalTextArea: React.ForwardRefRenderFunction<
   const { className, ...otherParams } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Input: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
-        }
-      }}
-    >
-      <Wrapper
-        className={classnames('basic-input-wrapper', className)}
-        ref={ref}
-        placeholder={t('common.form.placeholder.input')}
-        {...otherParams}
-      />
-    </ConfigProvider>
+    <Wrapper
+      className={classnames('basic-input-wrapper', className)}
+      ref={ref}
+      placeholder={t('common.form.placeholder.input')}
+      {...otherParams}
+    />
   );
 };
 

--- a/packages/shared/lib/components/BasicInputNumber/BasicInputNumber.tsx
+++ b/packages/shared/lib/components/BasicInputNumber/BasicInputNumber.tsx
@@ -1,30 +1,16 @@
 import classnames from 'classnames';
 import { BasicInputNumberStyleWrapper } from './style';
-import { ComponentControlHeight } from '../../data/common';
 import { BasicInputNumberProps } from './BasicInputNumber.types';
-import { ConfigProvider } from 'antd';
 
 const BasicInputNumber: React.FC<BasicInputNumberProps> = (props) => {
   const { className, ...params } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          InputNumber: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
-        }
-      }}
-    >
-      <BasicInputNumberStyleWrapper
-        size="large"
-        className={classnames('basic-inputNumber-wrapper', className)}
-        {...params}
-      />
-    </ConfigProvider>
+    <BasicInputNumberStyleWrapper
+      size="large"
+      className={classnames('basic-inputNumber-wrapper', className)}
+      {...params}
+    />
   );
 };
 

--- a/packages/shared/lib/components/BasicRangePicker/BasicRangePicker.tsx
+++ b/packages/shared/lib/components/BasicRangePicker/BasicRangePicker.tsx
@@ -1,7 +1,5 @@
-import { ConfigProvider } from 'antd';
 import classnames from 'classnames';
 import { BasicRangePickerStyleWrapper } from './style';
-import { ComponentControlHeight } from '../../data/common';
 import { BasicDatePickerDropDownStyleWrapper } from '../BasicDatePicker/style';
 import { CloseOutlined, RightOutlined, LeftOutlined } from '@actiontech/icons';
 import { BasicRangePickerProps } from './BasicRangePicker.types';
@@ -16,48 +14,34 @@ const BasicRangePicker: React.FC<BasicRangePickerProps> = (props) => {
   } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          DatePicker: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
+    <BasicDatePickerDropDownStyleWrapper hideSuperIcon={hideSuperIcon}>
+      <BasicRangePickerStyleWrapper
+        className={classnames('basic-range-picker-wrapper', className, {
+          'custom-picker-prefix': !suffixIcon && !!prefix
+        })}
+        {...otherParams}
+        /**
+         * when both suffixIcon and prefix exist, the former will force the latter to be overwritten
+         */
+        suffixIcon={suffixIcon ?? prefix}
+        //todo allowClear={{clearIcon: <IconClose />}} need antd 5.8.0
+        clearIcon={<CloseOutlined fill="currentColor" />}
+        separator={<RightOutlined width={14} height={14} fill="currentColor" />}
+        getPopupContainer={(trigger) => {
+          return trigger;
+        }}
+        nextIcon={
+          <span className="next-icon">
+            <RightOutlined width={14} height={14} />
+          </span>
         }
-      }}
-    >
-      <BasicDatePickerDropDownStyleWrapper hideSuperIcon={hideSuperIcon}>
-        <BasicRangePickerStyleWrapper
-          className={classnames('basic-range-picker-wrapper', className, {
-            'custom-picker-prefix': !suffixIcon && !!prefix
-          })}
-          {...otherParams}
-          /**
-           * when both suffixIcon and prefix exist, the former will force the latter to be overwritten
-           */
-          suffixIcon={suffixIcon ?? prefix}
-          //todo allowClear={{clearIcon: <IconClose />}} need antd 5.8.0
-          clearIcon={<CloseOutlined fill="currentColor" />}
-          separator={
-            <RightOutlined width={14} height={14} fill="currentColor" />
-          }
-          getPopupContainer={(trigger) => {
-            return trigger;
-          }}
-          nextIcon={
-            <span className="next-icon">
-              <RightOutlined width={14} height={14} />
-            </span>
-          }
-          prevIcon={
-            <span className="prev-icon">
-              <LeftOutlined width={14} height={14} />
-            </span>
-          }
-        />
-      </BasicDatePickerDropDownStyleWrapper>
-    </ConfigProvider>
+        prevIcon={
+          <span className="prev-icon">
+            <LeftOutlined width={14} height={14} />
+          </span>
+        }
+      />
+    </BasicDatePickerDropDownStyleWrapper>
   );
 };
 

--- a/packages/shared/lib/components/BasicSelect/BasicSelect.tsx
+++ b/packages/shared/lib/components/BasicSelect/BasicSelect.tsx
@@ -1,8 +1,6 @@
-import { ConfigProvider } from 'antd';
 import { useTranslation } from 'react-i18next';
 import classnames from 'classnames';
 import { BasicSelectStyleWrapper } from './style';
-import { ComponentControlHeight } from '../../data/common';
 import BasicEmpty from '../BasicEmpty/BasicEmpty';
 import { CloseOutlined } from '@actiontech/icons';
 import { BasicSelectProps } from './BasicSelect.types';
@@ -12,39 +10,27 @@ const BasicSelect = <V = string,>(props: BasicSelectProps<V>) => {
   const { className, allowClear, loading, ...otherParams } = props;
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Select: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
-        }
-      }}
-    >
-      <BasicSelectStyleWrapper
-        className={classnames('basic-select-wrapper', className)}
-        placeholder={t('common.form.placeholder.select')}
-        notFoundContent={
-          loading ? <BasicEmpty loading={loading} /> : <BasicEmpty />
-        }
-        {...otherParams}
-        clearIcon={<CloseOutlined width={14} height={14} fill="currentColor" />}
-        allowClear={allowClear}
-        loading={loading}
-        //ts checker error
-        // allowClear={
-        //   !!allowClear
-        //     ? {
-        //         clearIcon: (
-        //           <IconClose  />
-        //         )
-        //       }
-        //     : false
-        // }
-      />
-    </ConfigProvider>
+    <BasicSelectStyleWrapper
+      className={classnames('basic-select-wrapper', className)}
+      placeholder={t('common.form.placeholder.select')}
+      notFoundContent={
+        loading ? <BasicEmpty loading={loading} /> : <BasicEmpty />
+      }
+      {...otherParams}
+      clearIcon={<CloseOutlined width={14} height={14} fill="currentColor" />}
+      allowClear={allowClear}
+      loading={loading}
+      //ts checker error
+      // allowClear={
+      //   !!allowClear
+      //     ? {
+      //         clearIcon: (
+      //           <IconClose  />
+      //         )
+      //       }
+      //     : false
+      // }
+    />
   );
 };
 

--- a/packages/shared/lib/components/BasicTable/BasicTable.tsx
+++ b/packages/shared/lib/components/BasicTable/BasicTable.tsx
@@ -1,11 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import { Result, ConfigProvider } from 'antd';
+import { Result } from 'antd';
 import classnames from 'classnames';
-
-import {
-  tableToken,
-  ActiontechTableStyleWrapper
-} from '../ActiontechTable/style';
+import { ActiontechTableStyleWrapper } from '../ActiontechTable/style';
 import { BasicTableProps } from './BasicTable.types';
 
 const BasicTable = <T extends Record<string, any>>({
@@ -17,43 +13,41 @@ const BasicTable = <T extends Record<string, any>>({
   const { t } = useTranslation();
 
   return (
-    <ConfigProvider theme={tableToken}>
-      <ActiontechTableStyleWrapper
-        className={classnames('actiontech-table-namespace', className)}
-        locale={{
-          emptyText: errorMessage ? (
-            <Result
-              status="error"
-              title={t('common.request.noticeFailTitle')}
-              subTitle={errorMessage}
-            />
-          ) : undefined
-        }}
-        scroll={{
-          x: 'max-content'
-        }}
-        {...props}
-        pagination={
-          !props.pagination
-            ? false
-            : {
-                defaultPageSize: 20,
-                showSizeChanger: true,
-                showTotal: (total) => (
-                  <span>
-                    {t('common.actiontechTable.pagination.total', {
-                      total
-                    })}
-                  </span>
-                ),
-                className: classnames('actiontech-table-pagination', {
-                  'actiontech-table-pagination-fixed': isPaginationFixed
-                }),
-                ...props.pagination
-              }
-        }
-      />
-    </ConfigProvider>
+    <ActiontechTableStyleWrapper
+      className={classnames('actiontech-table-namespace', className)}
+      locale={{
+        emptyText: errorMessage ? (
+          <Result
+            status="error"
+            title={t('common.request.noticeFailTitle')}
+            subTitle={errorMessage}
+          />
+        ) : undefined
+      }}
+      scroll={{
+        x: 'max-content'
+      }}
+      {...props}
+      pagination={
+        !props.pagination
+          ? false
+          : {
+              defaultPageSize: 20,
+              showSizeChanger: true,
+              showTotal: (total) => (
+                <span>
+                  {t('common.actiontechTable.pagination.total', {
+                    total
+                  })}
+                </span>
+              ),
+              className: classnames('actiontech-table-pagination', {
+                'actiontech-table-pagination-fixed': isPaginationFixed
+              }),
+              ...props.pagination
+            }
+      }
+    />
   );
 };
 

--- a/packages/shared/lib/components/BasicTreeSelect/BasicTreeSelect.tsx
+++ b/packages/shared/lib/components/BasicTreeSelect/BasicTreeSelect.tsx
@@ -1,7 +1,5 @@
-import { ConfigProvider } from 'antd';
 import { useTranslation } from 'react-i18next';
 import classnames from 'classnames';
-import { ComponentControlHeight } from '../../data/common';
 import BasicEmpty from '../BasicEmpty/BasicEmpty';
 import { CloseOutlined, DownOutlined, RightOutlined } from '@actiontech/icons';
 import {
@@ -32,36 +30,24 @@ const BasicTreeSelect = <V extends string | number>(
   };
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Select: {
-            controlHeight: ComponentControlHeight.default,
-            controlHeightLG: ComponentControlHeight.lg,
-            controlHeightSM: ComponentControlHeight.sm
-          }
+    <BasicTreeSelectStyleWrapper
+      className={classnames('basic-tree-select-wrapper', className)}
+      placeholder={t('common.form.placeholder.select')}
+      notFoundContent={
+        loading ? <BasicEmpty loading={loading} /> : <BasicEmpty />
+      }
+      switcherIcon={({ expanded }: AntTreeNodeProps) => {
+        if (expanded) {
+          return <DownOutlined color="currentColor" />;
         }
+        return <RightOutlined />;
       }}
-    >
-      <BasicTreeSelectStyleWrapper
-        className={classnames('basic-tree-select-wrapper', className)}
-        placeholder={t('common.form.placeholder.select')}
-        notFoundContent={
-          loading ? <BasicEmpty loading={loading} /> : <BasicEmpty />
-        }
-        switcherIcon={({ expanded }: AntTreeNodeProps) => {
-          if (expanded) {
-            return <DownOutlined color="currentColor" />;
-          }
-          return <RightOutlined />;
-        }}
-        {...otherParams}
-        clearIcon={<CloseOutlined width={14} height={14} />}
-        allowClear={allowClear}
-        loading={loading}
-        dropdownRender={renderDropdown}
-      />
-    </ConfigProvider>
+      {...otherParams}
+      clearIcon={<CloseOutlined width={14} height={14} />}
+      allowClear={allowClear}
+      loading={loading}
+      dropdownRender={renderDropdown}
+    />
   );
 };
 

--- a/packages/shared/lib/testUtil/customRender.tsx
+++ b/packages/shared/lib/testUtil/customRender.tsx
@@ -93,7 +93,7 @@ export const renderHooksWithTheme = <TProps, TResult>(
     wrapper: ({ children }) => (
       <ConfigProvider
         locale={zhCN}
-        theme={{ algorithm: antdTheme.defaultAlgorithm }}
+        theme={{ algorithm: antdTheme.defaultAlgorithm, hashed: false }}
       >
         <StyledEngineProvider injectFirst>
           <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
@@ -133,13 +133,18 @@ export const superRender = (
   const renderReturn = render(ui, {
     wrapper: ({ children }) => {
       return (
-        <RecoilRoot {...otherProps?.recoilRootProps}>
-          <Provider store={storeFactory(otherProps?.initStore)}>
-            <MemoryRouter {...otherProps?.routerProps}>
-              <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
-            </MemoryRouter>
-          </Provider>
-        </RecoilRoot>
+        <ConfigProvider
+          locale={zhCN}
+          theme={{ algorithm: antdTheme.defaultAlgorithm, hashed: false }}
+        >
+          <RecoilRoot {...otherProps?.recoilRootProps}>
+            <Provider store={storeFactory(otherProps?.initStore)}>
+              <MemoryRouter {...otherProps?.routerProps}>
+                <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+              </MemoryRouter>
+            </Provider>
+          </RecoilRoot>
+        </ConfigProvider>
       );
     },
     ...option

--- a/packages/sqle/src/components/ChartCom/TableTopList/index.tsx
+++ b/packages/sqle/src/components/ChartCom/TableTopList/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { ReactNode } from 'react';
-import { Table, ConfigProvider, TableProps } from 'antd';
+import { Table, TableProps } from 'antd';
 import Icon from '@ant-design/icons/lib/components/Icon';
 import useThemeStyleData from '../../../hooks/useThemeStyleData';
 import { TableTopListStyleWrapper } from './style';
@@ -34,59 +34,48 @@ const TableTopList = <T extends Record<string, any>>(
   const dataLength = dataSource?.length ?? 0;
 
   return (
-    <ConfigProvider
-      theme={{
-        token: {
-          colorFillQuaternary:
-            sqleTheme.reportStatistics.TableTopList.colorFillQuaternary
-        }
-      }}
-    >
-      <TableTopListStyleWrapper className="report-base-table-wrapper">
-        <Table
-          className={classNames('report-base-table', {
-            'has-table-cont-style':
-              typeof hideTop3Style === 'boolean'
-                ? !hideTop3Style
-                : !!dataLength,
-            'no-table-data-style': !dataLength
-          })}
-          rowKey={rowKey}
-          dataSource={dataSource}
-          loading={{
-            spinning: apiLoading,
-            indicator: (
-              <Icon
-                component={() => <SpinIndicator />}
-                style={{
-                  color: sqleTheme.reportStatistics.loadingColor
-                }}
-              />
-            )
-          }}
-          pagination={false}
-          locale={{
-            emptyText: () => (
-              <BasicEmpty
-                loading={apiLoading}
-                emptyCont={emptyCont}
-                errorInfo={errorCont}
-                dataLength={dataLength}
-                onRefresh={onRefresh}
-              />
-            )
-          }}
-          columns={columns}
-          scroll={scroll}
-        />
-        <div
-          hidden={dataLength === 0 || dataLength === 10}
-          className="data-bottom-tip"
-        >
-          {t('reportStatistics.tableTopList.noMoreData')}
-        </div>
-      </TableTopListStyleWrapper>
-    </ConfigProvider>
+    <TableTopListStyleWrapper className="report-base-table-wrapper">
+      <Table
+        className={classNames('report-base-table', {
+          'has-table-cont-style':
+            typeof hideTop3Style === 'boolean' ? !hideTop3Style : !!dataLength,
+          'no-table-data-style': !dataLength
+        })}
+        rowKey={rowKey}
+        dataSource={dataSource}
+        loading={{
+          spinning: apiLoading,
+          indicator: (
+            <Icon
+              component={() => <SpinIndicator />}
+              style={{
+                color: sqleTheme.reportStatistics.loadingColor
+              }}
+            />
+          )
+        }}
+        pagination={false}
+        locale={{
+          emptyText: () => (
+            <BasicEmpty
+              loading={apiLoading}
+              emptyCont={emptyCont}
+              errorInfo={errorCont}
+              dataLength={dataLength}
+              onRefresh={onRefresh}
+            />
+          )
+        }}
+        columns={columns}
+        scroll={scroll}
+      />
+      <div
+        hidden={dataLength === 0 || dataLength === 10}
+        className="data-bottom-tip"
+      >
+        {t('reportStatistics.tableTopList.noMoreData')}
+      </div>
+    </TableTopListStyleWrapper>
   );
 };
 

--- a/packages/sqle/src/page/ProjectOverview/index.tsx
+++ b/packages/sqle/src/page/ProjectOverview/index.tsx
@@ -1,8 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import { ConfigProvider, Space, Row, Col } from 'antd';
+import { Space, Row, Col } from 'antd';
 import { PageHeader, EmptyBox } from '@actiontech/shared';
 import { SyncOutlined } from '@ant-design/icons';
-import useThemeStyleData from '../../hooks/useThemeStyleData';
 import { OverviewStyleWrapper } from './style';
 import ProjectScore from './component/ProjectScore';
 import SqlCount from './component/SqlCount';
@@ -21,7 +20,6 @@ import {
 
 const Overview = () => {
   const { t } = useTranslation();
-  const { sqleTheme } = useThemeStyleData();
   const { projectID } = useCurrentProject();
 
   const { moduleFeatureSupport } = usePermission();
@@ -35,17 +33,7 @@ const Overview = () => {
   }, [onRefreshPage, projectID]);
 
   return (
-    <ConfigProvider
-      theme={{
-        token: {
-          padding: 20,
-          paddingLG: 20,
-          paddingSM: 20,
-          paddingXS: 20,
-          colorBgContainer: sqleTheme.reportStatistics.bgColor
-        }
-      }}
-    >
+    <>
       <PageHeader
         fixed
         title={
@@ -131,7 +119,7 @@ const Overview = () => {
           </Col>
         </Row>
       </OverviewStyleWrapper>
-    </ConfigProvider>
+    </>
   );
 };
 

--- a/packages/sqle/src/page/ProjectOverview/style.ts
+++ b/packages/sqle/src/page/ProjectOverview/style.ts
@@ -6,6 +6,14 @@ export const OverviewStyleWrapper = styled('section')`
   background-color: ${({ theme }) =>
     theme.sharedTheme.uiToken.colorFillTertiary};
 
+  .item-wrapper {
+    & .ant-card {
+      .ant-card-body {
+        padding: 20px;
+      }
+    }
+  }
+
   .marginTop20 {
     margin-top: 20px;
   }

--- a/packages/sqle/src/page/ReportStatistics/EEIndex/component/base/CardShow/index.tsx
+++ b/packages/sqle/src/page/ReportStatistics/EEIndex/component/base/CardShow/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { CardProps, Statistic, ConfigProvider } from 'antd';
+import { CardProps, Statistic } from 'antd';
 import useThemeStyleData from '../../../../../../hooks/useThemeStyleData';
 import { CardShowStyleWrapper } from './style';
 
@@ -17,41 +17,32 @@ const CardShow = (props: ICardShowProps) => {
   const { sqleTheme } = useThemeStyleData();
 
   return (
-    <ConfigProvider
-      theme={{
-        components: {
-          Statistic: {
-            contentFontSize: sqleTheme.reportStatistics.cardShow.contentFontSize
-          }
-        }
-      }}
-    >
-      <CardShowStyleWrapper hoverable bordered={false}>
-        <header className="card-title">
-          <span className="title-cont">{titleCont}</span>
-          <span className="title-extra">{extraIcon ?? null}</span>
-        </header>
-        <section className="card-cont">
-          <div className="number-cont">
-            {typeof numberCont === 'number' ? (
-              <Statistic
-                value={numberCont ?? defaultNumber}
-                valueStyle={{
-                  fontWeight:
-                    sqleTheme.reportStatistics.cardShow.contentFontWeight,
-                  height: '40px',
-                  lineHeight: '40px',
-                  color: sqleTheme.reportStatistics.cardShow.numberContColor
-                }}
-              />
-            ) : (
-              numberCont ?? defaultNumber
-            )}
-          </div>
-          <div className="note-cont">{noteCont}</div>
-        </section>
-      </CardShowStyleWrapper>
-    </ConfigProvider>
+    <CardShowStyleWrapper hoverable bordered={false}>
+      <header className="card-title">
+        <span className="title-cont">{titleCont}</span>
+        <span className="title-extra">{extraIcon ?? null}</span>
+      </header>
+      <section className="card-cont">
+        <div className="number-cont">
+          {typeof numberCont === 'number' ? (
+            <Statistic
+              value={numberCont ?? defaultNumber}
+              valueStyle={{
+                fontWeight:
+                  sqleTheme.reportStatistics.cardShow.contentFontWeight,
+                height: '40px',
+                lineHeight: '40px',
+                color: sqleTheme.reportStatistics.cardShow.numberContColor,
+                fontSize: `${sqleTheme.reportStatistics.cardShow.contentFontSize}px`
+              }}
+            />
+          ) : (
+            numberCont ?? defaultNumber
+          )}
+        </div>
+        <div className="note-cont">{noteCont}</div>
+      </section>
+    </CardShowStyleWrapper>
   );
 };
 

--- a/packages/sqle/src/page/ReportStatistics/index.tsx
+++ b/packages/sqle/src/page/ReportStatistics/index.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { ConfigProvider, Typography } from 'antd';
-import useThemeStyleData from '../../hooks/useThemeStyleData';
+import { Typography } from 'antd';
 
 import { EnterpriseFeatureDisplay, PageHeader } from '@actiontech/shared';
 import { ReportStatisticsEEIndexStyleWrapper } from './style';
@@ -9,37 +8,24 @@ import EEIndex from './EEIndex';
 
 const ReportStatistics = () => {
   const { t } = useTranslation();
-  const { sqleTheme } = useThemeStyleData();
 
   return (
-    <ConfigProvider
-      theme={{
-        token: {
-          padding: 20,
-          paddingLG: 20,
-          paddingSM: 20,
-          paddingXS: 20,
-          colorBgContainer: sqleTheme.reportStatistics.bgColor
-        }
-      }}
-    >
-      <ReportStatisticsEEIndexStyleWrapper>
-        {/* #if [ce] */}
-        <PageHeader title={t('reportStatistics.title')} />
-        {/* #endif */}
+    <ReportStatisticsEEIndexStyleWrapper>
+      {/* #if [ce] */}
+      <PageHeader title={t('reportStatistics.title')} />
+      {/* #endif */}
 
-        <EnterpriseFeatureDisplay
-          featureName={t('reportStatistics.title')}
-          eeFeatureDescription={
-            <Typography.Paragraph className="paragraph">
-              {t('reportStatistics.ce.feature.desc')}
-            </Typography.Paragraph>
-          }
-        >
-          <EEIndex />
-        </EnterpriseFeatureDisplay>
-      </ReportStatisticsEEIndexStyleWrapper>
-    </ConfigProvider>
+      <EnterpriseFeatureDisplay
+        featureName={t('reportStatistics.title')}
+        eeFeatureDescription={
+          <Typography.Paragraph className="paragraph">
+            {t('reportStatistics.ce.feature.desc')}
+          </Typography.Paragraph>
+        }
+      >
+        <EEIndex />
+      </EnterpriseFeatureDisplay>
+    </ReportStatisticsEEIndexStyleWrapper>
   );
 };
 

--- a/packages/sqle/src/page/ReportStatistics/style.ts
+++ b/packages/sqle/src/page/ReportStatistics/style.ts
@@ -17,6 +17,12 @@ export const EEIndexStyleWrapper = styled('section')`
     width: 100%;
     height: 100%;
 
+    & .ant-card {
+      .ant-card-body {
+        padding: 20px;
+      }
+    }
+
     &.card-wrapper {
       height: 170px;
     }

--- a/packages/sqle/src/testUtils/customRender.tsx
+++ b/packages/sqle/src/testUtils/customRender.tsx
@@ -75,7 +75,7 @@ export const renderHooksWithTheme = <TProps, TResult>(
     wrapper: ({ children }) => (
       <ConfigProvider
         locale={zhCN}
-        theme={{ algorithm: antdTheme.defaultAlgorithm }}
+        theme={{ algorithm: antdTheme.defaultAlgorithm, hashed: false }}
       >
         <StyledEngineProvider injectFirst>
           <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
@@ -145,13 +145,18 @@ export const superRender = (
   const renderReturn = render(ui, {
     wrapper: ({ children }) => {
       return (
-        <Provider store={storeFactory(otherProps?.initStore)}>
-          <MemoryRouter {...otherProps?.routerProps}>
-            <StyledEngineProvider injectFirst>
-              <ThemeProvider theme={themeData}>{children}</ThemeProvider>
-            </StyledEngineProvider>
-          </MemoryRouter>
-        </Provider>
+        <ConfigProvider
+          locale={zhCN}
+          theme={{ algorithm: antdTheme.defaultAlgorithm, hashed: false }}
+        >
+          <Provider store={storeFactory(otherProps?.initStore)}>
+            <MemoryRouter {...otherProps?.routerProps}>
+              <StyledEngineProvider injectFirst>
+                <ThemeProvider theme={themeData}>{children}</ThemeProvider>
+              </StyledEngineProvider>
+            </MemoryRouter>
+          </Provider>
+        </ConfigProvider>
       );
     },
     ...option


### PR DESCRIPTION
basefrom https://github.com/actiontech/dms-ui/pull/620


1. 重构 ConfigProvider 配置管理
   - 移除各组件和页面中分散的 ConfigProvider 组件
   - 统一将配置集中到根组件 App.tsx

2. 优化单元测试配置
   - 在测试用例 render 方法中统一配置 `ConfigProvider` 
   - 设置 `hashed: false` 以移除开发环境的 CSS hash 值