### PR TITLE
feat(globalDashboard): add view_all enum, i18n and card to WorkflowPanel

### DIFF
--- a/packages/sqle/src/page/GlobalDashboard/__tests__/__snapshots__/index.sqle.test.tsx.snap
+++ b/packages/sqle/src/page/GlobalDashboard/__tests__/__snapshots__/index.sqle.test.tsx.snap
@@ -343,6 +343,45 @@ exports[`GlobalDashboard should render workflow tab by default 1`] = `
               已完结任务
             </div>
           </div>
+          <div
+            class="css-yrdq2f"
+          >
+            <div
+              class="stat-card-title"
+            >
+              查看全部
+            </div>
+            <div
+              class="stat-card-count-row"
+            >
+              <span
+                class="stat-card-icon"
+              >
+                <svg
+                  color="currentColor"
+                  height="20"
+                  viewBox="0 0 16 16"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M4.667 4.667V2a.667.667 0 0 1 .666-.667H14a.667.667 0 0 1 .667.667v8.667a.667.667 0 0 1-.667.667h-2.667v2.662c0 .37-.3.67-.671.67H2.005a.67.67 0 0 1-.672-.67l.002-8.658c0-.37.3-.671.672-.671zm1.333 0h4.662c.37 0 .671.3.671.671V10h2V2.667H6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+              <span
+                class="stat-card-count"
+              >
+                25
+              </span>
+            </div>
+            <div
+              class="stat-card-subtitle"
+            >
+              当前可见范围
+            </div>
+          </div>
         </div>
         <div
           class="ant-spin-nested-loading"


### PR DESCRIPTION
## Summary

- Add `view_all` enum value for GlobalDashboard workflow filter card
- Add i18n translations (zh-CN/en-US) and theme accent color for the new card
- Add "View All" card to WorkflowPanel with mock data and updated tests

Relates to https://github.com/actiontech/dms-ee/issues/802

assign in @LZS911 