### PR TITLE
forwardport: cherry-pick PR #706 from csvw-4.2505.x-ee to main

### DIFF
--- a/packages/sqle/src/page/GlobalDashboard/components/WorkflowPanel/index.tsx
+++ b/packages/sqle/src/page/GlobalDashboard/components/WorkflowPanel/index.tsx
@@ -170,9 +170,9 @@ const WorkflowPanel: React.FC<WorkflowPanelProps> = ({
     () =>
       new Map<keyof IGlobalWorkflowListItem, FilterCustomProps>([
         ['status', { options: workflowFilterStatusOptions() }],
-        ['updated_at', { showTime: false }],
+        ['updated_at', { showTime: true }],
         ['create_user_name', { options: userOptions }],
-        ['created_at', { showTime: false }]
+        ['created_at', { showTime: true }]
       ]),
     [userOptions]
   );


### PR DESCRIPTION
Forward-port of changes from `csvw-4.2505.x` (EE).

link https://github.com/actiontech/dms-ui-ee/pull/706

## Summary

- Enable `showTime` on `created_at` and `updated_at` column filters in Global Dashboard Workflow panel so users can pick a specific time when filtering workflow data.

## EE filter notes

- No EE-only code was filtered; the change only toggles `showTime` for shared date filter props.

Cherry-pick was clean, no conflicts.

## Test plan

- [ ] Open Global Dashboard → Workflow panel
- [ ] Open table filter for **Created at** / **Updated at**
- [ ] Verify the datetime picker includes time selection (not date-only)
- [ ] Apply a filter with a specific time and confirm the list updates correctly


Made with [Cursor](https://cursor.com)