### PR TITLE
fix: make password field optional for creating data source

### DIFF
--- a/packages/base/src/page/DataSource/components/Form/FormItem/index.tsx
+++ b/packages/base/src/page/DataSource/components/Form/FormItem/index.tsx
@@ -162,7 +162,9 @@ const DatabaseFormItem: React.FC<{
         </FormItemLabel>
       </EmptyBox>
       <FormItemLabel
-        className="has-required-style"
+        className={
+          props.isUpdate && needUpdatePassword ? 'has-required-style' : ''
+        }
         label={
           props.isUpdate
             ? t('dmsDataSource.dataSourceForm.updatePassword')
@@ -171,7 +173,7 @@ const DatabaseFormItem: React.FC<{
         name="password"
         rules={[
           {
-            required: (props.isUpdate && needUpdatePassword) || !props.isUpdate,
+            required: props.isUpdate && needUpdatePassword,
             message: t('common.form.rule.require', {
               name: t('dmsDataSource.dataSourceForm.password')
             })


### PR DESCRIPTION
## Summary
- Make password field optional (not required) when creating a new data source
- Keep required validation only when updating password on existing data source

Fixes https://github.com/actiontech/sqle-ee/issues/2738