### PR TITLE
fix(dms-kit): add defensive type check in useTableRequestError

### DIFF
--- a/packages/dms-kit/src/components/ActiontechTable/hooks/useTableRequestError.tsx
+++ b/packages/dms-kit/src/components/ActiontechTable/hooks/useTableRequestError.tsx
@@ -18,6 +18,15 @@ const useTableRequestError = () => {
     return request
       .then((response) => {
         setRequestErrorMessage('');
+        if (
+          typeof response.data !== 'object' ||
+          response.data === null
+        ) {
+          setRequestErrorMessage(
+            'Unexpected response format: expected JSON but received non-object data'
+          );
+          return { list: [], total: 0, otherData: {} };
+        }
         if ('data' in response.data && 'total_nums' in response.data) {
           const { data, total_nums, ...otherData } = response.data;
           return {


### PR DESCRIPTION
## Summary

- Add defensive type check in `useTableRequestError` hook to prevent crash when API returns non-JSON response
- Returns empty list fallback instead of throwing when response data is not an object

Related: https://github.com/actiontech/dms-ee/issues/787