### PR TITLE
[fix](auth): not redirect to login and clean  user when current path is login

### DIFF
--- a/packages/shared/lib/api/common/authInvalid/index.ts
+++ b/packages/shared/lib/api/common/authInvalid/index.ts
@@ -30,6 +30,14 @@ class AuthManager {
   redirectToLogin = () => {
     const currentPath = window.location.pathname;
     const currentSearch = window.location.search;
+
+    store.dispatch(updateToken({ token: '' }));
+    store.dispatch(updateUser({ username: '', role: '' }));
+    store.dispatch(updateUserUid({ uid: '' }));
+    store.dispatch(updateManagementPermissions({ managementPermissions: [] }));
+    store.dispatch(updateBindProjects({ bindProjects: [] }));
+    store.dispatch(updateUserInfoFetchStatus(false));
+
     if (currentPath === '/login') {
       return;
     }
@@ -38,13 +46,6 @@ class AuthManager {
     window.location.href = `/login?${DMS_REDIRECT_KEY_PARAMS_NAME}=${encodeURIComponent(
       targetUrl
     )}`;
-
-    store.dispatch(updateToken({ token: '' }));
-    store.dispatch(updateUser({ username: '', role: '' }));
-    store.dispatch(updateUserUid({ uid: '' }));
-    store.dispatch(updateManagementPermissions({ managementPermissions: [] }));
-    store.dispatch(updateBindProjects({ bindProjects: [] }));
-    store.dispatch(updateUserInfoFetchStatus(false));
   };
 
   refreshAuthToken = () => {


### PR DESCRIPTION
fix issue: https://github.com/actiontech/sqle-ee/issues/2361

修复当前 path 为 login ， token 过期并且 refresh token 报错的情况下未清空 token 等数据的问题