### PR TITLE
feat: strengthen environment tag color display (dms-ui)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "checker": "concurrently \"pnpm ts-check\" \"pnpm eslint\" \"pnpm stylelint\" \"pnpm prettier:c\"",
     "test": "sh ./scripts/jest/run.sh",
     "test:c": "sh ./scripts/jest/run-coverage.sh",
-    "test:ci": "sh ./scripts/jest/run-ci.sh 1 1 && node ./scripts/jest/merge-report-json.js",
+    "test:ci": "sh ./scripts/jest/run-ci.sh 1 1 && SHARD_COUNT=1 node ./scripts/jest/merge-report-json.js",
     "test:clean": "jest --clearCache",
     "icon:g": "pnpm --filter @actiontech/icons icon:g",
     "icon:docs:g": "pnpm --filter @actiontech/icons docs:g",

--- a/packages/base/src/__snapshots__/App.test.tsx.snap
+++ b/packages/base/src/__snapshots__/App.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`App render App when "checkPageAction" is false 1`] = `
               </div>
             </div>
             <div
-              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
               searchinputref="[object Object]"
             >
               <div
@@ -1442,7 +1442,7 @@ exports[`App render App when token is existed 1`] = `
               </div>
             </div>
             <div
-              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
               searchinputref="[object Object]"
             >
               <div

--- a/packages/base/src/hooks/useDbService/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/hooks/useDbService/__snapshots__/index.test.tsx.snap
@@ -9,11 +9,55 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
     />,
     "options": [
       {
-        "label": "test (127.0.0.1:3306)",
+        "label": <span
+          className="db-service-option-label"
+          style={
+            {
+              "alignItems": "center",
+              "display": "inline-flex",
+            }
+          }
+        >
+          <Memo(EnvironmentTag)
+            size="small"
+            style={
+              {
+                "marginRight": 6,
+              }
+            }
+          />
+          <span>
+            test (127.0.0.1:3306)
+          </span>
+        </span>,
+        "text": "test (127.0.0.1:3306)",
+        "title": "test (127.0.0.1:3306)",
         "value": "123123",
       },
       {
-        "label": "test2 (localhost:3306)",
+        "label": <span
+          className="db-service-option-label"
+          style={
+            {
+              "alignItems": "center",
+              "display": "inline-flex",
+            }
+          }
+        >
+          <Memo(EnvironmentTag)
+            size="small"
+            style={
+              {
+                "marginRight": 6,
+              }
+            }
+          />
+          <span>
+            test2 (localhost:3306)
+          </span>
+        </span>,
+        "text": "test2 (localhost:3306)",
+        "title": "test2 (localhost:3306)",
         "value": "300123",
       },
     ],
@@ -57,7 +101,14 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
           class="ant-select-selection-item"
           title="test (127.0.0.1:3306)"
         >
-          test (127.0.0.1:3306)
+          <span
+            class="db-service-option-label"
+            style="display: inline-flex; align-items: center;"
+          >
+            <span>
+              test (127.0.0.1:3306)
+            </span>
+          </span>
         </span>
       </div>
       <span
@@ -127,7 +178,14 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
           class="ant-select-selection-item"
           title="test (127.0.0.1:3306)"
         >
-          test (127.0.0.1:3306)
+          <span
+            class="db-service-option-label"
+            style="display: inline-flex; align-items: center;"
+          >
+            <span>
+              test (127.0.0.1:3306)
+            </span>
+          </span>
         </span>
       </div>
       <span
@@ -175,7 +233,6 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
             role="presentation"
           />
           <div
-            aria-label="test (127.0.0.1:3306)"
             aria-selected="true"
             id="rc_select_TEST_OR_SSR_list_1"
             role="option"
@@ -183,7 +240,6 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
             123123
           </div>
           <div
-            aria-label="test2 (localhost:3306)"
             aria-selected="false"
             id="rc_select_TEST_OR_SSR_list_2"
             role="option"
@@ -230,7 +286,14 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
                   <div
                     class="ant-select-item-option-content"
                   >
-                    test (127.0.0.1:3306)
+                    <span
+                      class="db-service-option-label"
+                      style="display: inline-flex; align-items: center;"
+                    >
+                      <span>
+                        test (127.0.0.1:3306)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -248,7 +311,14 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
                   <div
                     class="ant-select-item-option-content"
                   >
-                    test2 (localhost:3306)
+                    <span
+                      class="db-service-option-label"
+                      style="display: inline-flex; align-items: center;"
+                    >
+                      <span>
+                        test2 (localhost:3306)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -276,11 +346,55 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
     />,
     "options": [
       {
-        "label": "test (127.0.0.1:3306)",
+        "label": <span
+          className="db-service-option-label"
+          style={
+            {
+              "alignItems": "center",
+              "display": "inline-flex",
+            }
+          }
+        >
+          <Memo(EnvironmentTag)
+            size="small"
+            style={
+              {
+                "marginRight": 6,
+              }
+            }
+          />
+          <span>
+            test (127.0.0.1:3306)
+          </span>
+        </span>,
+        "text": "test (127.0.0.1:3306)",
+        "title": "test (127.0.0.1:3306)",
         "value": "test",
       },
       {
-        "label": "test2 (localhost:3306)",
+        "label": <span
+          className="db-service-option-label"
+          style={
+            {
+              "alignItems": "center",
+              "display": "inline-flex",
+            }
+          }
+        >
+          <Memo(EnvironmentTag)
+            size="small"
+            style={
+              {
+                "marginRight": 6,
+              }
+            }
+          />
+          <span>
+            test2 (localhost:3306)
+          </span>
+        </span>,
+        "text": "test2 (localhost:3306)",
+        "title": "test2 (localhost:3306)",
         "value": "test2",
       },
     ],
@@ -442,7 +556,6 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
             role="presentation"
           />
           <div
-            aria-label="test (127.0.0.1:3306)"
             aria-selected="false"
             id="rc_select_TEST_OR_SSR_list_1"
             role="option"
@@ -450,7 +563,6 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
             test
           </div>
           <div
-            aria-label="test2 (localhost:3306)"
             aria-selected="false"
             id="rc_select_TEST_OR_SSR_list_2"
             role="option"
@@ -497,7 +609,14 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
                   <div
                     class="ant-select-item-option-content"
                   >
-                    test (127.0.0.1:3306)
+                    <span
+                      class="db-service-option-label"
+                      style="display: inline-flex; align-items: center;"
+                    >
+                      <span>
+                        test (127.0.0.1:3306)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -515,7 +634,14 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
                   <div
                     class="ant-select-item-option-content"
                   >
-                    test2 (localhost:3306)
+                    <span
+                      class="db-service-option-label"
+                      style="display: inline-flex; align-items: center;"
+                    >
+                      <span>
+                        test2 (localhost:3306)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"

--- a/packages/base/src/hooks/useDbService/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/hooks/useDbService/__snapshots__/index.test.tsx.snap
@@ -15,18 +15,29 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
             {
               "alignItems": "center",
               "display": "inline-flex",
+              "maxWidth": "none",
             }
           }
         >
           <Memo(EnvironmentTag)
+            color="#F5222D"
+            ellipsis={false}
+            name="PROD"
             size="small"
             style={
               {
+                "flexShrink": 0,
                 "marginRight": 6,
               }
             }
           />
-          <span>
+          <span
+            style={
+              {
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
             test (127.0.0.1:3306)
           </span>
         </span>,
@@ -41,18 +52,29 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
             {
               "alignItems": "center",
               "display": "inline-flex",
+              "maxWidth": "none",
             }
           }
         >
           <Memo(EnvironmentTag)
+            color="#52C41A"
+            ellipsis={false}
+            name="TEST"
             size="small"
             style={
               {
+                "flexShrink": 0,
                 "marginRight": 6,
               }
             }
           />
-          <span>
+          <span
+            style={
+              {
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
             test2 (localhost:3306)
           </span>
         </span>,
@@ -103,9 +125,22 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
         >
           <span
             class="db-service-option-label"
-            style="display: inline-flex; align-items: center;"
+            style="display: inline-flex; align-items: center; max-width: none;"
           >
-            <span>
+            <span
+              class="css-cf91id"
+              color="#F5222D"
+              style="margin-right: 6px; flex-shrink: 0;"
+            >
+              <span
+                class="environment-tag-name"
+              >
+                PROD
+              </span>
+            </span>
+            <span
+              style="white-space: nowrap;"
+            >
               test (127.0.0.1:3306)
             </span>
           </span>
@@ -180,9 +215,22 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
         >
           <span
             class="db-service-option-label"
-            style="display: inline-flex; align-items: center;"
+            style="display: inline-flex; align-items: center; max-width: none;"
           >
-            <span>
+            <span
+              class="css-cf91id"
+              color="#F5222D"
+              style="margin-right: 6px; flex-shrink: 0;"
+            >
+              <span
+                class="environment-tag-name"
+              >
+                PROD
+              </span>
+            </span>
+            <span
+              style="white-space: nowrap;"
+            >
               test (127.0.0.1:3306)
             </span>
           </span>
@@ -288,9 +336,22 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
                   >
                     <span
                       class="db-service-option-label"
-                      style="display: inline-flex; align-items: center;"
+                      style="display: inline-flex; align-items: center; max-width: none;"
                     >
-                      <span>
+                      <span
+                        class="css-cf91id"
+                        color="#F5222D"
+                        style="margin-right: 6px; flex-shrink: 0;"
+                      >
+                        <span
+                          class="environment-tag-name"
+                        >
+                          PROD
+                        </span>
+                      </span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         test (127.0.0.1:3306)
                       </span>
                     </span>
@@ -313,9 +374,22 @@ exports[`useDbService should render options when use generateDbServiceIDSelectOp
                   >
                     <span
                       class="db-service-option-label"
-                      style="display: inline-flex; align-items: center;"
+                      style="display: inline-flex; align-items: center; max-width: none;"
                     >
-                      <span>
+                      <span
+                        class="css-1wvwrtw"
+                        color="#52C41A"
+                        style="margin-right: 6px; flex-shrink: 0;"
+                      >
+                        <span
+                          class="environment-tag-name"
+                        >
+                          TEST
+                        </span>
+                      </span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         test2 (localhost:3306)
                       </span>
                     </span>
@@ -352,18 +426,29 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
             {
               "alignItems": "center",
               "display": "inline-flex",
+              "maxWidth": "none",
             }
           }
         >
           <Memo(EnvironmentTag)
+            color="#F5222D"
+            ellipsis={false}
+            name="PROD"
             size="small"
             style={
               {
+                "flexShrink": 0,
                 "marginRight": 6,
               }
             }
           />
-          <span>
+          <span
+            style={
+              {
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
             test (127.0.0.1:3306)
           </span>
         </span>,
@@ -378,18 +463,29 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
             {
               "alignItems": "center",
               "display": "inline-flex",
+              "maxWidth": "none",
             }
           }
         >
           <Memo(EnvironmentTag)
+            color="#52C41A"
+            ellipsis={false}
+            name="TEST"
             size="small"
             style={
               {
+                "flexShrink": 0,
                 "marginRight": 6,
               }
             }
           />
-          <span>
+          <span
+            style={
+              {
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
             test2 (localhost:3306)
           </span>
         </span>,
@@ -611,9 +707,22 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
                   >
                     <span
                       class="db-service-option-label"
-                      style="display: inline-flex; align-items: center;"
+                      style="display: inline-flex; align-items: center; max-width: none;"
                     >
-                      <span>
+                      <span
+                        class="css-cf91id"
+                        color="#F5222D"
+                        style="margin-right: 6px; flex-shrink: 0;"
+                      >
+                        <span
+                          class="environment-tag-name"
+                        >
+                          PROD
+                        </span>
+                      </span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         test (127.0.0.1:3306)
                       </span>
                     </span>
@@ -636,9 +745,22 @@ exports[`useDbService should render options when use generateDbServiceSelectOpti
                   >
                     <span
                       class="db-service-option-label"
-                      style="display: inline-flex; align-items: center;"
+                      style="display: inline-flex; align-items: center; max-width: none;"
                     >
-                      <span>
+                      <span
+                        class="css-1wvwrtw"
+                        color="#52C41A"
+                        style="margin-right: 6px; flex-shrink: 0;"
+                      >
+                        <span
+                          class="environment-tag-name"
+                        >
+                          TEST
+                        </span>
+                      </span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         test2 (localhost:3306)
                       </span>
                     </span>

--- a/packages/base/src/hooks/useDbService/index.test.tsx
+++ b/packages/base/src/hooks/useDbService/index.test.tsx
@@ -23,7 +23,6 @@ describe('useDbService', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     listDbServicesSpy = dbServices.ListDBServicesTips();
-    dbServices.ListDBServicesV2();
   });
 
   afterEach(() => {

--- a/packages/base/src/hooks/useDbService/index.test.tsx
+++ b/packages/base/src/hooks/useDbService/index.test.tsx
@@ -23,6 +23,7 @@ describe('useDbService', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     listDbServicesSpy = dbServices.ListDBServicesTips();
+    dbServices.ListDBServicesV2();
   });
 
   afterEach(() => {

--- a/packages/base/src/hooks/useDbService/index.tsx
+++ b/packages/base/src/hooks/useDbService/index.tsx
@@ -2,10 +2,62 @@ import React, { useCallback, useMemo } from 'react';
 import { useBoolean } from 'ahooks';
 import { Select } from 'antd';
 import { useDbServiceDriver } from '@actiontech/shared/lib/features';
-import { IListDBServiceTipItem } from '@actiontech/shared/lib/api/base/service/common';
+import {
+  IListDBServiceTipItem,
+  IListDBServiceV2
+} from '@actiontech/shared/lib/api/base/service/common';
 import { DatabaseTypeLogo, ResponseCode } from '@actiontech/dms-kit';
+import { EnvironmentTag } from '@actiontech/shared';
 import DBService from '@actiontech/shared/lib/api/base/service/DBService';
 import { IListDBServiceTipsParams } from '@actiontech/shared/lib/api/base/service/DBService/index.d';
+
+const getDbServiceDisplayLabel = (dbService: IListDBServiceTipItem) => {
+  return !!dbService.host && !!dbService.port
+    ? `${dbService.name} (${dbService.host}:${dbService.port})`
+    : dbService.name;
+};
+
+const renderDbServiceOptionLabel = (dbService: IListDBServiceTipItem) => {
+  return (
+    <span
+      className="db-service-option-label"
+      style={{ display: 'inline-flex', alignItems: 'center' }}
+    >
+      <EnvironmentTag
+        name={dbService.environment_tag?.name}
+        color={dbService.environment_tag?.color}
+        size="small"
+        style={{ marginRight: 6 }}
+      />
+      <span>{getDbServiceDisplayLabel(dbService)}</span>
+    </span>
+  );
+};
+
+const mergeDbServiceEnvironmentTag = (
+  tips: IListDBServiceTipItem[],
+  dbServices: IListDBServiceV2[]
+) => {
+  if (dbServices.length === 0) {
+    return tips;
+  }
+
+  return tips.map((tip) => {
+    const dbService = dbServices.find(
+      (item) => item.uid === tip.id || item.name === tip.name
+    );
+
+    if (!dbService?.environment_tag) {
+      return tip;
+    }
+
+    return {
+      ...tip,
+      environment_tag: dbService.environment_tag
+    };
+  });
+};
+
 const useDbService = () => {
   const [dbServiceList, setDbServiceList] = React.useState<
     IListDBServiceTipItem[]
@@ -16,9 +68,28 @@ const useDbService = () => {
     (params: IListDBServiceTipsParams) => {
       setTrue();
       DBService.ListDBServiceTips(params)
-        .then((res) => {
+        .then(async (res) => {
           if (res.data.code === ResponseCode.SUCCESS) {
-            setDbServiceList(res.data?.data ?? []);
+            const tips = res.data?.data ?? [];
+            if (!params.project_uid || tips.length === 0) {
+              setDbServiceList(tips);
+              return;
+            }
+
+            const dbServicesRes = await DBService.ListDBServicesV2({
+              project_uid: params.project_uid,
+              page_index: 1,
+              page_size: 999
+            });
+
+            setDbServiceList(
+              mergeDbServiceEnvironmentTag(
+                tips,
+                dbServicesRes.data.code === ResponseCode.SUCCESS
+                  ? dbServicesRes.data?.data ?? []
+                  : []
+              )
+            );
           } else {
             setDbServiceList([]);
           }
@@ -54,17 +125,14 @@ const useDbService = () => {
               .map((db) => {
                 const id = db.id ?? '';
                 const name = db.name ?? '';
-                const label =
-                  !!db.host && !!db.port
-                    ? `${db.name} (${db.host}:${db.port})`
-                    : db.name;
+                const label = getDbServiceDisplayLabel(db);
                 return (
                   <Select.Option
                     key={db.id}
                     value={valueType === 'id' ? id : name}
                     label={label}
                   >
-                    {label}
+                    {renderDbServiceOptionLabel(db)}
                   </Select.Option>
                 );
               })}
@@ -97,10 +165,8 @@ const useDbService = () => {
           .filter((db) => db.db_type === type)
           .map((db) => ({
             value: valueType === 'id' ? db?.id : db?.name,
-            label:
-              !!db.host && !!db.port
-                ? `${db.name} (${db.host}:${db.port})`
-                : db.name
+            text: getDbServiceDisplayLabel(db),
+            label: renderDbServiceOptionLabel(db)
           }))
       }));
     },

--- a/packages/base/src/hooks/useDbService/index.tsx
+++ b/packages/base/src/hooks/useDbService/index.tsx
@@ -2,10 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useBoolean } from 'ahooks';
 import { Select } from 'antd';
 import { useDbServiceDriver } from '@actiontech/shared/lib/features';
-import {
-  IListDBServiceTipItem,
-  IListDBServiceV2
-} from '@actiontech/shared/lib/api/base/service/common';
+import { IListDBServiceTipItem } from '@actiontech/shared/lib/api/base/service/common';
 import { DatabaseTypeLogo, ResponseCode } from '@actiontech/dms-kit';
 import { EnvironmentTag } from '@actiontech/shared';
 import DBService from '@actiontech/shared/lib/api/base/service/DBService';
@@ -21,41 +18,20 @@ const renderDbServiceOptionLabel = (dbService: IListDBServiceTipItem) => {
   return (
     <span
       className="db-service-option-label"
-      style={{ display: 'inline-flex', alignItems: 'center' }}
+      style={{ display: 'inline-flex', alignItems: 'center', maxWidth: 'none' }}
     >
       <EnvironmentTag
         name={dbService.environment_tag?.name}
         color={dbService.environment_tag?.color}
         size="small"
-        style={{ marginRight: 6 }}
+        ellipsis={false}
+        style={{ marginRight: 6, flexShrink: 0 }}
       />
-      <span>{getDbServiceDisplayLabel(dbService)}</span>
+      <span style={{ whiteSpace: 'nowrap' }}>
+        {getDbServiceDisplayLabel(dbService)}
+      </span>
     </span>
   );
-};
-
-const mergeDbServiceEnvironmentTag = (
-  tips: IListDBServiceTipItem[],
-  dbServices: IListDBServiceV2[]
-) => {
-  if (dbServices.length === 0) {
-    return tips;
-  }
-
-  return tips.map((tip) => {
-    const dbService = dbServices.find(
-      (item) => item.uid === tip.id || item.name === tip.name
-    );
-
-    if (!dbService?.environment_tag) {
-      return tip;
-    }
-
-    return {
-      ...tip,
-      environment_tag: dbService.environment_tag
-    };
-  });
 };
 
 const useDbService = () => {
@@ -70,33 +46,7 @@ const useDbService = () => {
       DBService.ListDBServiceTips(params)
         .then((res) => {
           if (res.data.code === ResponseCode.SUCCESS) {
-            const tips = res.data?.data ?? [];
-            setDbServiceList(tips);
-
-            if (!params.project_uid || tips.length === 0) {
-              return;
-            }
-
-            DBService.ListDBServicesV2({
-              project_uid: params.project_uid,
-              page_index: 1,
-              page_size: 999
-            })
-              .then((dbServicesRes) => {
-                if (dbServicesRes.data.code !== ResponseCode.SUCCESS) {
-                  return;
-                }
-
-                setDbServiceList(
-                  mergeDbServiceEnvironmentTag(
-                    tips,
-                    dbServicesRes.data?.data ?? []
-                  )
-                );
-              })
-              .catch(() => {
-                setDbServiceList(tips);
-              });
+            setDbServiceList(res.data?.data ?? []);
           } else {
             setDbServiceList([]);
           }

--- a/packages/base/src/hooks/useDbService/index.tsx
+++ b/packages/base/src/hooks/useDbService/index.tsx
@@ -68,28 +68,35 @@ const useDbService = () => {
     (params: IListDBServiceTipsParams) => {
       setTrue();
       DBService.ListDBServiceTips(params)
-        .then(async (res) => {
+        .then((res) => {
           if (res.data.code === ResponseCode.SUCCESS) {
             const tips = res.data?.data ?? [];
+            setDbServiceList(tips);
+
             if (!params.project_uid || tips.length === 0) {
-              setDbServiceList(tips);
               return;
             }
 
-            const dbServicesRes = await DBService.ListDBServicesV2({
+            DBService.ListDBServicesV2({
               project_uid: params.project_uid,
               page_index: 1,
               page_size: 999
-            });
+            })
+              .then((dbServicesRes) => {
+                if (dbServicesRes.data.code !== ResponseCode.SUCCESS) {
+                  return;
+                }
 
-            setDbServiceList(
-              mergeDbServiceEnvironmentTag(
-                tips,
-                dbServicesRes.data.code === ResponseCode.SUCCESS
-                  ? dbServicesRes.data?.data ?? []
-                  : []
-              )
-            );
+                setDbServiceList(
+                  mergeDbServiceEnvironmentTag(
+                    tips,
+                    dbServicesRes.data?.data ?? []
+                  )
+                );
+              })
+              .catch(() => {
+                setDbServiceList(tips);
+              });
           } else {
             setDbServiceList([]);
           }
@@ -131,6 +138,7 @@ const useDbService = () => {
                     key={db.id}
                     value={valueType === 'id' ? id : name}
                     label={label}
+                    title={label}
                   >
                     {renderDbServiceOptionLabel(db)}
                   </Select.Option>
@@ -166,6 +174,7 @@ const useDbService = () => {
           .map((db) => ({
             value: valueType === 'id' ? db?.id : db?.name,
             text: getDbServiceDisplayLabel(db),
+            title: getDbServiceDisplayLabel(db),
             label: renderDbServiceOptionLabel(db)
           }))
       }));

--- a/packages/base/src/page/CloudBeaver/List/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/CloudBeaver/List/__snapshots__/index.test.tsx.snap
@@ -335,7 +335,7 @@ exports[`test base/CloudBeaver/List filter data with search 1`] = `
           style="margin-right: 12px; padding-bottom: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"
@@ -458,7 +458,7 @@ exports[`test base/CloudBeaver/List filter data with search 1`] = `
           style="margin-right: 12px; padding-bottom: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"
@@ -516,7 +516,7 @@ exports[`test base/CloudBeaver/List filter data with search 1`] = `
           style="padding-bottom: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace exec-result-filter-item css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace exec-result-filter-item css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"

--- a/packages/base/src/page/DataExportManagement/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`first should match snapshot when pageState is equal CREATE_TASK 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                         >
                           <div
                             class="ant-select-selector"
@@ -446,7 +446,7 @@ exports[`first should match snapshot when pageState is equal CREATE_TASK 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"

--- a/packages/base/src/page/DataExportManagement/Create/components/CreateTask/ExportSourceForm/ExportSourceFormItem.tsx
+++ b/packages/base/src/page/DataExportManagement/Create/components/CreateTask/ExportSourceForm/ExportSourceFormItem.tsx
@@ -169,6 +169,8 @@ const ExportSourceFormItem: React.FC<
       >
         <BasicSelect
           onChange={dbServiceChangeHandle}
+          optionFilterProp="label"
+          optionLabelProp="children"
           placeholder={t('common.form.placeholder.select', {
             name: t('dmsDataExport.create.form.source.dbService')
           })}

--- a/packages/base/src/page/DataExportManagement/Create/components/CreateTask/ExportSourceForm/ExportSourceFormItem.tsx
+++ b/packages/base/src/page/DataExportManagement/Create/components/CreateTask/ExportSourceForm/ExportSourceFormItem.tsx
@@ -1,9 +1,11 @@
 import {
   BasicSelect,
+  BasicInput,
+  CommonIconStyleWrapper,
+  environmentTagSelectProps,
   jsonParse,
   ROUTE_PATHS,
-  TRANSIT_FROM_CONSTANT,
-  BasicInput
+  TRANSIT_FROM_CONSTANT
 } from '@actiontech/dms-kit';
 import { FormItemLabel } from '@actiontech/dms-kit';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +18,6 @@ import { CreateExportTaskFormEntryProps } from '../index.type';
 import { Form, SelectProps } from 'antd';
 import dayjs from 'dayjs';
 import { RingPieFilled } from '@actiontech/icons';
-import { CommonIconStyleWrapper } from '@actiontech/dms-kit';
 import { useTypedQuery } from '@actiontech/shared';
 import { decompressFromEncodedURIComponent } from 'lz-string';
 const ExportSourceFormItem: React.FC<
@@ -168,6 +169,7 @@ const ExportSourceFormItem: React.FC<
         ]}
       >
         <BasicSelect
+          {...environmentTagSelectProps}
           onChange={dbServiceChangeHandle}
           optionFilterProp="label"
           optionLabelProp="children"

--- a/packages/base/src/page/DataExportManagement/Create/components/CreateTask/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Create/components/CreateTask/__tests__/__snapshots__/index.test.tsx.snap
@@ -319,7 +319,7 @@ exports[`test base/DataExport/Create/CreateExportTask should match snapshot when
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                         >
                           <div
                             class="ant-select-selector"
@@ -471,7 +471,7 @@ exports[`test base/DataExport/Create/CreateExportTask should match snapshot when
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -1179,7 +1179,7 @@ exports[`test base/DataExport/Create/CreateExportTask should match snapshot when
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                         >
                           <div
                             class="ant-select-selector"
@@ -1331,7 +1331,7 @@ exports[`test base/DataExport/Create/CreateExportTask should match snapshot when
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"

--- a/packages/base/src/page/DataExportManagement/Create/components/SubmitWorkflow/UpdateInfoDrawer/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Create/components/SubmitWorkflow/UpdateInfoDrawer/__snapshots__/index.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`test base/DataExport/Create/UpdateInfoDrawer should match snapshot 1`] 
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -485,7 +485,7 @@ exports[`test base/DataExport/Create/UpdateInfoDrawer should match snapshot 1`] 
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -1250,7 +1250,7 @@ exports[`test base/DataExport/Create/UpdateInfoDrawer should match snapshot when
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -1403,7 +1403,7 @@ exports[`test base/DataExport/Create/UpdateInfoDrawer should match snapshot when
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"

--- a/packages/base/src/page/DataExportManagement/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -3200,7 +3200,7 @@ exports[`test base/DataExport/List render table filter items 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"
@@ -3258,7 +3258,7 @@ exports[`test base/DataExport/List render table filter items 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"
@@ -3316,7 +3316,7 @@ exports[`test base/DataExport/List render table filter items 1`] = `
             style="padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"

--- a/packages/base/src/page/DataSource/components/AddDataSource/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/AddDataSource/__snapshots__/index.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`page/DataSource/AddDataSource render add database snap 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"
@@ -308,7 +308,7 @@ exports[`page/DataSource/AddDataSource render add database snap 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"
@@ -900,7 +900,7 @@ exports[`page/DataSource/AddDataSource render add database snap 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -1028,7 +1028,7 @@ exports[`page/DataSource/AddDataSource render add database snap 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -1345,7 +1345,7 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"
@@ -1476,7 +1476,7 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"
@@ -1881,9 +1881,14 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                         class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                       >
                         <span
-                          class="editable-select-option-label"
+                          class="css-1acawoa"
+                          color="#8C8C8C"
                         >
-                          environment-1
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-1
+                          </span>
                         </span>
                         <span
                           class="arrow-icon"
@@ -2229,7 +2234,7 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
       style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; pointer-events: none;"
     >
       <div
-        class="css-r6iuvr"
+        class="css-ljujqb"
         height="320"
       >
         <div
@@ -2293,9 +2298,14 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                       class="menu-item-content"
                     >
                       <span
-                        class="editable-select-option-label"
+                        class="css-1acawoa"
+                        color="#8C8C8C"
                       >
-                        environment-1
+                        <span
+                          class="environment-tag-name"
+                        >
+                          environment-1
+                        </span>
                       </span>
                       <div
                         class="ant-space ant-space-horizontal ant-space-align-center"
@@ -2368,9 +2378,14 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                       class="menu-item-content"
                     >
                       <span
-                        class="editable-select-option-label"
+                        class="css-1acawoa"
+                        color="#8C8C8C"
                       >
-                        environment-2
+                        <span
+                          class="environment-tag-name"
+                        >
+                          environment-2
+                        </span>
                       </span>
                       <div
                         class="ant-space ant-space-horizontal ant-space-align-center"

--- a/packages/base/src/page/DataSource/components/AddDataSource/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/AddDataSource/__snapshots__/index.test.tsx.snap
@@ -632,7 +632,7 @@ exports[`page/DataSource/AddDataSource render add database snap 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                        class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                       >
                         <span
                           class="placeholder"
@@ -1878,9 +1878,11 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                        class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                       >
-                        <span>
+                        <span
+                          class="editable-select-option-label"
+                        >
                           environment-1
                         </span>
                         <span
@@ -2227,7 +2229,7 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
       style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; pointer-events: none;"
     >
       <div
-        class="css-8go0jz"
+        class="css-r6iuvr"
         height="320"
       >
         <div
@@ -2290,7 +2292,9 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                     <div
                       class="menu-item-content"
                     >
-                      <span>
+                      <span
+                        class="editable-select-option-label"
+                      >
                         environment-1
                       </span>
                       <div
@@ -2363,7 +2367,9 @@ exports[`page/DataSource/AddDataSource render conenctable modal when current ser
                     <div
                       class="menu-item-content"
                     >
-                      <span>
+                      <span
+                        class="editable-select-option-label"
+                      >
                         environment-2
                       </span>
                       <div

--- a/packages/base/src/page/DataSource/components/Form/EnvironmentField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/Form/EnvironmentField/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Project/EnvironmentField render init snap 1`] = `
 <body>
   <div>
     <div
-      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
     >
       <span
         class="placeholder"

--- a/packages/base/src/page/DataSource/components/Form/EnvironmentField/__tests__/index.test.tsx
+++ b/packages/base/src/page/DataSource/components/Form/EnvironmentField/__tests__/index.test.tsx
@@ -57,6 +57,7 @@ describe('Project/EnvironmentField', () => {
     fireEvent.click(screen.getByText('添 加'));
     await act(async () => jest.advanceTimersByTime(0));
     expect(createEnvironmentTagSpy).toHaveBeenCalledWith({
+      color: '',
       environment_name: 'test',
       project_uid: mockProjectInfo.projectID
     });
@@ -81,6 +82,7 @@ describe('Project/EnvironmentField', () => {
     fireEvent.click(screen.getByText('保 存'));
     await act(async () => jest.advanceTimersByTime(0));
     expect(updateEnvironmentTagSpy).toHaveBeenCalledWith({
+      color: '',
       environment_tag_uid: '1',
       environment_name: 'Updated Option',
       project_uid: mockProjectInfo.projectID

--- a/packages/base/src/page/DataSource/components/Form/EnvironmentField/index.tsx
+++ b/packages/base/src/page/DataSource/components/Form/EnvironmentField/index.tsx
@@ -11,13 +11,18 @@ import { useRequest } from 'ahooks';
 import { ResponseCode } from '@actiontech/dms-kit';
 import { IListDBServiceV2 } from '@actiontech/shared/lib/api/base/service/common';
 import { useBoolean } from 'ahooks';
+import { EnvironmentTag } from '@actiontech/shared';
 
 const ENVIRONMENT_TAG_PRESET_COLORS = [
   '#F5222D',
   '#FA8C16',
+  '#FAAD14',
   '#52C41A',
+  '#13C2C2',
   '#1677FF',
+  '#2F54EB',
   '#722ED1',
+  '#EB2F96',
   '#8C8C8C'
 ];
 
@@ -152,6 +157,14 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
         onAdd={onAdd}
         colorable
         presetColors={ENVIRONMENT_TAG_PRESET_COLORS}
+        renderColorTag={(option) => (
+          <EnvironmentTag
+            name={option.label}
+            color={option.color}
+            size="small"
+            ellipsis={false}
+          />
+        )}
         loading={operationLoading || loading}
         errorMessage={
           boundServices.length > 0

--- a/packages/base/src/page/DataSource/components/Form/EnvironmentField/index.tsx
+++ b/packages/base/src/page/DataSource/components/Form/EnvironmentField/index.tsx
@@ -1,5 +1,8 @@
 import { EditableSelect } from '@actiontech/dms-kit';
-import { EditableSelectProps, EditableSelectOption } from '@actiontech/dms-kit';
+import type {
+  EditableSelectProps,
+  EditableSelectOption
+} from '@actiontech/dms-kit/es/components/EditableSelect/EditableSelect.types';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DmsApi } from '@actiontech/shared/lib/api';
@@ -8,6 +11,16 @@ import { useRequest } from 'ahooks';
 import { ResponseCode } from '@actiontech/dms-kit';
 import { IListDBServiceV2 } from '@actiontech/shared/lib/api/base/service/common';
 import { useBoolean } from 'ahooks';
+
+const ENVIRONMENT_TAG_PRESET_COLORS = [
+  '#F5222D',
+  '#FA8C16',
+  '#52C41A',
+  '#1677FF',
+  '#722ED1',
+  '#8C8C8C'
+];
+
 interface EnvironmentFieldProps extends Omit<EditableSelectProps, 'options'> {
   projectID?: string;
 }
@@ -36,7 +49,8 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
         if (res.data.code === ResponseCode.SUCCESS) {
           return res.data.data?.map((item) => ({
             value: item.uid || '',
-            label: item.name || ''
+            label: item.name || '',
+            color: item.color || undefined
           }));
         }
       }),
@@ -45,10 +59,11 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
       ready: !!projectID
     }
   );
-  const onAdd = (v: string) => {
+  const onAdd = (v: string, color?: string) => {
     startOperationLoading();
     DmsApi.ProjectService.CreateEnvironmentTag({
       environment_name: v,
+      color: color ?? '',
       project_uid: projectID ?? ''
     })
       .then((res) => {
@@ -105,6 +120,7 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
     DmsApi.ProjectService.UpdateEnvironmentTag({
       environment_tag_uid: item.value.toString(),
       environment_name: item.label,
+      color: item.color ?? '',
       project_uid: projectID ?? ''
     })
       .then((res) => {
@@ -134,6 +150,8 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
         onDelete={onDelete}
         onUpdate={onUpdate}
         onAdd={onAdd}
+        colorable
+        presetColors={ENVIRONMENT_TAG_PRESET_COLORS}
         loading={operationLoading || loading}
         errorMessage={
           boundServices.length > 0

--- a/packages/base/src/page/DataSource/components/Form/FormItem/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/Form/FormItem/__snapshots__/index.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`page/DataSource/DatabaseFormItem render async params 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -432,7 +432,7 @@ exports[`page/DataSource/DatabaseFormItem render form item snap 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -768,7 +768,7 @@ exports[`page/DataSource/DatabaseFormItem render form item snap when update 1`] 
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -1156,7 +1156,7 @@ exports[`page/DataSource/DatabaseFormItem render need pwd 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -1544,7 +1544,7 @@ exports[`page/DataSource/DatabaseFormItem render port validator 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -1892,7 +1892,7 @@ exports[`page/DataSource/DatabaseFormItem render port validator 2`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -2240,7 +2240,7 @@ exports[`page/DataSource/DatabaseFormItem render port validator 3`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/base/src/page/DataSource/components/Form/SqlAuditFields/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/Form/SqlAuditFields/__tests__/__snapshots__/index.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`SqlAuditFields should match snapshot when needSqlAuditService and needA
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"
@@ -296,7 +296,7 @@ exports[`SqlAuditFields should match snapshot when needSqlAuditService and needA
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"
@@ -483,7 +483,7 @@ exports[`SqlAuditFields should match snapshot when needSqlAuditService and needA
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -603,7 +603,7 @@ exports[`SqlAuditFields should match snapshot when needSqlAuditService and needA
                           </span>
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1083,7 +1083,7 @@ exports[`SqlAuditFields should match snapshot when needSqlAuditService is true 1
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"
@@ -1211,7 +1211,7 @@ exports[`SqlAuditFields should match snapshot when needSqlAuditService is true 1
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"

--- a/packages/base/src/page/DataSource/components/Form/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/Form/__snapshots__/index.ce.test.tsx.snap
@@ -564,7 +564,7 @@ exports[`page/DataSource/DataSourceForm CE render business field when getProject
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
                         class="placeholder"

--- a/packages/base/src/page/DataSource/components/Form/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/Form/__snapshots__/index.ce.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`page/DataSource/DataSourceForm CE render business field when getProject
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -241,7 +241,7 @@ exports[`page/DataSource/DataSourceForm CE render business field when getProject
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -832,7 +832,7 @@ exports[`page/DataSource/DataSourceForm CE render business field when getProject
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/base/src/page/DataSource/components/Form/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/Form/__snapshots__/index.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`page/DataSource/DataSourceForm render cancel rule 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -242,7 +242,7 @@ exports[`page/DataSource/DataSourceForm render cancel rule 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -681,9 +681,14 @@ exports[`page/DataSource/DataSourceForm render cancel rule 1`] = `
                       class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
-                        class="editable-select-option-label"
+                        class="css-1acawoa"
+                        color="#8C8C8C"
                       >
-                        environment-1
+                        <span
+                          class="environment-tag-name"
+                        >
+                          environment-1
+                        </span>
                       </span>
                       <span
                         class="arrow-icon"
@@ -946,7 +951,7 @@ exports[`page/DataSource/DataSourceForm render cancel rule 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -1093,7 +1098,7 @@ exports[`page/DataSource/DataSourceForm render cancel rule 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -1623,7 +1628,7 @@ exports[`page/DataSource/DataSourceForm render cancel rule 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -1754,7 +1759,7 @@ exports[`page/DataSource/DataSourceForm render cancel rule 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -2193,9 +2198,14 @@ exports[`page/DataSource/DataSourceForm render cancel rule 2`] = `
                       class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
-                        class="editable-select-option-label"
+                        class="css-1acawoa"
+                        color="#8C8C8C"
                       >
-                        environment-1
+                        <span
+                          class="environment-tag-name"
+                        >
+                          environment-1
+                        </span>
                       </span>
                       <span
                         class="arrow-icon"
@@ -2785,7 +2795,7 @@ exports[`page/DataSource/DataSourceForm render change switch when page is update
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -2916,7 +2926,7 @@ exports[`page/DataSource/DataSourceForm render change switch when page is update
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -3561,7 +3571,7 @@ exports[`page/DataSource/DataSourceForm render change switch when page is update
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -3708,7 +3718,7 @@ exports[`page/DataSource/DataSourceForm render change switch when page is update
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -3895,7 +3905,7 @@ exports[`page/DataSource/DataSourceForm render change switch when page is update
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4015,7 +4025,7 @@ exports[`page/DataSource/DataSourceForm render change switch when page is update
                               </span>
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-open"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-open"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -4453,7 +4463,7 @@ exports[`page/DataSource/DataSourceForm render database type 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -4584,7 +4594,7 @@ exports[`page/DataSource/DataSourceForm render database type 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -5253,7 +5263,7 @@ exports[`page/DataSource/DataSourceForm render database type 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -5381,7 +5391,7 @@ exports[`page/DataSource/DataSourceForm render database type 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -5786,7 +5796,7 @@ exports[`page/DataSource/DataSourceForm render name rule 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -5917,7 +5927,7 @@ exports[`page/DataSource/DataSourceForm render name rule 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -6508,7 +6518,7 @@ exports[`page/DataSource/DataSourceForm render name rule 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -6636,7 +6646,7 @@ exports[`page/DataSource/DataSourceForm render name rule 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -6898,7 +6908,7 @@ exports[`page/DataSource/DataSourceForm render name rule 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -7029,7 +7039,7 @@ exports[`page/DataSource/DataSourceForm render name rule 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -7620,7 +7630,7 @@ exports[`page/DataSource/DataSourceForm render name rule 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -7748,7 +7758,7 @@ exports[`page/DataSource/DataSourceForm render name rule 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -7998,7 +8008,7 @@ exports[`page/DataSource/DataSourceForm render update form snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -8129,7 +8139,7 @@ exports[`page/DataSource/DataSourceForm render update form snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -8773,7 +8783,7 @@ exports[`page/DataSource/DataSourceForm render update form snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -8901,7 +8911,7 @@ exports[`page/DataSource/DataSourceForm render update form snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/base/src/page/DataSource/components/Form/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/Form/__snapshots__/index.test.tsx.snap
@@ -678,9 +678,11 @@ exports[`page/DataSource/DataSourceForm render cancel rule 1`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
-                      <span>
+                      <span
+                        class="editable-select-option-label"
+                      >
                         environment-1
                       </span>
                       <span
@@ -2188,9 +2190,11 @@ exports[`page/DataSource/DataSourceForm render cancel rule 2`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
-                      <span>
+                      <span
+                        class="editable-select-option-label"
+                      >
                         environment-1
                       </span>
                       <span
@@ -3289,7 +3293,7 @@ exports[`page/DataSource/DataSourceForm render change switch when page is update
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
                         class="placeholder"
@@ -4981,7 +4985,7 @@ exports[`page/DataSource/DataSourceForm render database type 1`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
                         class="placeholder"
@@ -6236,7 +6240,7 @@ exports[`page/DataSource/DataSourceForm render name rule 1`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
                         class="placeholder"
@@ -7348,7 +7352,7 @@ exports[`page/DataSource/DataSourceForm render name rule 2`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
                         class="placeholder"
@@ -8501,7 +8505,7 @@ exports[`page/DataSource/DataSourceForm render update form snap 1`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                     >
                       <span
                         class="placeholder"

--- a/packages/base/src/page/DataSource/components/List/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/List/__snapshots__/index.test.tsx.snap
@@ -1178,7 +1178,7 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -1236,7 +1236,7 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -1294,7 +1294,7 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -1352,7 +1352,7 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -1410,7 +1410,7 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
         style="padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -1778,12 +1778,9 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -1934,12 +1931,9 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -2412,7 +2406,7 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2470,7 +2464,7 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2528,7 +2522,7 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2586,7 +2580,7 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2644,7 +2638,7 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
         style="padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -3012,12 +3006,9 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -3168,12 +3159,9 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -3896,12 +3884,9 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -4031,12 +4016,9 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -4792,12 +4774,9 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -5728,12 +5707,9 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -6664,12 +6640,9 @@ exports[`page/DataSource/DataSourceList render table for api has data 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -6820,12 +6793,9 @@ exports[`page/DataSource/DataSourceList render table for api has data 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -7627,12 +7597,9 @@ exports[`page/DataSource/DataSourceList render table for api has data 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -7783,12 +7750,9 @@ exports[`page/DataSource/DataSourceList render table for api has data 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >

--- a/packages/base/src/page/DataSource/components/List/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/List/__snapshots__/index.test.tsx.snap
@@ -1778,9 +1778,17 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test
+                          </span>
                         </span>
                       </td>
                       <td
@@ -1926,9 +1934,17 @@ exports[`page/DataSource/DataSourceList render table by filter enable masking 1`
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -2996,9 +3012,17 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test
+                          </span>
                         </span>
                       </td>
                       <td
@@ -3144,9 +3168,17 @@ exports[`page/DataSource/DataSourceList render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -3864,9 +3896,17 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test
+                          </span>
                         </span>
                       </td>
                       <td
@@ -3991,9 +4031,17 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -4744,9 +4792,17 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test
+                          </span>
                         </span>
                       </td>
                       <td
@@ -5672,9 +5728,17 @@ exports[`page/DataSource/DataSourceList render table for action btn render table
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test
+                          </span>
                         </span>
                       </td>
                       <td
@@ -6600,9 +6664,17 @@ exports[`page/DataSource/DataSourceList render table for api has data 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test
+                          </span>
                         </span>
                       </td>
                       <td
@@ -6748,9 +6820,17 @@ exports[`page/DataSource/DataSourceList render table for api has data 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -7547,9 +7627,17 @@ exports[`page/DataSource/DataSourceList render table for api has data 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test
+                          </span>
                         </span>
                       </td>
                       <td
@@ -7695,9 +7783,17 @@ exports[`page/DataSource/DataSourceList render table for api has data 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          test2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            test2
+                          </span>
                         </span>
                       </td>
                       <td

--- a/packages/base/src/page/DataSource/components/List/columns.tsx
+++ b/packages/base/src/page/DataSource/components/List/columns.tsx
@@ -4,8 +4,8 @@ import { t } from '../../../../locale';
 import { IListDBServiceV2 } from '@actiontech/shared/lib/api/base/service/common';
 import { ActiontechTableColumn } from '@actiontech/dms-kit/es/components/ActiontechTable';
 import { IListDBServicesV2Params } from '@actiontech/shared/lib/api/base/service/DBService/index.d';
-import { DatabaseTypeLogo, BasicTag } from '@actiontech/dms-kit';
-import { BasicTypographyEllipsis } from '@actiontech/shared';
+import { DatabaseTypeLogo } from '@actiontech/dms-kit';
+import { BasicTypographyEllipsis, EnvironmentTag } from '@actiontech/shared';
 import ScanTypeTagsCell from 'sqle/src/page/SqlManagementConf/List/ScanTypeTagsCell';
 import ConnectionResultColumn from './ConnectionResultColumn';
 
@@ -113,7 +113,9 @@ export const dataSourceColumns = (
         if (!environment?.name) {
           return '-';
         }
-        return <BasicTag>{environment?.name}</BasicTag>;
+        return (
+          <EnvironmentTag name={environment?.name} color={environment?.color} />
+        );
       },
       filterCustomType: 'select',
       filterKey: 'filter_by_environment_tag_uid'

--- a/packages/base/src/page/DataSource/components/UpdateDataSource/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/UpdateDataSource/__snapshots__/index.test.tsx.snap
@@ -669,7 +669,7 @@ exports[`page/DataSource/UpdateDataSource render edit database snap 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                            class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                           >
                             <span
                               class="placeholder"
@@ -2189,9 +2189,11 @@ exports[`page/DataSource/UpdateDataSource render prepare api 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                            class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                           >
-                            <span>
+                            <span
+                              class="editable-select-option-label"
+                            >
                               environment-1
                             </span>
                             <span
@@ -3413,7 +3415,7 @@ exports[`page/DataSource/UpdateDataSource return list by click return button 1`]
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                            class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                           >
                             <span
                               class="placeholder"

--- a/packages/base/src/page/DataSource/components/UpdateDataSource/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataSource/components/UpdateDataSource/__snapshots__/index.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`page/DataSource/UpdateDataSource render edit database snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -293,7 +293,7 @@ exports[`page/DataSource/UpdateDataSource render edit database snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -937,7 +937,7 @@ exports[`page/DataSource/UpdateDataSource render edit database snap 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -1065,7 +1065,7 @@ exports[`page/DataSource/UpdateDataSource render edit database snap 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -1682,7 +1682,7 @@ exports[`page/DataSource/UpdateDataSource render prepare api 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -1813,7 +1813,7 @@ exports[`page/DataSource/UpdateDataSource render prepare api 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -2192,9 +2192,14 @@ exports[`page/DataSource/UpdateDataSource render prepare api 1`] = `
                             class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                           >
                             <span
-                              class="editable-select-option-label"
+                              class="css-1acawoa"
+                              color="#8C8C8C"
                             >
-                              environment-1
+                              <span
+                                class="environment-tag-name"
+                              >
+                                environment-1
+                              </span>
                             </span>
                             <span
                               class="arrow-icon"
@@ -2457,7 +2462,7 @@ exports[`page/DataSource/UpdateDataSource render prepare api 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -2604,7 +2609,7 @@ exports[`page/DataSource/UpdateDataSource render prepare api 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -2908,7 +2913,7 @@ exports[`page/DataSource/UpdateDataSource return list by click return button 1`]
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -3039,7 +3044,7 @@ exports[`page/DataSource/UpdateDataSource return list by click return button 1`]
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -3683,7 +3688,7 @@ exports[`page/DataSource/UpdateDataSource return list by click return button 1`]
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -3811,7 +3816,7 @@ exports[`page/DataSource/UpdateDataSource return list by click return button 1`]
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"

--- a/packages/base/src/page/GlobalDataSource/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/GlobalDataSource/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -362,9 +362,17 @@ exports[`page/GlobalDataSource/List render list snap 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-1
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-1
+                          </span>
                         </span>
                       </td>
                       <td
@@ -594,9 +602,17 @@ exports[`page/GlobalDataSource/List render list snap 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -739,9 +755,17 @@ exports[`page/GlobalDataSource/List render list snap 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -1377,9 +1401,17 @@ exports[`page/GlobalDataSource/List render list snap 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-1
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-1
+                          </span>
                         </span>
                       </td>
                       <td
@@ -1609,9 +1641,17 @@ exports[`page/GlobalDataSource/List render list snap 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -1754,9 +1794,17 @@ exports[`page/GlobalDataSource/List render list snap 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -2630,9 +2678,17 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-1
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-1
+                          </span>
                         </span>
                       </td>
                       <td
@@ -2862,9 +2918,17 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -3007,9 +3071,17 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -3645,9 +3717,17 @@ exports[`page/GlobalDataSource/List render table for action btn render table for
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-1
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-1
+                          </span>
                         </span>
                       </td>
                       <td
@@ -4513,9 +4593,17 @@ exports[`page/GlobalDataSource/List render table for action btn render table for
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-1
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-1
+                          </span>
                         </span>
                       </td>
                       <td
@@ -5381,9 +5469,17 @@ exports[`page/GlobalDataSource/List render table for action btn should not rende
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-1
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-1
+                          </span>
                         </span>
                       </td>
                       <td
@@ -5571,9 +5667,17 @@ exports[`page/GlobalDataSource/List render table for action btn should not rende
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td
@@ -5674,9 +5778,17 @@ exports[`page/GlobalDataSource/List render table for action btn should not rende
                         class="ant-table-cell"
                       >
                         <span
-                          class="ant-tag ant-tag-default basic-tag-wrapper basic-default-tag-wrapper css-d31ub5"
+                          class="css-yuolwb"
+                          color="#8C8C8C"
                         >
-                          environment-2
+                          <span
+                            class="environment-tag-color-dot"
+                          />
+                          <span
+                            class="environment-tag-name"
+                          >
+                            environment-2
+                          </span>
                         </span>
                       </td>
                       <td

--- a/packages/base/src/page/GlobalDataSource/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/GlobalDataSource/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -362,12 +362,9 @@ exports[`page/GlobalDataSource/List render list snap 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -602,12 +599,9 @@ exports[`page/GlobalDataSource/List render list snap 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -755,12 +749,9 @@ exports[`page/GlobalDataSource/List render list snap 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -1401,12 +1392,9 @@ exports[`page/GlobalDataSource/List render list snap 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -1641,12 +1629,9 @@ exports[`page/GlobalDataSource/List render list snap 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -1794,12 +1779,9 @@ exports[`page/GlobalDataSource/List render list snap 2`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -2198,7 +2180,7 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2256,7 +2238,7 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2314,7 +2296,7 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
         style="margin-right: 12px; padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2372,7 +2354,7 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
         style="padding-bottom: 12px;"
       >
         <div
-          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
         >
           <div
             class="ant-select-selector"
@@ -2678,12 +2660,9 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -2918,12 +2897,9 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -3071,12 +3047,9 @@ exports[`page/GlobalDataSource/List render table filter option val 1`] = `
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -3717,12 +3690,9 @@ exports[`page/GlobalDataSource/List render table for action btn render table for
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -4593,12 +4563,9 @@ exports[`page/GlobalDataSource/List render table for action btn render table for
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -5469,12 +5436,9 @@ exports[`page/GlobalDataSource/List render table for action btn should not rende
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -5667,12 +5631,9 @@ exports[`page/GlobalDataSource/List render table for action btn should not rende
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >
@@ -5778,12 +5739,9 @@ exports[`page/GlobalDataSource/List render table for action btn should not rende
                         class="ant-table-cell"
                       >
                         <span
-                          class="css-yuolwb"
+                          class="css-1xciw48"
                           color="#8C8C8C"
                         >
-                          <span
-                            class="environment-tag-color-dot"
-                          />
                           <span
                             class="environment-tag-name"
                           >

--- a/packages/base/src/page/GlobalDataSource/List/columns.tsx
+++ b/packages/base/src/page/GlobalDataSource/List/columns.tsx
@@ -7,8 +7,8 @@ import {
   PageInfoWithoutIndexAndSize
 } from '@actiontech/dms-kit/es/components/ActiontechTable';
 import { IListGlobalDBServicesV2Params } from '@actiontech/shared/lib/api/base/service/DBService/index.d';
-import { DatabaseTypeLogo, BasicTag } from '@actiontech/dms-kit';
-import { BasicTypographyEllipsis } from '@actiontech/shared';
+import { DatabaseTypeLogo } from '@actiontech/dms-kit';
+import { BasicTypographyEllipsis, EnvironmentTag } from '@actiontech/shared';
 import ConnectionResultColumn from '../../DataSource/components/List/ConnectionResultColumn';
 import { ListDBServiceV2LastConnectionTestStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
 
@@ -42,7 +42,9 @@ export const GlobalDataSourceColumns = (
         if (!environment?.name) {
           return '-';
         }
-        return <BasicTag>{environment?.name}</BasicTag>;
+        return (
+          <EnvironmentTag name={environment?.name} color={environment?.color} />
+        );
       },
       filterCustomType: 'select',
       filterKey: 'filter_by_environment_tag_uid'

--- a/packages/base/src/page/Home/DefaultScene/components/NotFoundProject/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Home/DefaultScene/components/NotFoundProject/__snapshots__/index.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`test base/home/NotFoundProject should match snapshot 1`] = `
                    暂无最近打开的项目, 请选择一个项目!
                 </span>
                 <div
-                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow ant-select-open"
+                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow ant-select-open"
                   searchinputref="[object Object]"
                 >
                   <div
@@ -173,7 +173,7 @@ exports[`test base/home/NotFoundProject should match snapshot 1`] = `
   <div>
     <div
       class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px;"
     >
       <div>
         <div
@@ -405,7 +405,7 @@ exports[`test base/home/NotFoundProject should match snapshot when clicked cance
                    暂无最近打开的项目, 请选择一个项目!
                 </span>
                 <div
-                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
                   searchinputref="[object Object]"
                 >
                   <div

--- a/packages/base/src/page/Member/Drawer/Member/__tests__/__snapshots__/AddMember.test.tsx.snap
+++ b/packages/base/src/page/Member/Drawer/Member/__tests__/__snapshots__/AddMember.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`base/Member/Drawer/AddMember should render add member form with all fie
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/base/src/page/Member/Drawer/Member/__tests__/__snapshots__/MemberForm.test.tsx.snap
+++ b/packages/base/src/page/Member/Drawer/Member/__tests__/__snapshots__/MemberForm.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`base/Member/Drawer/MemberForm should match snapshot when isUpdate is fa
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -350,7 +350,7 @@ exports[`base/Member/Drawer/MemberForm should match snapshot when isUpdate is tr
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/base/src/page/Member/Drawer/Member/__tests__/__snapshots__/UpdateMember.test.tsx.snap
+++ b/packages/base/src/page/Member/Drawer/Member/__tests__/__snapshots__/UpdateMember.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`base/Member/Drawer/UpdateMember should render update member form with p
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/AddMemberGroup.test.tsx.snap
+++ b/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/AddMemberGroup.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`base/Member/Drawer/AddMemberGroup should render add member group form w
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -667,7 +667,7 @@ exports[`base/Member/Drawer/AddMemberGroup should send add member group request 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -1194,7 +1194,7 @@ exports[`base/Member/Drawer/AddMemberGroup should send add member group request 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-open ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-open ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -1598,7 +1598,7 @@ exports[`base/Member/Drawer/AddMemberGroup should send add member group request 
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -1711,7 +1711,7 @@ exports[`base/Member/Drawer/AddMemberGroup should send add member group request 
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"

--- a/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/MemberGroupForm.test.tsx.snap
+++ b/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/MemberGroupForm.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`base/Member/Drawer/MemberGroupForm should match snapshot when isUpdate 
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-loading ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-loading ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -378,7 +378,7 @@ exports[`base/Member/Drawer/MemberGroupForm should match snapshot when isUpdate 
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-loading ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-loading ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/UpdateMemberGroup.test.tsx.snap
+++ b/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/UpdateMemberGroup.test.tsx.snap
@@ -568,7 +568,14 @@ exports[`base/Member/Drawer/UpdateMemberGroup should render update member group 
                                             <span
                                               class="ant-select-selection-item-content"
                                             >
-                                              test (127.0.0.1:3306)
+                                              <span
+                                                class="db-service-option-label"
+                                                style="display: inline-flex; align-items: center;"
+                                              >
+                                                <span>
+                                                  test (127.0.0.1:3306)
+                                                </span>
+                                              </span>
                                             </span>
                                             <span
                                               aria-hidden="true"
@@ -1512,7 +1519,14 @@ exports[`base/Member/Drawer/UpdateMemberGroup should send update member group re
                                             <span
                                               class="ant-select-selection-item-content"
                                             >
-                                              test (127.0.0.1:3306)
+                                              <span
+                                                class="db-service-option-label"
+                                                style="display: inline-flex; align-items: center;"
+                                              >
+                                                <span>
+                                                  test (127.0.0.1:3306)
+                                                </span>
+                                              </span>
                                             </span>
                                             <span
                                               aria-hidden="true"

--- a/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/UpdateMemberGroup.test.tsx.snap
+++ b/packages/base/src/page/Member/Drawer/MemberGroup/__tests__/__snapshots__/UpdateMemberGroup.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`base/Member/Drawer/UpdateMemberGroup should render update member group 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -549,7 +549,7 @@ exports[`base/Member/Drawer/UpdateMemberGroup should render update member group 
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -570,9 +570,22 @@ exports[`base/Member/Drawer/UpdateMemberGroup should render update member group 
                                             >
                                               <span
                                                 class="db-service-option-label"
-                                                style="display: inline-flex; align-items: center;"
+                                                style="display: inline-flex; align-items: center; max-width: none;"
                                               >
-                                                <span>
+                                                <span
+                                                  class="css-cf91id"
+                                                  color="#F5222D"
+                                                  style="margin-right: 6px; flex-shrink: 0;"
+                                                >
+                                                  <span
+                                                    class="environment-tag-name"
+                                                  >
+                                                    PROD
+                                                  </span>
+                                                </span>
+                                                <span
+                                                  style="white-space: nowrap;"
+                                                >
                                                   test (127.0.0.1:3306)
                                                 </span>
                                               </span>
@@ -724,7 +737,7 @@ exports[`base/Member/Drawer/UpdateMemberGroup should render update member group 
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -1092,7 +1105,7 @@ exports[`base/Member/Drawer/UpdateMemberGroup should send update member group re
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -1500,7 +1513,7 @@ exports[`base/Member/Drawer/UpdateMemberGroup should send update member group re
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -1521,9 +1534,22 @@ exports[`base/Member/Drawer/UpdateMemberGroup should send update member group re
                                             >
                                               <span
                                                 class="db-service-option-label"
-                                                style="display: inline-flex; align-items: center;"
+                                                style="display: inline-flex; align-items: center; max-width: none;"
                                               >
-                                                <span>
+                                                <span
+                                                  class="css-cf91id"
+                                                  color="#F5222D"
+                                                  style="margin-right: 6px; flex-shrink: 0;"
+                                                >
+                                                  <span
+                                                    class="environment-tag-name"
+                                                  >
+                                                    PROD
+                                                  </span>
+                                                </span>
+                                                <span
+                                                  style="white-space: nowrap;"
+                                                >
                                                   test (127.0.0.1:3306)
                                                 </span>
                                               </span>
@@ -1675,7 +1701,7 @@ exports[`base/Member/Drawer/UpdateMemberGroup should send update member group re
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"

--- a/packages/base/src/page/Nav/SideMenu/ProjectSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/ProjectSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when clicked more pr
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
       searchinputref="[object Object]"
     >
       <div
@@ -60,7 +60,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when clicked more pr
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px; pointer-events: none;"
     >
       <div>
         <div
@@ -254,7 +254,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when closed select d
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
       searchinputref="[object Object]"
     >
       <div
@@ -310,7 +310,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when closed select d
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px; pointer-events: none;"
     >
       <div>
         <div
@@ -504,7 +504,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 1`] = 
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
       searchinputref="[object Object]"
     >
       <div
@@ -535,7 +535,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 1`] = 
           class="ant-select-selection-item"
         >
           <span
-            class="custom-select-option-content css-17mg133"
+            class="custom-select-option-content css-1xzd9w3"
           >
             <span
               class="custom-select-option-content-prefix"
@@ -545,7 +545,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 1`] = 
               </span>
             </span>
             <span
-              class="custom-select-option-content-label"
+              class="custom-select-option-content-label is-text-label"
             >
               test1
             </span>
@@ -580,7 +580,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 2`] = 
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow ant-select-open"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow ant-select-open"
       searchinputref="[object Object]"
     >
       <div
@@ -611,7 +611,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 2`] = 
           class="ant-select-selection-item"
         >
           <span
-            class="custom-select-option-content css-17mg133"
+            class="custom-select-option-content css-1xzd9w3"
           >
             <span
               class="custom-select-option-content-prefix"
@@ -621,7 +621,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 2`] = 
               </span>
             </span>
             <span
-              class="custom-select-option-content-label"
+              class="custom-select-option-content-label is-text-label"
             >
               test1
             </span>
@@ -652,7 +652,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 2`] = 
   <div>
     <div
       class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px;"
     >
       <div>
         <div
@@ -889,7 +889,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 3`] = 
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-focused ant-select-single ant-select-show-arrow ant-select-open"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-focused ant-select-single ant-select-show-arrow ant-select-open"
       searchinputref="[object Object]"
     >
       <div
@@ -920,7 +920,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 3`] = 
           class="ant-select-selection-item"
         >
           <span
-            class="custom-select-option-content css-17mg133"
+            class="custom-select-option-content css-1xzd9w3"
           >
             <span
               class="custom-select-option-content-prefix"
@@ -930,7 +930,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 3`] = 
               </span>
             </span>
             <span
-              class="custom-select-option-content-label"
+              class="custom-select-option-content-label is-text-label"
             >
               test1
             </span>
@@ -961,7 +961,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 3`] = 
   <div>
     <div
       class="ant-select-dropdown custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px;"
     >
       <div>
         <div
@@ -1198,7 +1198,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 4`] = 
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-focused ant-select-single ant-select-show-arrow ant-select-open"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-focused ant-select-single ant-select-show-arrow ant-select-open"
       searchinputref="[object Object]"
     >
       <div
@@ -1229,7 +1229,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 4`] = 
           class="ant-select-selection-item"
         >
           <span
-            class="custom-select-option-content css-17mg133"
+            class="custom-select-option-content css-1xzd9w3"
           >
             <span
               class="custom-select-option-content-prefix"
@@ -1239,7 +1239,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 4`] = 
               </span>
             </span>
             <span
-              class="custom-select-option-content-label"
+              class="custom-select-option-content-label is-text-label"
             >
               test1
             </span>
@@ -1270,7 +1270,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 4`] = 
   <div>
     <div
       class="ant-select-dropdown custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px;"
     >
       <div>
         <div
@@ -1507,7 +1507,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 5`] = 
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-focused ant-select-single ant-select-show-arrow ant-select-open"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-focused ant-select-single ant-select-show-arrow ant-select-open"
       searchinputref="[object Object]"
     >
       <div
@@ -1539,7 +1539,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 5`] = 
           style="visibility: hidden;"
         >
           <span
-            class="custom-select-option-content css-17mg133"
+            class="custom-select-option-content css-1xzd9w3"
           >
             <span
               class="custom-select-option-content-prefix"
@@ -1549,7 +1549,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 5`] = 
               </span>
             </span>
             <span
-              class="custom-select-option-content-label"
+              class="custom-select-option-content-label is-text-label"
             >
               test1
             </span>
@@ -1580,7 +1580,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when has data 5`] = 
   <div>
     <div
       class="ant-select-dropdown custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px;"
     >
       <div>
         <div
@@ -1775,7 +1775,7 @@ exports[`base/page/Nav/SideMenu/ProjectSelector render snap when no data 1`] = `
 <body>
   <div>
     <div
-      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+      class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
       searchinputref="[object Object]"
     >
       <div

--- a/packages/base/src/page/Nav/SideMenu/ProjectSelector/index.tsx
+++ b/packages/base/src/page/Nav/SideMenu/ProjectSelector/index.tsx
@@ -125,7 +125,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       }}
       allowClear={false}
       dropdownRender={renderDropdown}
-      onDropdownVisibleChange={(visible) => {
+      onDropdownVisibleChange={(visible: boolean) => {
         setOpen(visible);
         if (!visible) {
           setSearchValue('');

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/BasicVersionModal.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/BasicVersionModal.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`base/Nav/SideMenu/UserMenu/BasicVersionModal render snap when open is t
                             class="ant-typography"
                           >
                             UI: 
-                            sync/data-masking   417b194dd
+                            main   6fdc83ce
                           </article>
                         </div>
                         <div
@@ -345,7 +345,7 @@ exports[`base/Nav/SideMenu/UserMenu/BasicVersionModal render snap when open is t
                             class="ant-typography"
                           >
                             UI: 
-                            sync/data-masking   417b194dd
+                            main   6fdc83ce
                           </article>
                         </div>
                         <div

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/BasicVersionModal.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/BasicVersionModal.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`base/Nav/SideMenu/UserMenu/BasicVersionModal render snap when open is t
                             class="ant-typography"
                           >
                             UI: 
-                            main   6fdc83ce
+                            dms-ui/feat-2983   ce77b682
                           </article>
                         </div>
                         <div
@@ -345,7 +345,7 @@ exports[`base/Nav/SideMenu/UserMenu/BasicVersionModal render snap when open is t
                             class="ant-typography"
                           >
                             UI: 
-                            main   6fdc83ce
+                            dms-ui/feat-2983   ce77b682
                           </article>
                         </div>
                         <div

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.ce.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ce render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            main   6fdc83ce
+                            dms-ui/feat-2983   ce77b682
                           </article>
                         </div>
                         <div
@@ -1550,7 +1550,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ce render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            main   6fdc83ce
+                            dms-ui/feat-2983   ce77b682
                           </article>
                         </div>
                         <div

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.ce.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ce render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            sync/data-masking   417b194dd
+                            main   6fdc83ce
                           </article>
                         </div>
                         <div
@@ -1550,7 +1550,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ce render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            sync/data-masking   417b194dd
+                            main   6fdc83ce
                           </article>
                         </div>
                         <div

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ee render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            sync/data-masking   417b194dd
+                            main   6fdc83ce
                           </article>
                         </div>
                         <div
@@ -352,7 +352,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ee render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            sync/data-masking   417b194dd
+                            main   6fdc83ce
                           </article>
                         </div>
                         <div

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/Modal/VersionModal/test/__snapshots__/index.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ee render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            main   6fdc83ce
+                            dms-ui/feat-2983   ce77b682
                           </article>
                         </div>
                         <div
@@ -352,7 +352,7 @@ exports[`base/Nav/SideMenu/UserMenu/VersionModal-ee render snap when open is tru
                             class="ant-typography"
                           >
                             UI: 
-                            main   6fdc83ce
+                            dms-ui/feat-2983   ce77b682
                           </article>
                         </div>
                         <div

--- a/packages/base/src/page/Nav/SideMenu/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/__tests__/__snapshots__/index.test.tsx.snap
@@ -183,7 +183,30 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 1`] = `
                     <span
                       class="custom-select-option-content-label"
                     >
-                      test_project_1
+                      <div
+                        class="css-1abqcxt"
+                      >
+                        <svg
+                          height="18"
+                          viewBox="0 0 18 18"
+                          width="18"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2.25 2.25h7.037a.75.75 0 0 1 .67.415L10.5 3.75H15a.75.75 0 0 1 .75.75v8.25a.75.75 0 0 1-.75.75h-4.786a.75.75 0 0 1-.671-.415L9 12H3.75v4.5h-1.5z"
+                            fill="#EBAD1C"
+                          />
+                        </svg>
+                        <span
+                          class="project-selector-label-text"
+                        >
+                          <div
+                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
+                          >
+                            test_project_1
+                          </div>
+                        </span>
+                      </div>
                     </span>
                   </span>
                 </span>
@@ -442,7 +465,29 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 2`] = `
                     <span
                       class="custom-select-option-content-label"
                     >
-                      test_project_1
+                      <div
+                        class="css-1abqcxt"
+                      >
+                        <svg
+                          height="18"
+                          viewBox="64 64 896 896"
+                          width="18"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
+                          />
+                        </svg>
+                        <span
+                          class="project-selector-label-text"
+                        >
+                          <div
+                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
+                          >
+                            test_project_1
+                          </div>
+                        </span>
+                      </div>
                     </span>
                   </span>
                 </span>
@@ -701,7 +746,29 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 3`] = `
                     <span
                       class="custom-select-option-content-label"
                     >
-                      test_project_1
+                      <div
+                        class="css-1abqcxt"
+                      >
+                        <svg
+                          height="18"
+                          viewBox="64 64 896 896"
+                          width="18"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
+                          />
+                        </svg>
+                        <span
+                          class="project-selector-label-text"
+                        >
+                          <div
+                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
+                          >
+                            test_project_1
+                          </div>
+                        </span>
+                      </div>
                     </span>
                   </span>
                 </span>

--- a/packages/base/src/page/Nav/SideMenu/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/__tests__/__snapshots__/index.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 1`] = `
               </div>
             </div>
             <div
-              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
               searchinputref="[object Object]"
             >
               <div
@@ -162,53 +162,30 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 1`] = `
                 <span
                   class="ant-select-selection-item"
                 >
-                  <span
-                    class="custom-select-option-content css-17mg133"
+                  <div
+                    class="css-1abqcxt"
                   >
-                    <span
-                      class="custom-select-option-content-prefix"
+                    <svg
+                      height="18"
+                      viewBox="0 0 18 18"
+                      width="18"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="18"
-                        viewBox="0 0 18 18"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2.25 2.25h7.037a.75.75 0 0 1 .67.415L10.5 3.75H15a.75.75 0 0 1 .75.75v8.25a.75.75 0 0 1-.75.75h-4.786a.75.75 0 0 1-.671-.415L9 12H3.75v4.5h-1.5z"
-                          fill="#EBAD1C"
-                        />
-                      </svg>
-                    </span>
+                      <path
+                        d="M2.25 2.25h7.037a.75.75 0 0 1 .67.415L10.5 3.75H15a.75.75 0 0 1 .75.75v8.25a.75.75 0 0 1-.75.75h-4.786a.75.75 0 0 1-.671-.415L9 12H3.75v4.5h-1.5z"
+                        fill="#EBAD1C"
+                      />
+                    </svg>
                     <span
-                      class="custom-select-option-content-label"
+                      class="project-selector-label-text"
                     >
                       <div
-                        class="css-1abqcxt"
+                        class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
                       >
-                        <svg
-                          height="18"
-                          viewBox="0 0 18 18"
-                          width="18"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M2.25 2.25h7.037a.75.75 0 0 1 .67.415L10.5 3.75H15a.75.75 0 0 1 .75.75v8.25a.75.75 0 0 1-.75.75h-4.786a.75.75 0 0 1-.671-.415L9 12H3.75v4.5h-1.5z"
-                            fill="#EBAD1C"
-                          />
-                        </svg>
-                        <span
-                          class="project-selector-label-text"
-                        >
-                          <div
-                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
-                          >
-                            test_project_1
-                          </div>
-                        </span>
+                        test_project_1
                       </div>
                     </span>
-                  </span>
+                  </div>
                 </span>
               </div>
               <span
@@ -415,7 +392,7 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 2`] = `
               </div>
             </div>
             <div
-              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
               searchinputref="[object Object]"
             >
               <div
@@ -445,51 +422,29 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 2`] = `
                 <span
                   class="ant-select-selection-item"
                 >
-                  <span
-                    class="custom-select-option-content css-17mg133"
+                  <div
+                    class="css-1abqcxt"
                   >
-                    <span
-                      class="custom-select-option-content-prefix"
+                    <svg
+                      height="18"
+                      viewBox="64 64 896 896"
+                      width="18"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="18"
-                        viewBox="64 64 896 896"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
-                        />
-                      </svg>
-                    </span>
+                      <path
+                        d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
+                      />
+                    </svg>
                     <span
-                      class="custom-select-option-content-label"
+                      class="project-selector-label-text"
                     >
                       <div
-                        class="css-1abqcxt"
+                        class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
                       >
-                        <svg
-                          height="18"
-                          viewBox="64 64 896 896"
-                          width="18"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
-                          />
-                        </svg>
-                        <span
-                          class="project-selector-label-text"
-                        >
-                          <div
-                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
-                          >
-                            test_project_1
-                          </div>
-                        </span>
+                        test_project_1
                       </div>
                     </span>
-                  </span>
+                  </div>
                 </span>
               </div>
               <span
@@ -696,7 +651,7 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 3`] = `
               </div>
             </div>
             <div
-              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow ant-select-open"
+              class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow ant-select-open"
               searchinputref="[object Object]"
             >
               <div
@@ -726,51 +681,29 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 3`] = `
                 <span
                   class="ant-select-selection-item"
                 >
-                  <span
-                    class="custom-select-option-content css-17mg133"
+                  <div
+                    class="css-1abqcxt"
                   >
-                    <span
-                      class="custom-select-option-content-prefix"
+                    <svg
+                      height="18"
+                      viewBox="64 64 896 896"
+                      width="18"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="18"
-                        viewBox="64 64 896 896"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
-                        />
-                      </svg>
-                    </span>
+                      <path
+                        d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
+                      />
+                    </svg>
                     <span
-                      class="custom-select-option-content-label"
+                      class="project-selector-label-text"
                     >
                       <div
-                        class="css-1abqcxt"
+                        class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
                       >
-                        <svg
-                          height="18"
-                          viewBox="64 64 896 896"
-                          width="18"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M832 464h-68V240c0-70.7-57.3-128-128-128H388c-70.7 0-128 57.3-128 128v224h-68c-17.7 0-32 14.3-32 32v384c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V496c0-17.7-14.3-32-32-32M332 240c0-30.9 25.1-56 56-56h248c30.9 0 56 25.1 56 56v224H332zm460 600H232V536h560zM484 701v53c0 4.4 3.6 8 8 8h40c4.4 0 8-3.6 8-8v-53a48.01 48.01 0 1 0-56 0"
-                          />
-                        </svg>
-                        <span
-                          class="project-selector-label-text"
-                        >
-                          <div
-                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line basic-typography-ellipsis css-wgj5gs"
-                          >
-                            test_project_1
-                          </div>
-                        </span>
+                        test_project_1
                       </div>
                     </span>
-                  </span>
+                  </div>
                 </span>
               </div>
               <span
@@ -825,7 +758,7 @@ exports[`test Base/Nav/SideMenu/index mount and unmount component 3`] = `
   <div>
     <div
       class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px;"
     >
       <div>
         <div

--- a/packages/base/src/page/Project/Detail/NotFoundRecentlyProject/__tests__/__snapshots__/ProjectSelectorModal.test.tsx.snap
+++ b/packages/base/src/page/Project/Detail/NotFoundRecentlyProject/__tests__/__snapshots__/ProjectSelectorModal.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`test base/page/project/detail/notFoundRecentlyProject/ProjectSelectorMo
                    暂无最近打开的项目, 请选择一个项目!
                 </span>
                 <div
-                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow ant-select-open"
+                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow ant-select-open"
                   searchinputref="[object Object]"
                 >
                   <div
@@ -103,10 +103,10 @@ exports[`test base/page/project/detail/notFoundRecentlyProject/ProjectSelectorMo
                       class="ant-select-selection-item"
                     >
                       <span
-                        class="custom-select-option-content css-17mg133"
+                        class="custom-select-option-content css-1xzd9w3"
                       >
                         <span
-                          class="custom-select-option-content-label"
+                          class="custom-select-option-content-label is-text-label"
                         >
                           test1
                         </span>
@@ -181,7 +181,7 @@ exports[`test base/page/project/detail/notFoundRecentlyProject/ProjectSelectorMo
   <div>
     <div
       class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 240px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 240px;"
     >
       <div>
         <div

--- a/packages/base/src/page/Project/Detail/NotFoundRecentlyProject/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Project/Detail/NotFoundRecentlyProject/__tests__/__snapshots__/index.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`test base/page/project/detail/notFoundRecentlyProject should execute "n
                    暂无最近打开的项目, 请选择一个项目!
                 </span>
                 <div
-                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
                   searchinputref="[object Object]"
                 >
                   <div
@@ -243,7 +243,7 @@ exports[`test base/page/project/detail/notFoundRecentlyProject should match snap
                    暂无最近打开的项目, 请选择一个项目!
                 </span>
                 <div
-                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
                   searchinputref="[object Object]"
                 >
                   <div
@@ -416,7 +416,7 @@ exports[`test base/page/project/detail/notFoundRecentlyProject should match snap
                    暂无最近打开的项目, 请选择一个项目!
                 </span>
                 <div
-                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
                   searchinputref="[object Object]"
                 >
                   <div

--- a/packages/base/src/page/Project/Detail/__tests__/__snapshots__/index.ee.test.tsx.snap
+++ b/packages/base/src/page/Project/Detail/__tests__/__snapshots__/index.ee.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`test base/page/project/detail/ee should match snapshot when the current
                    暂无最近打开的项目, 请选择一个项目!
                 </span>
                 <div
-                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-1jmxnk5 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-lg ant-select-borderless basic-select-wrapper custom-select-namespace custom-project-selector css-8xciap ant-select-single ant-select-show-arrow"
                   searchinputref="[object Object]"
                 >
                   <div

--- a/packages/base/src/page/Project/Drawer/ProjectForm/BusinessField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/Project/Drawer/ProjectForm/BusinessField/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Project/BusinessField render init snap 1`] = `
 <body>
   <div>
     <div
-      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
     >
       <span
         class="placeholder"

--- a/packages/base/src/page/Project/Drawer/ProjectForm/BusinessField/index.tsx
+++ b/packages/base/src/page/Project/Drawer/ProjectForm/BusinessField/index.tsx
@@ -1,5 +1,8 @@
 import { EditableSelect } from '@actiontech/dms-kit';
-import { EditableSelectValue, EditableSelectOption } from '@actiontech/dms-kit';
+import type {
+  EditableSelectValue,
+  EditableSelectOption
+} from '@actiontech/dms-kit/es/components/EditableSelect/EditableSelect.types';
 import { useTranslation } from 'react-i18next';
 import { DmsApi } from '@actiontech/shared/lib/api';
 import { useRequest } from 'ahooks';

--- a/packages/base/src/page/Project/Drawer/__tests__/__snapshots__/AddProject.test.tsx.snap
+++ b/packages/base/src/page/Project/Drawer/__tests__/__snapshots__/AddProject.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`test base/page/project/drawer/add should match snapshot 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -555,7 +555,7 @@ exports[`test base/page/project/drawer/add should match snapshot when getPreferr
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/base/src/page/Project/Drawer/__tests__/__snapshots__/AddProject.test.tsx.snap
+++ b/packages/base/src/page/Project/Drawer/__tests__/__snapshots__/AddProject.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`test base/page/project/drawer/add should match snapshot 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                            class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                           >
                             <span
                               class="placeholder"
@@ -647,7 +647,7 @@ exports[`test base/page/project/drawer/add should match snapshot when getPreferr
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+                            class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
                           >
                             <span
                               class="placeholder"

--- a/packages/base/src/page/ResourceOverview/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/ResourceOverview/__tests__/__snapshots__/index.test.tsx.snap
@@ -1428,12 +1428,9 @@ exports[`base/page/ResourceOverview render init snap 1`] = `
                                         class="ant-table-cell"
                                       >
                                         <span
-                                          class="css-yuolwb"
+                                          class="css-1xciw48"
                                           color="#8C8C8C"
                                         >
-                                          <span
-                                            class="environment-tag-color-dot"
-                                          />
                                           <span
                                             class="environment-tag-name"
                                           >
@@ -1548,12 +1545,9 @@ exports[`base/page/ResourceOverview render init snap 1`] = `
                                         class="ant-table-cell"
                                       >
                                         <span
-                                          class="css-yuolwb"
+                                          class="css-1xciw48"
                                           color="#8C8C8C"
                                         >
-                                          <span
-                                            class="environment-tag-color-dot"
-                                          />
                                           <span
                                             class="environment-tag-name"
                                           >

--- a/packages/base/src/page/ResourceOverview/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/ResourceOverview/__tests__/__snapshots__/index.test.tsx.snap
@@ -1427,7 +1427,19 @@ exports[`base/page/ResourceOverview render init snap 1`] = `
                                       <td
                                         class="ant-table-cell"
                                       >
-                                        environment-1
+                                        <span
+                                          class="css-yuolwb"
+                                          color="#8C8C8C"
+                                        >
+                                          <span
+                                            class="environment-tag-color-dot"
+                                          />
+                                          <span
+                                            class="environment-tag-name"
+                                          >
+                                            environment-1
+                                          </span>
+                                        </span>
                                       </td>
                                       <td
                                         class="ant-table-cell"
@@ -1535,7 +1547,19 @@ exports[`base/page/ResourceOverview render init snap 1`] = `
                                       <td
                                         class="ant-table-cell"
                                       >
-                                        environment-2
+                                        <span
+                                          class="css-yuolwb"
+                                          color="#8C8C8C"
+                                        >
+                                          <span
+                                            class="environment-tag-color-dot"
+                                          />
+                                          <span
+                                            class="environment-tag-name"
+                                          >
+                                            environment-2
+                                          </span>
+                                        </span>
                                       </td>
                                       <td
                                         class="ant-table-cell"

--- a/packages/base/src/page/ResourceOverview/components/ResourceDetail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/ResourceOverview/components/ResourceDetail/__tests__/__snapshots__/index.test.tsx.snap
@@ -1128,7 +1128,19 @@ exports[`base/page/ResourceDetail/ResourceDetail render init snap 1`] = `
                                   <td
                                     class="ant-table-cell"
                                   >
-                                    environment-1
+                                    <span
+                                      class="css-yuolwb"
+                                      color="#8C8C8C"
+                                    >
+                                      <span
+                                        class="environment-tag-color-dot"
+                                      />
+                                      <span
+                                        class="environment-tag-name"
+                                      >
+                                        environment-1
+                                      </span>
+                                    </span>
                                   </td>
                                   <td
                                     class="ant-table-cell"
@@ -1236,7 +1248,19 @@ exports[`base/page/ResourceDetail/ResourceDetail render init snap 1`] = `
                                   <td
                                     class="ant-table-cell"
                                   >
-                                    environment-2
+                                    <span
+                                      class="css-yuolwb"
+                                      color="#8C8C8C"
+                                    >
+                                      <span
+                                        class="environment-tag-color-dot"
+                                      />
+                                      <span
+                                        class="environment-tag-name"
+                                      >
+                                        environment-2
+                                      </span>
+                                    </span>
                                   </td>
                                   <td
                                     class="ant-table-cell"

--- a/packages/base/src/page/ResourceOverview/components/ResourceDetail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/ResourceOverview/components/ResourceDetail/__tests__/__snapshots__/index.test.tsx.snap
@@ -1129,12 +1129,9 @@ exports[`base/page/ResourceDetail/ResourceDetail render init snap 1`] = `
                                     class="ant-table-cell"
                                   >
                                     <span
-                                      class="css-yuolwb"
+                                      class="css-1xciw48"
                                       color="#8C8C8C"
                                     >
-                                      <span
-                                        class="environment-tag-color-dot"
-                                      />
                                       <span
                                         class="environment-tag-name"
                                       >
@@ -1249,12 +1246,9 @@ exports[`base/page/ResourceDetail/ResourceDetail render init snap 1`] = `
                                     class="ant-table-cell"
                                   >
                                     <span
-                                      class="css-yuolwb"
+                                      class="css-1xciw48"
                                       color="#8C8C8C"
                                     >
-                                      <span
-                                        class="environment-tag-color-dot"
-                                      />
                                       <span
                                         class="environment-tag-name"
                                       >

--- a/packages/base/src/page/ResourceOverview/components/ResourceDetail/columns.tsx
+++ b/packages/base/src/page/ResourceOverview/components/ResourceDetail/columns.tsx
@@ -6,6 +6,7 @@ import { DatabaseTypeLogo, BasicToolTip } from '@actiontech/dms-kit';
 import { TableColumnWithIconStyleWrapper } from '@actiontech/dms-kit';
 import { FlagFilled, DatabaseSchemaFilled } from '@actiontech/icons';
 import { ResourceOverviewTheme } from '../../../../theme/type';
+import { EnvironmentTag } from '@actiontech/shared';
 export const ResourceDetailListColumns = (
   getLogoUrlByDbType: (dbType: string) => string,
   theme: ResourceOverviewTheme
@@ -66,7 +67,16 @@ export const ResourceDetailListColumns = (
       dataIndex: 'environment_tag',
       title: t('resourceOverview.resourceList.environment'),
       render: (environmentTag) => {
-        return environmentTag?.name ?? '-';
+        if (!environmentTag?.name) {
+          return '-';
+        }
+
+        return (
+          <EnvironmentTag
+            name={environmentTag.name}
+            color={environmentTag.color}
+          />
+        );
       },
       filterCustomType: 'select',
       filterKey: 'filter_by_environment_tag_uid'

--- a/packages/base/src/page/SyncDataSource/AddPage/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/SyncDataSource/AddPage/__snapshots__/index.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`page/SyncDataSource/AddPage render add submit for success 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -416,7 +416,7 @@ exports[`page/SyncDataSource/AddPage render add submit for success 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -705,7 +705,7 @@ exports[`page/SyncDataSource/AddPage render add submit for success 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -852,7 +852,7 @@ exports[`page/SyncDataSource/AddPage render add submit for success 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -1058,7 +1058,7 @@ exports[`page/SyncDataSource/AddPage render add submit for success 1`] = `
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -1197,7 +1197,7 @@ exports[`page/SyncDataSource/AddPage render add submit for success 1`] = `
                                       </span>
                                       <div
                                         aria-required="true"
-                                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                       >
                                         <div
                                           class="ant-select-selector"
@@ -2636,7 +2636,7 @@ exports[`page/SyncDataSource/AddPage render add sync task snap 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2779,7 +2779,7 @@ exports[`page/SyncDataSource/AddPage render add sync task snap 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3038,7 +3038,7 @@ exports[`page/SyncDataSource/AddPage render add sync task snap 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -3166,7 +3166,7 @@ exports[`page/SyncDataSource/AddPage render add sync task snap 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -3580,7 +3580,7 @@ exports[`page/SyncDataSource/AddPage render form item for prepare api 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3840,7 +3840,7 @@ exports[`page/SyncDataSource/AddPage render form item for prepare api 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4129,7 +4129,7 @@ exports[`page/SyncDataSource/AddPage render form item for prepare api 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -4257,7 +4257,7 @@ exports[`page/SyncDataSource/AddPage render form item for prepare api 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"

--- a/packages/base/src/page/SyncDataSource/Form/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/SyncDataSource/Form/__snapshots__/index.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`page/SyncDataSource/SyncTaskForm render for loading form 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -262,7 +262,7 @@ exports[`page/SyncDataSource/SyncTaskForm render for loading form 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -521,7 +521,7 @@ exports[`page/SyncDataSource/SyncTaskForm render for loading form 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -649,7 +649,7 @@ exports[`page/SyncDataSource/SyncTaskForm render for loading form 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -983,7 +983,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -1126,7 +1126,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -1385,7 +1385,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -1513,7 +1513,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -1847,7 +1847,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -1990,7 +1990,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2249,7 +2249,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 2`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -2377,7 +2377,7 @@ exports[`page/SyncDataSource/SyncTaskForm render name rule 2`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -2698,7 +2698,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 1`] 
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2841,7 +2841,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 1`] 
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -3100,7 +3100,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 1`] 
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -3228,7 +3228,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 1`] 
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -3560,7 +3560,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 2`] 
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -3703,7 +3703,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 2`] 
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -3962,7 +3962,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 2`] 
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -4090,7 +4090,7 @@ exports[`page/SyncDataSource/SyncTaskForm render syncInterval for form item 2`] 
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"

--- a/packages/base/src/page/SyncDataSource/UpdatePage/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/SyncDataSource/UpdatePage/__snapshots__/index.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`page/SyncDataSource/UpdateSyncTask get task source failed 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                           >
                             <div
                               class="ant-select-selector"
@@ -326,7 +326,7 @@ exports[`page/SyncDataSource/UpdateSyncTask get task source failed 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                           >
                             <div
                               class="ant-select-selector"
@@ -585,7 +585,7 @@ exports[`page/SyncDataSource/UpdateSyncTask get task source failed 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -713,7 +713,7 @@ exports[`page/SyncDataSource/UpdateSyncTask get task source failed 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -1290,7 +1290,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                           >
                             <div
                               class="ant-select-selector"
@@ -1433,7 +1433,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                           >
                             <div
                               class="ant-select-selector"
@@ -1692,7 +1692,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -1820,7 +1820,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -2231,7 +2231,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -2474,7 +2474,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -2735,7 +2735,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 2`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -2882,7 +2882,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 2`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -3088,7 +3088,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 2`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -3227,7 +3227,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render click reset btn 2`] = `
                                     </span>
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -3712,7 +3712,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render edit database snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -3955,7 +3955,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render edit database snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -4216,7 +4216,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render edit database snap 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -4363,7 +4363,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render edit database snap 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -4569,7 +4569,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render edit database snap 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -4708,7 +4708,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render edit database snap 1`] = `
                                     </span>
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -5526,7 +5526,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render update task submit 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -5769,7 +5769,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render update task submit 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -6030,7 +6030,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render update task submit 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -6177,7 +6177,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render update task submit 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -6383,7 +6383,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render update task submit 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                                 >
                                   <div
                                     class="ant-select-selector"
@@ -6522,7 +6522,7 @@ exports[`page/SyncDataSource/UpdateSyncTask render update task submit 1`] = `
                                   </span>
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   >
                                     <div
                                       class="ant-select-selector"

--- a/packages/base/src/page/UserCenter/Drawer/User/AddUser/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/UserCenter/Drawer/User/AddUser/__snapshots__/index.test.tsx.snap
@@ -392,7 +392,7 @@ exports[`base/UserCenter/Drawer/AddUser should send add user request when click 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/base/src/page/UserCenter/Drawer/User/UpdateUser/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/UserCenter/Drawer/User/UpdateUser/__snapshots__/index.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`base/UserCenter/Drawer/UpdateUser should send update user request when 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/base/src/page/UserCenter/Drawer/User/UserForm/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/UserCenter/Drawer/User/UserForm/__snapshots__/index.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`base/UserCenter/Drawer/UserForm should match snapshot when isAdmin is t
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                 >
                   <div
                     class="ant-select-selector"
@@ -639,7 +639,7 @@ exports[`base/UserCenter/Drawer/UserForm should match snapshot when isUpdate is 
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                 >
                   <div
                     class="ant-select-selector"
@@ -950,7 +950,7 @@ exports[`base/UserCenter/Drawer/UserForm should match snapshot when isUpdate is 
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/base/src/scripts/version.ts
+++ b/packages/base/src/scripts/version.ts
@@ -1,1 +1,1 @@
-export const UI_VERSION = 'main   6fdc83ce';
+export const UI_VERSION = 'dms-ui/feat-2983   ce77b682';

--- a/packages/base/src/scripts/version.ts
+++ b/packages/base/src/scripts/version.ts
@@ -1,1 +1,1 @@
-export const UI_VERSION = 'sync/data-masking   417b194dd';
+export const UI_VERSION = 'main   6fdc83ce';

--- a/packages/dms-kit/src/components/BasicSelect/BasicSelect.tsx
+++ b/packages/dms-kit/src/components/BasicSelect/BasicSelect.tsx
@@ -1,9 +1,22 @@
 import { useTranslation } from 'react-i18next';
 import classnames from 'classnames';
+import GlobalStyles from '@mui/material/GlobalStyles';
 import { BasicSelectStyleWrapper, SelectContainerStyleWrapper } from './style';
 import BasicEmpty from '../BasicEmpty/BasicEmpty';
 import { CloseOutlined } from '@actiontech/icons';
 import { BasicSelectProps } from './BasicSelect.types';
+import { ENVIRONMENT_TAG_SELECT_DROPDOWN_CLASS_NAME } from './environmentTagSelectProps';
+
+const environmentTagSelectGlobalStyles = {
+  [`.${ENVIRONMENT_TAG_SELECT_DROPDOWN_CLASS_NAME}`]: {
+    minWidth: 'max-content'
+  },
+  [`.${ENVIRONMENT_TAG_SELECT_DROPDOWN_CLASS_NAME} .ant-select-item-option-content`]:
+    {
+      overflow: 'visible',
+      whiteSpace: 'nowrap'
+    }
+};
 
 const BasicSelect = <V = string,>(props: BasicSelectProps<V>) => {
   const { t } = useTranslation();
@@ -35,14 +48,22 @@ const BasicSelect = <V = string,>(props: BasicSelectProps<V>) => {
   );
 
   if (!prefix) {
-    return selectComponent;
+    return (
+      <>
+        <GlobalStyles styles={environmentTagSelectGlobalStyles} />
+        {selectComponent}
+      </>
+    );
   }
 
   return (
-    <SelectContainerStyleWrapper className="basic-select-container has-prefix">
-      <span className="basic-select-prefix">{prefix}</span>
-      {selectComponent}
-    </SelectContainerStyleWrapper>
+    <>
+      <GlobalStyles styles={environmentTagSelectGlobalStyles} />
+      <SelectContainerStyleWrapper className="basic-select-container has-prefix">
+        <span className="basic-select-prefix">{prefix}</span>
+        {selectComponent}
+      </SelectContainerStyleWrapper>
+    </>
   );
 };
 

--- a/packages/dms-kit/src/components/BasicSelect/__snapshots__/BasicSelect.test.tsx.snap
+++ b/packages/dms-kit/src/components/BasicSelect/__snapshots__/BasicSelect.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`lib/BasicSelect render custom filter fn 1`] = `
 <body>
   <div>
     <div
-      class="ant-select basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
+      class="ant-select basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-open ant-select-show-search"
     >
       <div
         class="ant-select-selector"
@@ -125,7 +125,7 @@ exports[`lib/BasicSelect render custom filter fn 1`] = `
 exports[`lib/BasicSelect render diff size select 1`] = `
 <div>
   <div
-    class="ant-select basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+    class="ant-select basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
   >
     <div
       class="ant-select-selector"
@@ -190,7 +190,7 @@ exports[`lib/BasicSelect render diff size select 1`] = `
 exports[`lib/BasicSelect render diff size select 2`] = `
 <div>
   <div
-    class="ant-select ant-select-sm basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+    class="ant-select ant-select-sm basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
   >
     <div
       class="ant-select-selector"
@@ -255,7 +255,7 @@ exports[`lib/BasicSelect render diff size select 2`] = `
 exports[`lib/BasicSelect render diff size select 3`] = `
 <div>
   <div
-    class="ant-select ant-select-lg basic-select-wrapper custom-select-class-name css-x5nat1 ant-select-single ant-select-show-arrow"
+    class="ant-select ant-select-lg basic-select-wrapper custom-select-class-name css-16awv9j ant-select-single ant-select-show-arrow"
   >
     <div
       class="ant-select-selector"
@@ -338,7 +338,7 @@ exports[`lib/BasicSelect render with prefix icon 1`] = `
       </svg>
     </span>
     <div
-      class="ant-select basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+      class="ant-select basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
     >
       <div
         class="ant-select-selector"

--- a/packages/dms-kit/src/components/BasicSelect/environmentTagSelectProps.ts
+++ b/packages/dms-kit/src/components/BasicSelect/environmentTagSelectProps.ts
@@ -1,0 +1,17 @@
+import { CSSProperties } from 'react';
+import { BasicSelectProps } from './BasicSelect.types';
+
+export const ENVIRONMENT_TAG_SELECT_CLASS_NAME = 'environment-tag-select';
+
+export const ENVIRONMENT_TAG_SELECT_DROPDOWN_CLASS_NAME =
+  'environment-tag-select-dropdown';
+
+export const environmentTagSelectProps = {
+  popupMatchSelectWidth: false,
+  dropdownStyle: { minWidth: 'max-content' } satisfies CSSProperties,
+  popupClassName: ENVIRONMENT_TAG_SELECT_DROPDOWN_CLASS_NAME,
+  className: ENVIRONMENT_TAG_SELECT_CLASS_NAME
+} satisfies Pick<
+  BasicSelectProps,
+  'popupMatchSelectWidth' | 'dropdownStyle' | 'popupClassName' | 'className'
+>;

--- a/packages/dms-kit/src/components/BasicSelect/index.ts
+++ b/packages/dms-kit/src/components/BasicSelect/index.ts
@@ -1,3 +1,4 @@
 export { default as BasicSelect } from './BasicSelect';
 export type * from './BasicSelect.types';
 export * from './utils';
+export * from './environmentTagSelectProps';

--- a/packages/dms-kit/src/components/BasicSelect/style.ts
+++ b/packages/dms-kit/src/components/BasicSelect/style.ts
@@ -51,6 +51,13 @@ export const BasicSelectStyleWrapper = styled(Select<any>)`
     }
   }
 
+  &.environment-tag-select.ant-select.basic-select-wrapper {
+    .ant-select-selector .ant-select-selection-item {
+      overflow: visible;
+      text-overflow: unset;
+    }
+  }
+
   &.ant-select-disabled {
     .ant-select-selector {
       border: ${({ theme }) =>

--- a/packages/dms-kit/src/components/CustomSelect/CustomOptionLabel.tsx
+++ b/packages/dms-kit/src/components/CustomSelect/CustomOptionLabel.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import classnames from 'classnames';
 import { CustomSelectOptionLabelStyleWrapper } from './style';
 
 export interface ICustomOptionLabel {
@@ -7,12 +8,20 @@ export interface ICustomOptionLabel {
 }
 
 const CustomOptionLabel: React.FC<ICustomOptionLabel> = ({ prefix, label }) => {
+  const isTextLabel = typeof label === 'string';
+
   return (
     <CustomSelectOptionLabelStyleWrapper className="custom-select-option-content">
       {prefix && (
         <span className="custom-select-option-content-prefix">{prefix}</span>
       )}
-      <span className="custom-select-option-content-label">{label}</span>
+      <span
+        className={classnames('custom-select-option-content-label', {
+          'is-text-label': isTextLabel
+        })}
+      >
+        {label}
+      </span>
     </CustomSelectOptionLabelStyleWrapper>
   );
 };

--- a/packages/dms-kit/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/dms-kit/src/components/CustomSelect/CustomSelect.tsx
@@ -41,8 +41,6 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
         typeof option.label === 'string'
           ? option.label
           : option.text ?? option.value;
-      const displayLabel =
-        typeof option.label === 'string' ? showLabel : option.label;
 
       if (
         !showLabel.toLowerCase().includes(innerSearchValue?.toLowerCase() ?? '')
@@ -53,8 +51,10 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
         ...option,
         optionLabel: !!props.mode ? (
           showLabel
+        ) : typeof option.label === 'string' ? (
+          <CustomOptionLabel prefix={valuePrefix} label={showLabel} />
         ) : (
-          <CustomOptionLabel prefix={valuePrefix} label={displayLabel} />
+          option.label
         )
       };
     };
@@ -154,7 +154,8 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
       }
       popupClassName={classnames('custom-select-popup-wrapper', popupClassName)}
       dropdownStyle={{
-        padding: 0
+        padding: 0,
+        minWidth: 'max-content'
       }}
       showSearch={false}
       tagRender={tagRender}

--- a/packages/dms-kit/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/dms-kit/src/components/CustomSelect/CustomSelect.tsx
@@ -41,6 +41,8 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
         typeof option.label === 'string'
           ? option.label
           : option.text ?? option.value;
+      const displayLabel =
+        typeof option.label === 'string' ? showLabel : option.label;
 
       if (
         !showLabel.toLowerCase().includes(innerSearchValue?.toLowerCase() ?? '')
@@ -52,7 +54,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
         optionLabel: !!props.mode ? (
           showLabel
         ) : (
-          <CustomOptionLabel prefix={valuePrefix} label={showLabel} />
+          <CustomOptionLabel prefix={valuePrefix} label={displayLabel} />
         )
       };
     };

--- a/packages/dms-kit/src/components/CustomSelect/__tests__/__snapshots__/CustomOptionLabel.test.tsx.snap
+++ b/packages/dms-kit/src/components/CustomSelect/__tests__/__snapshots__/CustomOptionLabel.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`lib/CustomOptionLabel render ui when no prefix 1`] = `
 <div>
   <span
-    class="custom-select-option-content css-17mg133"
+    class="custom-select-option-content css-1xzd9w3"
   >
     <span
-      class="custom-select-option-content-label"
+      class="custom-select-option-content-label is-text-label"
     >
       label string
     </span>

--- a/packages/dms-kit/src/components/CustomSelect/__tests__/__snapshots__/CustomSelect.test.tsx.snap
+++ b/packages/dms-kit/src/components/CustomSelect/__tests__/__snapshots__/CustomSelect.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`lib/CustomSelect should handle tags mode and render custom tags 1`] = `
 <div>
   <div
-    class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace custom-select-class css-d0rd34 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-open"
+    class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace custom-select-class css-15f13hq ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-open"
   >
     <div
       class="ant-select-selector"
@@ -17,7 +17,7 @@ exports[`lib/CustomSelect should handle tags mode and render custom tags 1`] = `
         >
           <span>
             <span
-              class="custom-select-option-content css-17mg133"
+              class="custom-select-option-content css-1xzd9w3"
             >
               <span
                 class="custom-select-option-content-prefix"
@@ -25,7 +25,7 @@ exports[`lib/CustomSelect should handle tags mode and render custom tags 1`] = `
                 前缀
               </span>
               <span
-                class="custom-select-option-content-label"
+                class="custom-select-option-content-label is-text-label"
               >
                 label1
               </span>
@@ -115,7 +115,7 @@ exports[`lib/CustomSelect should handle tags mode and render custom tags 1`] = `
 exports[`lib/CustomSelect should render default select and handle search 1`] = `
 <div>
   <div
-    class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+    class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
     style="width: 200px;"
   >
     <div

--- a/packages/dms-kit/src/components/CustomSelect/style.ts
+++ b/packages/dms-kit/src/components/CustomSelect/style.ts
@@ -37,7 +37,7 @@ export const CustomSelectStyleWrapper = styled(BasicSelect)`
         .custom-select-option-content {
           display: inline-flex;
           align-items: center;
-          max-width: 100%;
+          max-width: none;
         }
       }
     }
@@ -93,11 +93,19 @@ export const CustomSelectOptionLabelStyleWrapper = styled('span')`
 
   .custom-select-option-content-label {
     font-weight: 500;
-    text-overflow: ellipsis;
     white-space: pre;
-    overflow: hidden;
     color: ${({ theme }) =>
       theme.sharedTheme.components.customSelect.content.labelColor};
+
+    &.is-text-label {
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    &:not(.is-text-label) {
+      overflow: visible;
+      max-width: none;
+    }
   }
 `;
 

--- a/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
+++ b/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
@@ -1,4 +1,6 @@
 import { useState, useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import GlobalStyles from '@mui/material/GlobalStyles';
 import { Dropdown, Menu, Space, Popconfirm, Spin, ColorPicker } from 'antd';
 import { BasicButton } from '../BasicButton';
 import { BasicInput } from '../BasicInput';
@@ -23,6 +25,16 @@ import {
 import type { MenuProps } from 'antd';
 import { ReminderInformation } from '../ReminderInformation';
 import { BasicEmpty } from '../BasicEmpty';
+
+const COLOR_PICKER_POPUP_CLASS_NAME = 'editable-select-color-picker-popup';
+
+const COLOR_PICKER_POPUP_STYLE: CSSProperties = {
+  zIndex: 1070
+};
+
+const COLOR_PICKER_POPUP_INNER_STYLE: CSSProperties = {
+  zIndex: 1071
+};
 
 const EditableSelect: React.FC<EditableSelectProps> = ({
   value,
@@ -162,6 +174,11 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
                     <ColorPicker
                       value={editColor}
                       presets={colorPresets}
+                      rootClassName={COLOR_PICKER_POPUP_CLASS_NAME}
+                      styles={{
+                        popup: COLOR_PICKER_POPUP_STYLE,
+                        popupOverlayInner: COLOR_PICKER_POPUP_INNER_STYLE
+                      }}
                       onChangeComplete={(color) =>
                         setEditColor(color.toHexString())
                       }
@@ -288,6 +305,11 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
                     <ColorPicker
                       value={newItemColor}
                       presets={colorPresets}
+                      rootClassName={COLOR_PICKER_POPUP_CLASS_NAME}
+                      styles={{
+                        popup: COLOR_PICKER_POPUP_STYLE,
+                        popupOverlayInner: COLOR_PICKER_POPUP_INNER_STYLE
+                      }}
                       onChangeComplete={(color) =>
                         setNewItemColor(color.toHexString())
                       }
@@ -334,44 +356,56 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
   const selectedColor = options.find((o) => o.value === value)?.color;
 
   return (
-    <Dropdown
-      dropdownRender={() => dropdownContentRender}
-      trigger={['click']}
-      open={dropdownOpen}
-      onOpenChange={onOpenChange}
-      disabled={disabled}
-    >
-      <EditableSelectTriggerStyleWrapper
+    <>
+      <GlobalStyles
+        styles={{
+          [`.${COLOR_PICKER_POPUP_CLASS_NAME}`]: {
+            zIndex: `${COLOR_PICKER_POPUP_STYLE.zIndex} !important`
+          },
+          [`.${COLOR_PICKER_POPUP_CLASS_NAME} .ant-popover-inner`]: {
+            zIndex: `${COLOR_PICKER_POPUP_INNER_STYLE.zIndex} !important`
+          }
+        }}
+      />
+      <Dropdown
+        dropdownRender={() => dropdownContentRender}
+        trigger={['click']}
         open={dropdownOpen}
+        onOpenChange={onOpenChange}
         disabled={disabled}
-        className={classNames('editable-select-trigger', {
-          'editable-select-trigger-disabled': disabled
-        })}
       >
-        {selectedLabel ? (
-          <span className="editable-select-option-label">
-            <EmptyBox if={colorable && !!selectedColor}>
-              <span
-                className="editable-select-color-dot"
-                style={{ background: selectedColor }}
-              />
-            </EmptyBox>
-            {selectedLabel}
-          </span>
-        ) : (
-          <span className="placeholder">
-            {placeholder ?? t('common.form.placeholder.select')}
-          </span>
-        )}
-        <span className="arrow-icon">
-          {dropdownOpen ? (
-            <UpOutlined width={20} height={20} />
+        <EditableSelectTriggerStyleWrapper
+          open={dropdownOpen}
+          disabled={disabled}
+          className={classNames('editable-select-trigger', {
+            'editable-select-trigger-disabled': disabled
+          })}
+        >
+          {selectedLabel ? (
+            <span className="editable-select-option-label">
+              <EmptyBox if={colorable && !!selectedColor}>
+                <span
+                  className="editable-select-color-dot"
+                  style={{ background: selectedColor }}
+                />
+              </EmptyBox>
+              {selectedLabel}
+            </span>
           ) : (
-            <DownOutlined width={20} height={20} />
+            <span className="placeholder">
+              {placeholder ?? t('common.form.placeholder.select')}
+            </span>
           )}
-        </span>
-      </EditableSelectTriggerStyleWrapper>
-    </Dropdown>
+          <span className="arrow-icon">
+            {dropdownOpen ? (
+              <UpOutlined width={20} height={20} />
+            ) : (
+              <DownOutlined width={20} height={20} />
+            )}
+          </span>
+        </EditableSelectTriggerStyleWrapper>
+      </Dropdown>
+    </>
   );
 };
 

--- a/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
+++ b/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, type ReactNode } from 'react';
 import type { CSSProperties } from 'react';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import { Dropdown, Menu, Space, Popconfirm, Spin, ColorPicker } from 'antd';
@@ -36,6 +36,63 @@ const COLOR_PICKER_POPUP_INNER_STYLE: CSSProperties = {
   zIndex: 1071
 };
 
+interface EditableSelectColorControlProps {
+  color?: string;
+  onColorChange: (color?: string) => void;
+}
+
+const EditableSelectColorControl: React.FC<EditableSelectColorControlProps> = ({
+  color,
+  onColorChange
+}) => {
+  const { t } = useTranslation();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  return (
+    <div className="editable-select-color-control">
+      <span
+        className="editable-select-color-swatch"
+        style={{ background: color ?? undefined }}
+      />
+      <span className="editable-select-color-value">
+        {color?.toUpperCase() ?? '-'}
+      </span>
+      <div className="editable-select-color-actions">
+        <EmptyBox if={!!color}>
+          <BasicButton
+            type="link"
+            size="small"
+            className="editable-select-color-action"
+            onClick={() => onColorChange(undefined)}
+          >
+            {t('common.clear')}
+          </BasicButton>
+        </EmptyBox>
+        <ColorPicker
+          value={color}
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          rootClassName={COLOR_PICKER_POPUP_CLASS_NAME}
+          styles={{
+            popup: COLOR_PICKER_POPUP_STYLE,
+            popupOverlayInner: COLOR_PICKER_POPUP_INNER_STYLE
+          }}
+          onChange={(nextColor) => onColorChange(nextColor.toHexString())}
+          allowClear={false}
+        >
+          <BasicButton
+            type="link"
+            size="small"
+            className="editable-select-color-action"
+          >
+            {t('common.editableSelect.select')}
+          </BasicButton>
+        </ColorPicker>
+      </div>
+    </div>
+  );
+};
+
 const EditableSelect: React.FC<EditableSelectProps> = ({
   value,
   onChange,
@@ -56,7 +113,8 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
   searchPlaceholder,
   contentMaxHeight = 320,
   colorable = false,
-  presetColors = []
+  presetColors = [],
+  renderColorTag
 }) => {
   const { t } = useTranslation();
   const [newItemName, setNewItemName] = useState('');
@@ -138,14 +196,146 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
     );
   }, [searchable, searchValue, options]);
 
-  const colorPresets = presetColors.length
-    ? [
-        {
-          label: '',
-          colors: presetColors
-        }
-      ]
-    : undefined;
+  const isColorFormOpen = colorable && (isAdding || !!editingItem);
+  const effectiveContentMaxHeight = isColorFormOpen
+    ? Math.max(contentMaxHeight, 420)
+    : contentMaxHeight;
+
+  const renderPresetColors = (
+    selectedColor: string | undefined,
+    onSelect: (color: string) => void
+  ) => {
+    if (!presetColors.length) {
+      return null;
+    }
+
+    return (
+      <div className="editable-select-preset-colors">
+        {presetColors.map((color) => (
+          <button
+            key={color}
+            type="button"
+            aria-label={color}
+            className={classNames('editable-select-preset-color', {
+              'editable-select-preset-color-active': selectedColor === color
+            })}
+            style={{ background: color }}
+            onClick={() => onSelect(color)}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  const renderColorControl = (
+    color: string | undefined,
+    onColorChange: (color?: string) => void
+  ) => (
+    <EditableSelectColorControl color={color} onColorChange={onColorChange} />
+  );
+
+  const renderColorEditForm = ({
+    name,
+    onNameChange,
+    namePlaceholder,
+    color,
+    onColorChange,
+    previewLabel,
+    autoFocus,
+    footer
+  }: {
+    name: string;
+    onNameChange: (value: string) => void;
+    namePlaceholder?: string;
+    color: string | undefined;
+    onColorChange: (color?: string) => void;
+    previewLabel: string;
+    autoFocus?: boolean;
+    footer: ReactNode;
+  }) => (
+    <div
+      className="edit-mode editable-select-color-form"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="editable-select-form-section">
+        <div className="editable-select-form-label">
+          {t('common.editableSelect.tagName')}
+        </div>
+        <BasicInput
+          value={name}
+          autoFocus={autoFocus}
+          placeholder={namePlaceholder}
+          onChange={(e) => onNameChange(e.target.value)}
+        />
+      </div>
+
+      <EmptyBox if={colorable}>
+        <div className="editable-select-form-section">
+          <div className="editable-select-form-label">
+            {t('common.editableSelect.tagColor')}
+          </div>
+          {renderColorControl(color, onColorChange)}
+        </div>
+
+        <EmptyBox if={!!presetColors.length}>
+          <div className="editable-select-form-section">
+            <div className="editable-select-form-label">
+              {t('common.editableSelect.presetColors')}
+            </div>
+            {renderPresetColors(color, (nextColor) => onColorChange(nextColor))}
+          </div>
+        </EmptyBox>
+
+        <EmptyBox if={!!renderColorTag}>
+          <div className="editable-select-form-section">
+            <div className="editable-select-form-label">
+              {t('common.preview')}
+            </div>
+            <div className="editable-select-color-preview">
+              {renderColorTag?.({
+                label: previewLabel,
+                color
+              })}
+            </div>
+          </div>
+        </EmptyBox>
+      </EmptyBox>
+
+      <div className="button-group">{footer}</div>
+    </div>
+  );
+
+  const renderColorLabel = (option: Pick<EditableSelectOption, 'label' | 'color'>) => {
+    if (renderColorTag) {
+      return renderColorTag(option);
+    }
+
+    if (!colorable || !option.color) {
+      return null;
+    }
+
+    return (
+      <span
+        className="editable-select-color-dot"
+        style={{ background: option.color }}
+      />
+    );
+  };
+
+  const renderOptionLabel = (option: Pick<EditableSelectOption, 'label' | 'color'>) => {
+    const colorLabel = renderColorLabel(option);
+
+    if (renderColorTag) {
+      return colorLabel ?? option.label;
+    }
+
+    return (
+      <span className="editable-select-option-label">
+        <EmptyBox if={!!colorLabel}>{colorLabel}</EmptyBox>
+        {option.label}
+      </span>
+    );
+  };
 
   const generateMenuItems = (): MenuProps['items'] => {
     const optionItems: MenuProps['items'] = filteredOptions.map((option) => ({
@@ -162,56 +352,32 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
         <div>
           <div className="menu-item-content">
             {editingItem?.value === option.value ? (
-              <div className="edit-mode" onClick={(e) => e.stopPropagation()}>
-                <BasicInput
-                  value={editName}
-                  autoFocus
-                  onChange={(e) => setEditName(e.target.value)}
-                />
-                <EmptyBox if={colorable}>
-                  <div className="editable-select-color-row">
-                    <span>{t('common.color')}</span>
-                    <ColorPicker
-                      value={editColor}
-                      presets={colorPresets}
-                      rootClassName={COLOR_PICKER_POPUP_CLASS_NAME}
-                      styles={{
-                        popup: COLOR_PICKER_POPUP_STYLE,
-                        popupOverlayInner: COLOR_PICKER_POPUP_INNER_STYLE
-                      }}
-                      onChangeComplete={(color) =>
-                        setEditColor(color.toHexString())
-                      }
-                      allowClear
-                      onClear={() => setEditColor(undefined)}
-                    />
-                  </div>
-                </EmptyBox>
-                <div className="button-group">
-                  <BasicButton size="small" onClick={cancelEditing}>
-                    {t('common.cancel')}
-                  </BasicButton>
-                  <BasicButton
-                    type="primary"
-                    size="small"
-                    onClick={handleUpdate}
-                    disabled={!editName.trim()}
-                  >
-                    {t('common.save')}
-                  </BasicButton>
-                </div>
-              </div>
+              renderColorEditForm({
+                name: editName,
+                onNameChange: setEditName,
+                color: editColor,
+                onColorChange: setEditColor,
+                previewLabel: editName.trim() || option.label,
+                autoFocus: true,
+                footer: (
+                  <>
+                    <BasicButton size="small" onClick={cancelEditing}>
+                      {t('common.cancel')}
+                    </BasicButton>
+                    <BasicButton
+                      type="primary"
+                      size="small"
+                      onClick={handleUpdate}
+                      disabled={!editName.trim()}
+                    >
+                      {t('common.save')}
+                    </BasicButton>
+                  </>
+                )
+              })
             ) : (
               <>
-                <span className="editable-select-option-label">
-                  <EmptyBox if={colorable && !!option.color}>
-                    <span
-                      className="editable-select-color-dot"
-                      style={{ background: option.color }}
-                    />
-                  </EmptyBox>
-                  {option.label}
-                </span>
+                {renderOptionLabel(option)}
                 <Space>
                   <EmptyBox if={updatable}>
                     <BasicButton
@@ -264,7 +430,7 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
   };
 
   const dropdownContentRender = (
-    <EditableSelectStyleWrapper height={contentMaxHeight}>
+    <EditableSelectStyleWrapper height={effectiveContentMaxHeight}>
       <Spin spinning={loading}>
         <EmptyBox if={searchable}>
           <div className="editable-select-search">
@@ -292,52 +458,37 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
         <EmptyBox if={addable}>
           <div className="editable-select-add-section">
             {isAdding ? (
-              <div className="edit-mode" onClick={(e) => e.stopPropagation()}>
-                <BasicInput
-                  value={newItemName}
-                  autoFocus
-                  onChange={(e) => setNewItemName(e.target.value)}
-                  placeholder={t('common.form.placeholder.input')}
-                />
-                <EmptyBox if={colorable}>
-                  <div className="editable-select-color-row">
-                    <span>{t('common.color')}</span>
-                    <ColorPicker
-                      value={newItemColor}
-                      presets={colorPresets}
-                      rootClassName={COLOR_PICKER_POPUP_CLASS_NAME}
-                      styles={{
-                        popup: COLOR_PICKER_POPUP_STYLE,
-                        popupOverlayInner: COLOR_PICKER_POPUP_INNER_STYLE
+              renderColorEditForm({
+                name: newItemName,
+                onNameChange: setNewItemName,
+                namePlaceholder: t('common.form.placeholder.input'),
+                color: newItemColor,
+                onColorChange: setNewItemColor,
+                previewLabel: newItemName.trim(),
+                autoFocus: true,
+                footer: (
+                  <>
+                    <BasicButton
+                      size="small"
+                      onClick={() => {
+                        setIsAdding(false);
+                        setNewItemName('');
+                        setNewItemColor(undefined);
                       }}
-                      onChangeComplete={(color) =>
-                        setNewItemColor(color.toHexString())
-                      }
-                      allowClear
-                      onClear={() => setNewItemColor(undefined)}
-                    />
-                  </div>
-                </EmptyBox>
-                <div className="button-group">
-                  <BasicButton
-                    size="small"
-                    onClick={() => {
-                      setIsAdding(false);
-                      setNewItemName('');
-                    }}
-                  >
-                    {t('common.cancel')}
-                  </BasicButton>
-                  <BasicButton
-                    type="primary"
-                    size="small"
-                    onClick={handleAdd}
-                    disabled={!newItemName.trim()}
-                  >
-                    {t('common.add')}
-                  </BasicButton>
-                </div>
-              </div>
+                    >
+                      {t('common.cancel')}
+                    </BasicButton>
+                    <BasicButton
+                      type="primary"
+                      size="small"
+                      onClick={handleAdd}
+                      disabled={!newItemName.trim()}
+                    >
+                      {t('common.add')}
+                    </BasicButton>
+                  </>
+                )
+              })
             ) : (
               <Space
                 className="add-button-wraper"
@@ -352,8 +503,7 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
       </Spin>
     </EditableSelectStyleWrapper>
   );
-  const selectedLabel = options.find((o) => o.value === value)?.label;
-  const selectedColor = options.find((o) => o.value === value)?.color;
+  const selectedOption = options.find((o) => o.value === value);
 
   return (
     <>
@@ -381,16 +531,20 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
             'editable-select-trigger-disabled': disabled
           })}
         >
-          {selectedLabel ? (
-            <span className="editable-select-option-label">
-              <EmptyBox if={colorable && !!selectedColor}>
-                <span
-                  className="editable-select-color-dot"
-                  style={{ background: selectedColor }}
-                />
-              </EmptyBox>
-              {selectedLabel}
-            </span>
+          {selectedOption ? (
+            renderColorTag ? (
+              renderOptionLabel(selectedOption)
+            ) : (
+              <span className="editable-select-option-label">
+                <EmptyBox if={colorable && !!selectedOption.color}>
+                  <span
+                    className="editable-select-color-dot"
+                    style={{ background: selectedOption.color }}
+                  />
+                </EmptyBox>
+                {selectedOption.label}
+              </span>
+            )
           ) : (
             <span className="placeholder">
               {placeholder ?? t('common.form.placeholder.select')}

--- a/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
+++ b/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
@@ -305,7 +305,9 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
     </div>
   );
 
-  const renderColorLabel = (option: Pick<EditableSelectOption, 'label' | 'color'>) => {
+  const renderColorLabel = (
+    option: Pick<EditableSelectOption, 'label' | 'color'>
+  ) => {
     if (renderColorTag) {
       return renderColorTag(option);
     }
@@ -322,7 +324,9 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
     );
   };
 
-  const renderOptionLabel = (option: Pick<EditableSelectOption, 'label' | 'color'>) => {
+  const renderOptionLabel = (
+    option: Pick<EditableSelectOption, 'label' | 'color'>
+  ) => {
     const colorLabel = renderColorLabel(option);
 
     if (renderColorTag) {

--- a/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
+++ b/packages/dms-kit/src/components/EditableSelect/EditableSelect.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Dropdown, Menu, Space, Popconfirm, Spin } from 'antd';
+import { Dropdown, Menu, Space, Popconfirm, Spin, ColorPicker } from 'antd';
 import { BasicButton } from '../BasicButton';
 import { BasicInput } from '../BasicInput';
 import { useTranslation } from 'react-i18next';
@@ -7,7 +7,10 @@ import {
   EditableSelectStyleWrapper,
   EditableSelectTriggerStyleWrapper
 } from './style';
-import { EditableSelectProps, EditableSelectOption } from './index.type';
+import {
+  EditableSelectProps,
+  EditableSelectOption
+} from './EditableSelect.types';
 import classNames from 'classnames';
 import { EmptyBox } from '../EmptyBox';
 import {
@@ -39,7 +42,9 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
   errorMessage,
   searchable = true,
   searchPlaceholder,
-  contentMaxHeight = 320
+  contentMaxHeight = 320,
+  colorable = false,
+  presetColors = []
 }) => {
   const { t } = useTranslation();
   const [newItemName, setNewItemName] = useState('');
@@ -48,6 +53,8 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
     null
   );
   const [editName, setEditName] = useState('');
+  const [newItemColor, setNewItemColor] = useState<string>();
+  const [editColor, setEditColor] = useState<string>();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [deletingItem, setDeletingItem] = useState<EditableSelectOption | null>(
     null
@@ -55,29 +62,34 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
   const [searchValue, setSearchValue] = useState('');
 
   const handleAdd = () => {
-    onAdd?.(newItemName);
+    onAdd?.(newItemName, newItemColor);
     setNewItemName('');
+    setNewItemColor(undefined);
     setIsAdding(false);
   };
 
   const handleUpdate = () => {
     onUpdate?.({
       value: editingItem?.value ?? '',
-      label: editName.trim()
+      label: editName.trim(),
+      color: editColor
     });
     setEditingItem(null);
     setEditName('');
+    setEditColor(undefined);
   };
 
   const startEditing = (item: EditableSelectOption) => {
     setEditingItem(item);
     setEditName(item.label);
+    setEditColor(item.color);
     setDeletingItem(null);
   };
 
   const cancelEditing = () => {
     setEditingItem(null);
     setEditName('');
+    setEditColor(undefined);
   };
 
   const startAdding = () => {
@@ -87,9 +99,11 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
 
   const resetState = () => {
     setNewItemName('');
+    setNewItemColor(undefined);
     setIsAdding(false);
     setEditingItem(null);
     setEditName('');
+    setEditColor(undefined);
     setDeletingItem(null);
     setSearchValue('');
   };
@@ -112,6 +126,15 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
     );
   }, [searchable, searchValue, options]);
 
+  const colorPresets = presetColors.length
+    ? [
+        {
+          label: '',
+          colors: presetColors
+        }
+      ]
+    : undefined;
+
   const generateMenuItems = (): MenuProps['items'] => {
     const optionItems: MenuProps['items'] = filteredOptions.map((option) => ({
       key: option.value,
@@ -133,6 +156,20 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
                   autoFocus
                   onChange={(e) => setEditName(e.target.value)}
                 />
+                <EmptyBox if={colorable}>
+                  <div className="editable-select-color-row">
+                    <span>{t('common.color')}</span>
+                    <ColorPicker
+                      value={editColor}
+                      presets={colorPresets}
+                      onChangeComplete={(color) =>
+                        setEditColor(color.toHexString())
+                      }
+                      allowClear
+                      onClear={() => setEditColor(undefined)}
+                    />
+                  </div>
+                </EmptyBox>
                 <div className="button-group">
                   <BasicButton size="small" onClick={cancelEditing}>
                     {t('common.cancel')}
@@ -149,7 +186,15 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
               </div>
             ) : (
               <>
-                <span>{option.label}</span>
+                <span className="editable-select-option-label">
+                  <EmptyBox if={colorable && !!option.color}>
+                    <span
+                      className="editable-select-color-dot"
+                      style={{ background: option.color }}
+                    />
+                  </EmptyBox>
+                  {option.label}
+                </span>
                 <Space>
                   <EmptyBox if={updatable}>
                     <BasicButton
@@ -237,6 +282,20 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
                   onChange={(e) => setNewItemName(e.target.value)}
                   placeholder={t('common.form.placeholder.input')}
                 />
+                <EmptyBox if={colorable}>
+                  <div className="editable-select-color-row">
+                    <span>{t('common.color')}</span>
+                    <ColorPicker
+                      value={newItemColor}
+                      presets={colorPresets}
+                      onChangeComplete={(color) =>
+                        setNewItemColor(color.toHexString())
+                      }
+                      allowClear
+                      onClear={() => setNewItemColor(undefined)}
+                    />
+                  </div>
+                </EmptyBox>
                 <div className="button-group">
                   <BasicButton
                     size="small"
@@ -272,6 +331,7 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
     </EditableSelectStyleWrapper>
   );
   const selectedLabel = options.find((o) => o.value === value)?.label;
+  const selectedColor = options.find((o) => o.value === value)?.color;
 
   return (
     <Dropdown
@@ -289,7 +349,15 @@ const EditableSelect: React.FC<EditableSelectProps> = ({
         })}
       >
         {selectedLabel ? (
-          <span>{selectedLabel}</span>
+          <span className="editable-select-option-label">
+            <EmptyBox if={colorable && !!selectedColor}>
+              <span
+                className="editable-select-color-dot"
+                style={{ background: selectedColor }}
+              />
+            </EmptyBox>
+            {selectedLabel}
+          </span>
         ) : (
           <span className="placeholder">
             {placeholder ?? t('common.form.placeholder.select')}

--- a/packages/dms-kit/src/components/EditableSelect/EditableSelect.types.ts
+++ b/packages/dms-kit/src/components/EditableSelect/EditableSelect.types.ts
@@ -29,4 +29,7 @@ export interface EditableSelectProps {
   contentMaxHeight?: number;
   colorable?: boolean;
   presetColors?: string[];
+  renderColorTag?: (
+    option: Pick<EditableSelectOption, 'label' | 'color'>
+  ) => React.ReactNode;
 }

--- a/packages/dms-kit/src/components/EditableSelect/EditableSelect.types.ts
+++ b/packages/dms-kit/src/components/EditableSelect/EditableSelect.types.ts
@@ -5,13 +5,14 @@ export type EditableSelectValue = string | number;
 export interface EditableSelectOption {
   value: EditableSelectValue;
   label: string;
+  color?: string;
 }
 
 export interface EditableSelectProps {
   value?: EditableSelectValue;
   onChange?: (value: EditableSelectValue) => void;
   loading?: boolean;
-  onAdd?: (value: string) => void;
+  onAdd?: (value: string, color?: string) => void;
   addable?: boolean;
   onUpdate?: (newData: EditableSelectOption) => void;
   updatable?: boolean;
@@ -26,4 +27,6 @@ export interface EditableSelectProps {
   searchable?: boolean;
   searchPlaceholder?: string;
   contentMaxHeight?: number;
+  colorable?: boolean;
+  presetColors?: string[];
 }

--- a/packages/dms-kit/src/components/EditableSelect/__tests__/EditableSelect.test.tsx
+++ b/packages/dms-kit/src/components/EditableSelect/__tests__/EditableSelect.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, act, screen } from '@testing-library/react';
 import { superRender } from '../../../testUtil/superRender';
 import EditableSelect from '../EditableSelect';
-import { EditableSelectOption } from '../index.type';
+import { EditableSelectOption } from '../EditableSelect.types';
 import {
   getBySelector,
   getAllBySelector,

--- a/packages/dms-kit/src/components/EditableSelect/__tests__/EditableSelect.test.tsx
+++ b/packages/dms-kit/src/components/EditableSelect/__tests__/EditableSelect.test.tsx
@@ -124,7 +124,7 @@ describe('EditableSelect', () => {
     fireEvent.click(saveButton);
     await act(async () => jest.advanceTimersByTime(0));
 
-    expect(mockOnAdd).toHaveBeenCalledWith('New Option');
+    expect(mockOnAdd).toHaveBeenCalledWith('New Option', undefined);
   });
 
   it('should disable add button when input is empty', async () => {

--- a/packages/dms-kit/src/components/EditableSelect/__tests__/__snapshots__/EditableSelect.test.tsx.snap
+++ b/packages/dms-kit/src/components/EditableSelect/__tests__/__snapshots__/EditableSelect.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EditableSelect should render select when options is empty 1`] = `
 <body>
   <div>
     <div
-      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
     >
       <span
         class="placeholder"
@@ -35,7 +35,7 @@ exports[`EditableSelect should render select when options is empty 2`] = `
 <body>
   <div>
     <div
-      class="ant-dropdown-trigger editable-select-trigger ant-dropdown-open css-iiqyi4"
+      class="ant-dropdown-trigger editable-select-trigger ant-dropdown-open css-159cif1"
       open=""
     >
       <span
@@ -67,7 +67,7 @@ exports[`EditableSelect should render select when options is empty 2`] = `
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div
-        class="css-8go0jz"
+        class="css-r6iuvr"
         height="320"
       >
         <div
@@ -210,7 +210,7 @@ exports[`EditableSelect should render select with options 1`] = `
 <body>
   <div>
     <div
-      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
     >
       <span
         class="placeholder"
@@ -241,7 +241,7 @@ exports[`EditableSelect should render select with options 2`] = `
 <body>
   <div>
     <div
-      class="ant-dropdown-trigger editable-select-trigger ant-dropdown-open css-iiqyi4"
+      class="ant-dropdown-trigger editable-select-trigger ant-dropdown-open css-159cif1"
       open=""
     >
       <span
@@ -273,7 +273,7 @@ exports[`EditableSelect should render select with options 2`] = `
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div
-        class="css-8go0jz"
+        class="css-r6iuvr"
         height="320"
       >
         <div
@@ -336,7 +336,9 @@ exports[`EditableSelect should render select with options 2`] = `
                     <div
                       class="menu-item-content"
                     >
-                      <span>
+                      <span
+                        class="editable-select-option-label"
+                      >
                         Option 1
                       </span>
                       <div
@@ -409,7 +411,9 @@ exports[`EditableSelect should render select with options 2`] = `
                     <div
                       class="menu-item-content"
                     >
-                      <span>
+                      <span
+                        class="editable-select-option-label"
+                      >
                         Option 2
                       </span>
                       <div
@@ -518,7 +522,7 @@ exports[`EditableSelect should render without options 1`] = `
 <body>
   <div>
     <div
-      class="ant-dropdown-trigger editable-select-trigger css-e92p61"
+      class="ant-dropdown-trigger editable-select-trigger css-1xfzz7b"
     >
       <span
         class="placeholder"

--- a/packages/dms-kit/src/components/EditableSelect/__tests__/__snapshots__/EditableSelect.test.tsx.snap
+++ b/packages/dms-kit/src/components/EditableSelect/__tests__/__snapshots__/EditableSelect.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`EditableSelect should render select when options is empty 2`] = `
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div
-        class="css-r6iuvr"
+        class="css-ljujqb"
         height="320"
       >
         <div
@@ -273,7 +273,7 @@ exports[`EditableSelect should render select with options 2`] = `
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div
-        class="css-r6iuvr"
+        class="css-ljujqb"
         height="320"
       >
         <div

--- a/packages/dms-kit/src/components/EditableSelect/index.ts
+++ b/packages/dms-kit/src/components/EditableSelect/index.ts
@@ -1,2 +1,2 @@
 export { default as EditableSelect } from './EditableSelect';
-export type * from './index.type';
+export type * from './EditableSelect.types';

--- a/packages/dms-kit/src/components/EditableSelect/style.ts
+++ b/packages/dms-kit/src/components/EditableSelect/style.ts
@@ -112,7 +112,8 @@ export const EditableSelectStyleWrapper = styled('div')<{
         ${({ theme }) => theme.sharedTheme.uiToken.colorBorderSecondary};
       border-radius: 4px;
       box-sizing: border-box;
-      background: ${({ theme }) => theme.sharedTheme.uiToken.colorFillQuaternary};
+      background: ${({ theme }) =>
+        theme.sharedTheme.uiToken.colorFillQuaternary};
     }
 
     .editable-select-color-value {
@@ -167,7 +168,8 @@ export const EditableSelectStyleWrapper = styled('div')<{
       min-height: 32px;
       padding: 6px 8px;
       border-radius: 4px;
-      background: ${({ theme }) => theme.sharedTheme.uiToken.colorFillQuaternary};
+      background: ${({ theme }) =>
+        theme.sharedTheme.uiToken.colorFillQuaternary};
     }
 
     .button-group {

--- a/packages/dms-kit/src/components/EditableSelect/style.ts
+++ b/packages/dms-kit/src/components/EditableSelect/style.ts
@@ -71,12 +71,35 @@ export const EditableSelectStyleWrapper = styled('div')<{
     width: 100%;
     padding: 0 8px;
 
+    .editable-select-color-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-top: 8px;
+    }
+
     .button-group {
       display: flex;
       justify-content: flex-end;
-      gap: 8px;
       margin-top: 8px;
+
+      button + button {
+        margin-left: 8px;
+      }
     }
+  }
+
+  .editable-select-option-label {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .editable-select-color-dot {
+    width: 6px;
+    height: 6px;
+    margin-right: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
   }
 `;
 
@@ -118,5 +141,18 @@ export const EditableSelectTriggerStyleWrapper = styled('div')<{
 
   .arrow-icon {
     display: flex;
+  }
+
+  .editable-select-option-label {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .editable-select-color-dot {
+    width: 6px;
+    height: 6px;
+    margin-right: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
   }
 `;

--- a/packages/dms-kit/src/components/EditableSelect/style.ts
+++ b/packages/dms-kit/src/components/EditableSelect/style.ts
@@ -31,7 +31,11 @@ export const EditableSelectStyleWrapper = styled('div')<{
     padding: 5px 12px;
     box-sizing: content-box;
     display: flex;
-    align-items: center;
+    align-items: stretch;
+
+    .edit-mode {
+      padding: 4px 0;
+    }
   }
 
   .editable-select-menu {
@@ -52,6 +56,10 @@ export const EditableSelectStyleWrapper = styled('div')<{
         width: 100%;
         padding: 0 8px;
       }
+
+      .editable-select-color-form {
+        width: 100%;
+      }
     }
   }
 
@@ -69,19 +77,103 @@ export const EditableSelectStyleWrapper = styled('div')<{
 
   .edit-mode {
     width: 100%;
-    padding: 0 8px;
+    min-width: 240px;
+    padding: 4px 8px;
+    box-sizing: border-box;
 
-    .editable-select-color-row {
+    &.editable-select-color-form {
+      padding-top: 8px;
+      padding-bottom: 8px;
+    }
+
+    .editable-select-form-section + .editable-select-form-section {
+      margin-top: 12px;
+    }
+
+    .editable-select-form-label {
+      margin-bottom: 6px;
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextSecondary};
+      font-size: 12px;
+      line-height: 20px;
+    }
+
+    .editable-select-color-control {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      margin-top: 8px;
+      gap: 8px;
+      min-height: 24px;
+    }
+
+    .editable-select-color-swatch {
+      width: 24px;
+      height: 24px;
+      flex-shrink: 0;
+      border: 1px solid
+        ${({ theme }) => theme.sharedTheme.uiToken.colorBorderSecondary};
+      border-radius: 4px;
+      box-sizing: border-box;
+      background: ${({ theme }) => theme.sharedTheme.uiToken.colorFillQuaternary};
+    }
+
+    .editable-select-color-value {
+      flex: 1;
+      min-width: 0;
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorText};
+      font-size: 12px;
+      font-family: monospace;
+      line-height: 20px;
+    }
+
+    .editable-select-color-actions {
+      display: flex;
+      align-items: center;
+      flex-shrink: 0;
+      gap: 4px;
+    }
+
+    .editable-select-color-action {
+      padding: 0;
+      height: auto;
+      font-size: 12px;
+    }
+
+    .editable-select-preset-colors {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .editable-select-preset-color {
+      width: 20px;
+      height: 20px;
+      padding: 0;
+      border: 1px solid
+        ${({ theme }) => theme.sharedTheme.uiToken.colorBorderSecondary};
+      border-radius: 4px;
+      cursor: pointer;
+      box-sizing: border-box;
+      flex-shrink: 0;
+    }
+
+    .editable-select-preset-color-active {
+      outline: 2px solid
+        ${({ theme }) => theme.sharedTheme.uiToken.colorPrimary};
+      outline-offset: 1px;
+    }
+
+    .editable-select-color-preview {
+      display: flex;
+      align-items: center;
+      min-height: 32px;
+      padding: 6px 8px;
+      border-radius: 4px;
+      background: ${({ theme }) => theme.sharedTheme.uiToken.colorFillQuaternary};
     }
 
     .button-group {
       display: flex;
       justify-content: flex-end;
-      margin-top: 8px;
+      margin-top: 12px;
 
       button + button {
         margin-left: 8px;

--- a/packages/dms-kit/src/index.ts
+++ b/packages/dms-kit/src/index.ts
@@ -49,6 +49,7 @@ export * from './components/CustomSelect';
 export * from './components/DatabaseTypeLogo';
 export * from './components/EditText';
 export * from './components/EditableSelect';
+export type * from './components/EditableSelect/EditableSelect.types';
 export * from './components/EmptyBox';
 export * from './components/HeaderProgress';
 export * from './components/LazyLoadComponent';

--- a/packages/dms-kit/src/locale/en-US/common.ts
+++ b/packages/dms-kit/src/locale/en-US/common.ts
@@ -272,5 +272,12 @@ export default {
     code: 'Verification code',
     sendCode: 'Send code',
     secondsLater: 'Retry in {{number}} seconds'
+  },
+
+  editableSelect: {
+    tagName: 'Tag name',
+    tagColor: 'Tag color',
+    presetColors: 'Preset colors',
+    select: 'Select'
   }
 };

--- a/packages/dms-kit/src/locale/en-US/common.ts
+++ b/packages/dms-kit/src/locale/en-US/common.ts
@@ -7,6 +7,7 @@ export default {
   unknownStatus: 'Unknown status...',
   unknown: 'Unknown',
   status: 'Status',
+  color: 'Color',
 
   all: 'All',
   enabled: 'Enabled',

--- a/packages/dms-kit/src/locale/zh-CN/common.ts
+++ b/packages/dms-kit/src/locale/zh-CN/common.ts
@@ -7,6 +7,7 @@ export default {
   unknownStatus: '未知状态...',
   unknown: '未知',
   status: '状态',
+  color: '颜色',
 
   all: '全部',
   enabled: '已启用',

--- a/packages/dms-kit/src/locale/zh-CN/common.ts
+++ b/packages/dms-kit/src/locale/zh-CN/common.ts
@@ -266,6 +266,13 @@ export default {
     sendCode: '发送验证码',
     secondsLater: '{{number}}秒后重试'
   },
+  editableSelect: {
+    tagName: '标签名称',
+    tagColor: '标签颜色',
+    presetColors: '预设颜色',
+    select: '选择'
+  },
+
   deleteConfirmTitle: '确认要删除么?',
   somethingWentWrong: '出错了',
   backToHome: '返回首页',

--- a/packages/dms-kit/src/testUtil/customQuery.ts
+++ b/packages/dms-kit/src/testUtil/customQuery.ts
@@ -70,8 +70,9 @@ export const selectOptionByIndex = (
 ) => {
   fireEvent.mouseDown(screen.getByLabelText(label));
   const option = screen.getAllByText(optionText)[index];
-  expect(option).toHaveClass('ant-select-item-option-content');
-  fireEvent.click(option);
+  const optionContent = option.closest('.ant-select-item-option-content');
+  expect(optionContent).toBeInTheDocument();
+  fireEvent.click(optionContent!);
 };
 
 /**

--- a/packages/shared/lib/api/base/service/Project/index.d.ts
+++ b/packages/shared/lib/api/base/service/Project/index.d.ts
@@ -168,6 +168,8 @@ export interface ICreateEnvironmentTagParams {
   project_uid: string;
 
   environment_name: string;
+
+  color?: string;
 }
 
 export interface ICreateEnvironmentTagReturn extends IGenericResp {}
@@ -178,6 +180,8 @@ export interface IUpdateEnvironmentTagParams {
   environment_tag_uid: string;
 
   environment_name: string;
+
+  color?: string;
 }
 
 export interface IUpdateEnvironmentTagReturn extends IGenericResp {}

--- a/packages/shared/lib/api/base/service/common.d.ts
+++ b/packages/shared/lib/api/base/service/common.d.ts
@@ -796,6 +796,8 @@ export interface IDeleteSensitiveDataDiscoveryTaskReply {
 }
 
 export interface IEnvironmentTag {
+  color?: string;
+
   name?: string;
 
   uid?: string;
@@ -1657,6 +1659,8 @@ export interface IListDBServiceSyncTasksReply {
 
 export interface IListDBServiceTipItem {
   db_type?: string;
+
+  environment_tag?: IEnvironmentTag;
 
   host?: string;
 

--- a/packages/shared/lib/api/sqle/service/common.d.ts
+++ b/packages/shared/lib/api/sqle/service/common.d.ts
@@ -4943,6 +4943,8 @@ export interface IInstanceTipResV2 {
 
   enable_backup?: boolean;
 
+  environment_tag_color?: string;
+
   environment_tag_name?: string;
 
   environment_tag_uid?: string;

--- a/packages/shared/lib/components/EnvironmentTag/index.tsx
+++ b/packages/shared/lib/components/EnvironmentTag/index.tsx
@@ -9,6 +9,7 @@ export type EnvironmentTagProps = {
   size?: 'small' | 'default';
   className?: string;
   style?: CSSProperties;
+  ellipsis?: boolean;
 };
 
 const EnvironmentTag: React.FC<EnvironmentTagProps> = ({
@@ -16,7 +17,8 @@ const EnvironmentTag: React.FC<EnvironmentTagProps> = ({
   color,
   size = 'default',
   className,
-  style
+  style,
+  ellipsis = true
 }) => {
   if (!name) {
     return null;
@@ -30,8 +32,8 @@ const EnvironmentTag: React.FC<EnvironmentTagProps> = ({
       size={size}
       className={className}
       style={style}
+      ellipsis={ellipsis}
     >
-      <span className="environment-tag-color-dot" />
       <span className="environment-tag-name">{name}</span>
     </EnvironmentTagStyleWrapper>
   );

--- a/packages/shared/lib/components/EnvironmentTag/index.tsx
+++ b/packages/shared/lib/components/EnvironmentTag/index.tsx
@@ -1,0 +1,40 @@
+import { CSSProperties, memo } from 'react';
+import { EnvironmentTagStyleWrapper } from './style';
+
+export const DEFAULT_ENVIRONMENT_TAG_COLOR = '#8C8C8C';
+
+export type EnvironmentTagProps = {
+  name?: string;
+  color?: string;
+  size?: 'small' | 'default';
+  className?: string;
+  style?: CSSProperties;
+};
+
+const EnvironmentTag: React.FC<EnvironmentTagProps> = ({
+  name,
+  color,
+  size = 'default',
+  className,
+  style
+}) => {
+  if (!name) {
+    return null;
+  }
+
+  const tagColor = color || DEFAULT_ENVIRONMENT_TAG_COLOR;
+
+  return (
+    <EnvironmentTagStyleWrapper
+      color={tagColor}
+      size={size}
+      className={className}
+      style={style}
+    >
+      <span className="environment-tag-color-dot" />
+      <span className="environment-tag-name">{name}</span>
+    </EnvironmentTagStyleWrapper>
+  );
+};
+
+export default memo(EnvironmentTag);

--- a/packages/shared/lib/components/EnvironmentTag/style.ts
+++ b/packages/shared/lib/components/EnvironmentTag/style.ts
@@ -34,7 +34,8 @@ export const EnvironmentTagStyleWrapper = styled('span')<{
 
   .environment-tag-name {
     overflow: ${({ ellipsis = true }) => (ellipsis ? 'hidden' : 'visible')};
-    text-overflow: ${({ ellipsis = true }) => (ellipsis ? 'ellipsis' : 'unset')};
+    text-overflow: ${({ ellipsis = true }) =>
+      ellipsis ? 'ellipsis' : 'unset'};
     white-space: nowrap;
   }
 `;

--- a/packages/shared/lib/components/EnvironmentTag/style.ts
+++ b/packages/shared/lib/components/EnvironmentTag/style.ts
@@ -1,0 +1,47 @@
+import { styled } from '@mui/material/styles';
+
+const hexToRgba = (hexColor: string, alpha: number) => {
+  if (!/^#([0-9a-fA-F]{6})$/.test(hexColor)) {
+    return `rgba(140, 140, 140, ${alpha})`;
+  }
+
+  const red = parseInt(hexColor.slice(1, 3), 16);
+  const green = parseInt(hexColor.slice(3, 5), 16);
+  const blue = parseInt(hexColor.slice(5, 7), 16);
+
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+};
+
+export const EnvironmentTagStyleWrapper = styled('span')<{
+  color: string;
+  size: 'small' | 'default';
+}>`
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  max-width: 100%;
+  height: ${({ size }) => (size === 'small' ? '22px' : '24px')};
+  padding: ${({ size }) => (size === 'small' ? '0 6px' : '0 8px')};
+  border-radius: 4px;
+  color: ${({ color }) => color};
+  background: ${({ color }) => hexToRgba(color, 0.1)};
+  border: 1px solid ${({ color }) => hexToRgba(color, 0.32)};
+  font-size: 12px;
+  line-height: 1;
+  vertical-align: middle;
+
+  .environment-tag-color-dot {
+    flex-shrink: 0;
+    width: 6px;
+    height: 6px;
+    margin-right: 6px;
+    border-radius: 50%;
+    background: ${({ color }) => color};
+  }
+
+  .environment-tag-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;

--- a/packages/shared/lib/components/EnvironmentTag/style.ts
+++ b/packages/shared/lib/components/EnvironmentTag/style.ts
@@ -15,11 +15,12 @@ const hexToRgba = (hexColor: string, alpha: number) => {
 export const EnvironmentTagStyleWrapper = styled('span')<{
   color: string;
   size: 'small' | 'default';
+  ellipsis?: boolean;
 }>`
   display: inline-flex;
   align-items: center;
   width: max-content;
-  max-width: 100%;
+  max-width: ${({ ellipsis = true }) => (ellipsis ? '100%' : 'none')};
   height: ${({ size }) => (size === 'small' ? '22px' : '24px')};
   padding: ${({ size }) => (size === 'small' ? '0 6px' : '0 8px')};
   border-radius: 4px;
@@ -29,19 +30,11 @@ export const EnvironmentTagStyleWrapper = styled('span')<{
   font-size: 12px;
   line-height: 1;
   vertical-align: middle;
-
-  .environment-tag-color-dot {
-    flex-shrink: 0;
-    width: 6px;
-    height: 6px;
-    margin-right: 6px;
-    border-radius: 50%;
-    background: ${({ color }) => color};
-  }
+  flex-shrink: 0;
 
   .environment-tag-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow: ${({ ellipsis = true }) => (ellipsis ? 'hidden' : 'visible')};
+    text-overflow: ${({ ellipsis = true }) => (ellipsis ? 'ellipsis' : 'unset')};
     white-space: nowrap;
   }
 `;

--- a/packages/shared/lib/components/index.ts
+++ b/packages/shared/lib/components/index.ts
@@ -14,3 +14,6 @@ export * from './TypedRouter';
 export * from './BasicMDEditor';
 
 export * from './BackendForm';
+
+export { default as EnvironmentTag } from './EnvironmentTag';
+export type * from './EnvironmentTag';

--- a/packages/shared/lib/testUtil/mockApi/base/dbServices/data.ts
+++ b/packages/shared/lib/testUtil/mockApi/base/dbServices/data.ts
@@ -53,14 +53,22 @@ export const dbServicesTips: IListDBServiceTipItem[] = [
     host: '127.0.0.1',
     name: 'test',
     port: '3306',
-    id: '123123'
+    id: '123123',
+    environment_tag: {
+      name: 'PROD',
+      color: '#F5222D'
+    }
   },
   {
     db_type: 'MySQL',
     host: 'localhost',
     name: 'test2',
     port: '3306',
-    id: '300123'
+    id: '300123',
+    environment_tag: {
+      name: 'TEST',
+      color: '#52C41A'
+    }
   }
 ];
 

--- a/packages/shared/lib/testUtil/mockApi/base/dbServices/index.ts
+++ b/packages/shared/lib/testUtil/mockApi/base/dbServices/index.ts
@@ -12,6 +12,7 @@ import DBService from '../../../../api/base/service/DBService';
 class MockDbServicesApi implements MockSpyApy {
   public mockAllApi(): void {
     this.ListDBServices();
+    this.ListDBServicesV2();
     this.AddDBService();
     this.UpdateDBService();
     this.DelDBService();
@@ -27,6 +28,17 @@ class MockDbServicesApi implements MockSpyApy {
     spy.mockImplementation(() =>
       createSpySuccessResponse({
         data: dbServices
+      })
+    );
+    return spy;
+  }
+
+  public ListDBServicesV2() {
+    const spy = jest.spyOn(DBService, 'ListDBServicesV2');
+    spy.mockImplementation(() =>
+      createSpySuccessResponse({
+        data: dbServices,
+        total_nums: dbServices.length
       })
     );
     return spy;

--- a/packages/sqle/src/components/RuleDetail/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/components/RuleDetail/__snapshots__/index.test.tsx.snap
@@ -277,7 +277,7 @@ exports[`sqle/components/RuleDetail render error snap 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -335,7 +335,7 @@ exports[`sqle/components/RuleDetail render error snap 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -393,7 +393,7 @@ exports[`sqle/components/RuleDetail render error snap 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -451,7 +451,7 @@ exports[`sqle/components/RuleDetail render error snap 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -515,7 +515,7 @@ exports[`sqle/components/RuleDetail render error snap 1`] = `
                         style="margin-right: 4px;"
                       >
                         <div
-                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -968,7 +968,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -1026,7 +1026,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -1084,7 +1084,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -1142,7 +1142,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -1206,7 +1206,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                         style="margin-right: 4px;"
                       >
                         <div
-                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                         >
                           <div
                             class="ant-select-selector"
@@ -1635,7 +1635,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1693,7 +1693,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1751,7 +1751,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1809,7 +1809,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1873,7 +1873,7 @@ exports[`sqle/components/RuleDetail render project rule template when projectNam
                         style="margin-right: 4px;"
                       >
                         <div
-                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2432,7 +2432,7 @@ exports[`sqle/components/RuleDetail render snap when route params is undefined 1
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2490,7 +2490,7 @@ exports[`sqle/components/RuleDetail render snap when route params is undefined 1
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2548,7 +2548,7 @@ exports[`sqle/components/RuleDetail render snap when route params is undefined 1
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2606,7 +2606,7 @@ exports[`sqle/components/RuleDetail render snap when route params is undefined 1
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2670,7 +2670,7 @@ exports[`sqle/components/RuleDetail render snap when route params is undefined 1
                         style="margin-right: 4px;"
                       >
                         <div
-                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"

--- a/packages/sqle/src/components/RuleList/RuleFilter/__tests__/__snapshots__/RuleFilterCommonFields.test.tsx.snap
+++ b/packages/sqle/src/components/RuleList/RuleFilter/__tests__/__snapshots__/RuleFilterCommonFields.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`sqle/components/RuleList/RuleFilterCommonFields render int snap shot 1`
           style="margin-right: 12px;"
         >
           <div
-            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"
@@ -122,7 +122,7 @@ exports[`sqle/components/RuleList/RuleFilterCommonFields render int snap shot 1`
           style="margin-right: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"
@@ -180,7 +180,7 @@ exports[`sqle/components/RuleList/RuleFilterCommonFields render int snap shot 1`
           style="margin-right: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"
@@ -238,7 +238,7 @@ exports[`sqle/components/RuleList/RuleFilterCommonFields render int snap shot 1`
           style="margin-right: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"
@@ -302,7 +302,7 @@ exports[`sqle/components/RuleList/RuleFilterCommonFields render int snap shot 1`
               style="margin-right: 4px;"
             >
               <div
-                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"

--- a/packages/sqle/src/components/RuleList/RuleFilter/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/components/RuleList/RuleFilter/__tests__/__snapshots__/index.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`sqle/components/RuleList/RuleFilter render init snap shot 1`] = `
               style="margin-right: 12px;"
             >
               <div
-                class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -129,7 +129,7 @@ exports[`sqle/components/RuleList/RuleFilter render init snap shot 1`] = `
               style="margin-right: 12px;"
             >
               <div
-                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -187,7 +187,7 @@ exports[`sqle/components/RuleList/RuleFilter render init snap shot 1`] = `
               style="margin-right: 12px;"
             >
               <div
-                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -245,7 +245,7 @@ exports[`sqle/components/RuleList/RuleFilter render init snap shot 1`] = `
               style="margin-right: 12px;"
             >
               <div
-                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -309,7 +309,7 @@ exports[`sqle/components/RuleList/RuleFilter render init snap shot 1`] = `
                   style="margin-right: 4px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"

--- a/packages/sqle/src/hooks/useInstance/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/hooks/useInstance/__snapshots__/index.test.tsx.snap
@@ -83,7 +83,6 @@ exports[`useInstance should be group instance by database type 1`] = `
             role="presentation"
           />
           <div
-            aria-label="mysql_instance_test_name_1"
             aria-selected="false"
             id="rc_select_TEST_OR_SSR_list_1"
             role="option"
@@ -91,7 +90,6 @@ exports[`useInstance should be group instance by database type 1`] = `
             mysql_instance_test_name_1
           </div>
           <div
-            aria-label="mysql_instance_test_name_2"
             aria-selected="false"
             id="rc_select_TEST_OR_SSR_list_2"
             role="option"
@@ -132,12 +130,19 @@ exports[`useInstance should be group instance by database type 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active"
+                  label="mysql_instance_test_name_1"
                   title="mysql_instance_test_name_1"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql_instance_test_name_1
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql_instance_test_name_1
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -149,12 +154,19 @@ exports[`useInstance should be group instance by database type 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="mysql_instance_test_name_2"
                   title="mysql_instance_test_name_2"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql_instance_test_name_2
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql_instance_test_name_2
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -183,12 +195,19 @@ exports[`useInstance should be group instance by database type 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="oracle_instance_test_name"
                   title="oracle_instance_test_name"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    oracle_instance_test_name
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        oracle_instance_test_name
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -217,12 +236,19 @@ exports[`useInstance should be group instance by database type 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="sqlserver_instance_test_name"
                   title="sqlserver_instance_test_name"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    sqlserver_instance_test_name
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        sqlserver_instance_test_name
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -458,7 +484,6 @@ exports[`useInstance should get instance data from request 3`] = `
             role="presentation"
           />
           <div
-            aria-label="instance_test_name (127.0.0.1:8081)"
             aria-selected="false"
             id="rc_select_TEST_OR_SSR_list_1"
             role="option"
@@ -499,12 +524,19 @@ exports[`useInstance should get instance data from request 3`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active"
+                  label="instance_test_name (127.0.0.1:8081)"
                   title="instance_test_name (127.0.0.1:8081)"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    instance_test_name (127.0.0.1:8081)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        instance_test_name (127.0.0.1:8081)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -558,7 +590,13 @@ exports[`useInstance should show one database type which your choose 1`] = `
           class="ant-select-selection-item"
           title="oracle_instance_test_name"
         >
-          oracle_instance_test_name
+          <span
+            class="instance-option-label"
+          >
+            <span>
+              oracle_instance_test_name
+            </span>
+          </span>
         </span>
       </div>
       <span
@@ -627,7 +665,13 @@ exports[`useInstance should show one database type which your choose 2`] = `
           class="ant-select-selection-item"
           title="oracle_instance_test_name"
         >
-          oracle_instance_test_name
+          <span
+            class="instance-option-label"
+          >
+            <span>
+              oracle_instance_test_name
+            </span>
+          </span>
         </span>
       </div>
       <span
@@ -675,7 +719,6 @@ exports[`useInstance should show one database type which your choose 2`] = `
             role="presentation"
           />
           <div
-            aria-label="oracle_instance_test_name"
             aria-selected="true"
             id="rc_select_TEST_OR_SSR_list_1"
             role="option"
@@ -716,12 +759,19 @@ exports[`useInstance should show one database type which your choose 2`] = `
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active ant-select-item-option-selected"
+                  label="oracle_instance_test_name"
                   title="oracle_instance_test_name"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    oracle_instance_test_name
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        oracle_instance_test_name
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"

--- a/packages/sqle/src/hooks/useInstance/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/hooks/useInstance/__snapshots__/index.test.tsx.snap
@@ -139,7 +139,9 @@ exports[`useInstance should be group instance by database type 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql_instance_test_name_1
                       </span>
                     </span>
@@ -163,7 +165,9 @@ exports[`useInstance should be group instance by database type 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql_instance_test_name_2
                       </span>
                     </span>
@@ -204,7 +208,9 @@ exports[`useInstance should be group instance by database type 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         oracle_instance_test_name
                       </span>
                     </span>
@@ -245,7 +251,9 @@ exports[`useInstance should be group instance by database type 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         sqlserver_instance_test_name
                       </span>
                     </span>
@@ -533,7 +541,9 @@ exports[`useInstance should get instance data from request 3`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         instance_test_name (127.0.0.1:8081)
                       </span>
                     </span>
@@ -593,7 +603,9 @@ exports[`useInstance should show one database type which your choose 1`] = `
           <span
             class="instance-option-label"
           >
-            <span>
+            <span
+              style="white-space: nowrap;"
+            >
               oracle_instance_test_name
             </span>
           </span>
@@ -668,7 +680,9 @@ exports[`useInstance should show one database type which your choose 2`] = `
           <span
             class="instance-option-label"
           >
-            <span>
+            <span
+              style="white-space: nowrap;"
+            >
               oracle_instance_test_name
             </span>
           </span>
@@ -768,7 +782,9 @@ exports[`useInstance should show one database type which your choose 2`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         oracle_instance_test_name
                       </span>
                     </span>

--- a/packages/sqle/src/hooks/useInstance/index.tsx
+++ b/packages/sqle/src/hooks/useInstance/index.tsx
@@ -75,6 +75,7 @@ const useInstance = () => {
                     key={item.instance_name}
                     value={item.instance_name ?? ''}
                     label={label}
+                    title={label}
                   >
                     <span className="instance-option-label">
                       <EnvironmentTag
@@ -108,6 +109,7 @@ const useInstance = () => {
           .map((v) => ({
             value: v.instance_name,
             text: `${v.instance_name}(${v.host}:${v.port})`,
+            title: `${v.instance_name}(${v.host}:${v.port})`,
             label: (
               <span className="instance-option-label">
                 <EnvironmentTag
@@ -138,6 +140,7 @@ const useInstance = () => {
           .map((v) => ({
             value: v.instance_id,
             text: `${v.instance_name}(${v.host}:${v.port})`,
+            title: `${v.instance_name}(${v.host}:${v.port})`,
             label: (
               <span className="instance-option-label">
                 <EnvironmentTag

--- a/packages/sqle/src/hooks/useInstance/index.tsx
+++ b/packages/sqle/src/hooks/useInstance/index.tsx
@@ -6,6 +6,7 @@ import { instanceListDefaultKey } from '../../data/common';
 import { IGetInstanceTipListV2Params } from '@actiontech/shared/lib/api/sqle/service/instance/index.d';
 import { IInstanceTipResV2 } from '@actiontech/shared/lib/api/sqle/service/common';
 import { DatabaseTypeLogo } from '@actiontech/dms-kit';
+import { EnvironmentTag } from '@actiontech/shared';
 import useDatabaseType from '../useDatabaseType';
 import { SqleApi } from '@actiontech/shared/lib/api';
 const useInstance = () => {
@@ -65,14 +66,25 @@ const useInstance = () => {
             {filterInstanceList
               .filter((item) => item.instance_type === type)
               .map((item) => {
+                const label =
+                  !!item.host && !!item.port
+                    ? `${item.instance_name} (${item.host}:${item.port})`
+                    : item.instance_name;
                 return (
                   <Select.Option
                     key={item.instance_name}
                     value={item.instance_name ?? ''}
+                    label={label}
                   >
-                    {!!item.host && !!item.port
-                      ? `${item.instance_name} (${item.host}:${item.port})`
-                      : item.instance_name}
+                    <span className="instance-option-label">
+                      <EnvironmentTag
+                        name={item.environment_tag_name}
+                        color={item.environment_tag_color}
+                        size="small"
+                        style={{ marginRight: 6 }}
+                      />
+                      <span>{label}</span>
+                    </span>
                   </Select.Option>
                 );
               })}
@@ -95,7 +107,18 @@ const useInstance = () => {
           .filter((v) => v.instance_type === type)
           .map((v) => ({
             value: v.instance_name,
-            label: `${v.instance_name}(${v.host}:${v.port})`
+            text: `${v.instance_name}(${v.host}:${v.port})`,
+            label: (
+              <span className="instance-option-label">
+                <EnvironmentTag
+                  name={v.environment_tag_name}
+                  color={v.environment_tag_color}
+                  size="small"
+                  style={{ marginRight: 6 }}
+                />
+                <span>{`${v.instance_name}(${v.host}:${v.port})`}</span>
+              </span>
+            )
           }))
       };
     });
@@ -114,7 +137,18 @@ const useInstance = () => {
           .filter((v) => v.instance_type === type)
           .map((v) => ({
             value: v.instance_id,
-            label: `${v.instance_name}(${v.host}:${v.port})`
+            text: `${v.instance_name}(${v.host}:${v.port})`,
+            label: (
+              <span className="instance-option-label">
+                <EnvironmentTag
+                  name={v.environment_tag_name}
+                  color={v.environment_tag_color}
+                  size="small"
+                  style={{ marginRight: 6 }}
+                />
+                <span>{`${v.instance_name}(${v.host}:${v.port})`}</span>
+              </span>
+            )
           }))
       };
     });

--- a/packages/sqle/src/hooks/useInstance/index.tsx
+++ b/packages/sqle/src/hooks/useInstance/index.tsx
@@ -120,7 +120,9 @@ const useInstance = () => {
                   ellipsis={false}
                   style={{ marginRight: 6, flexShrink: 0 }}
                 />
-                <span style={{ whiteSpace: 'nowrap' }}>{`${v.instance_name}(${v.host}:${v.port})`}</span>
+                <span
+                  style={{ whiteSpace: 'nowrap' }}
+                >{`${v.instance_name}(${v.host}:${v.port})`}</span>
               </span>
             )
           }))
@@ -152,7 +154,9 @@ const useInstance = () => {
                   ellipsis={false}
                   style={{ marginRight: 6, flexShrink: 0 }}
                 />
-                <span style={{ whiteSpace: 'nowrap' }}>{`${v.instance_name}(${v.host}:${v.port})`}</span>
+                <span
+                  style={{ whiteSpace: 'nowrap' }}
+                >{`${v.instance_name}(${v.host}:${v.port})`}</span>
               </span>
             )
           }))

--- a/packages/sqle/src/hooks/useInstance/index.tsx
+++ b/packages/sqle/src/hooks/useInstance/index.tsx
@@ -82,9 +82,10 @@ const useInstance = () => {
                         name={item.environment_tag_name}
                         color={item.environment_tag_color}
                         size="small"
-                        style={{ marginRight: 6 }}
+                        ellipsis={false}
+                        style={{ marginRight: 6, flexShrink: 0 }}
                       />
-                      <span>{label}</span>
+                      <span style={{ whiteSpace: 'nowrap' }}>{label}</span>
                     </span>
                   </Select.Option>
                 );
@@ -116,9 +117,10 @@ const useInstance = () => {
                   name={v.environment_tag_name}
                   color={v.environment_tag_color}
                   size="small"
-                  style={{ marginRight: 6 }}
+                  ellipsis={false}
+                  style={{ marginRight: 6, flexShrink: 0 }}
                 />
-                <span>{`${v.instance_name}(${v.host}:${v.port})`}</span>
+                <span style={{ whiteSpace: 'nowrap' }}>{`${v.instance_name}(${v.host}:${v.port})`}</span>
               </span>
             )
           }))
@@ -147,9 +149,10 @@ const useInstance = () => {
                   name={v.environment_tag_name}
                   color={v.environment_tag_color}
                   size="small"
-                  style={{ marginRight: 6 }}
+                  ellipsis={false}
+                  style={{ marginRight: 6, flexShrink: 0 }}
                 />
-                <span>{`${v.instance_name}(${v.host}:${v.port})`}</span>
+                <span style={{ whiteSpace: 'nowrap' }}>{`${v.instance_name}(${v.host}:${v.port})`}</span>
               </span>
             )
           }))

--- a/packages/sqle/src/hooks/useServiceEnvironment/__tests__/index.test.tsx
+++ b/packages/sqle/src/hooks/useServiceEnvironment/__tests__/index.test.tsx
@@ -50,7 +50,15 @@ describe('sqle/hooks/useServiceEnvironment', () => {
     expect(result.current.environmentList).toEqual(mockEnvironmentTagsData);
     expect(result.current.environmentOptions).toEqual(
       mockEnvironmentTagsData.map((environment) => ({
-        label: environment.name,
+        label: expect.objectContaining({
+          props: expect.objectContaining({
+            name: environment.name,
+            color: environment.color,
+            size: 'small'
+          })
+        }),
+        text: environment.name,
+        title: environment.name,
         value: environment.uid
       }))
     );

--- a/packages/sqle/src/hooks/useServiceEnvironment/index.ts
+++ b/packages/sqle/src/hooks/useServiceEnvironment/index.ts
@@ -36,7 +36,8 @@ const useServiceEnvironment = () => {
         label: createElement(EnvironmentTag, {
           name: environment.name,
           color: environment.color,
-          size: 'small'
+          size: 'small',
+          ellipsis: false
         }),
         text: environment.name,
         title: environment.name,

--- a/packages/sqle/src/hooks/useServiceEnvironment/index.ts
+++ b/packages/sqle/src/hooks/useServiceEnvironment/index.ts
@@ -1,7 +1,8 @@
 import { useRequest } from 'ahooks';
 import { DmsApi } from '@actiontech/shared/lib/api';
 import { ResponseCode } from '@actiontech/dms-kit';
-import { useMemo } from 'react';
+import { createElement, useMemo } from 'react';
+import { EnvironmentTag } from '@actiontech/shared';
 
 const useServiceEnvironment = () => {
   const {
@@ -32,7 +33,12 @@ const useServiceEnvironment = () => {
   const environmentOptions = useMemo(() => {
     return (
       data?.map((environment) => ({
-        label: environment.name,
+        label: createElement(EnvironmentTag, {
+          name: environment.name,
+          color: environment.color,
+          size: 'small'
+        }),
+        text: environment.name,
         value: environment.uid
       })) ?? []
     );

--- a/packages/sqle/src/hooks/useServiceEnvironment/index.ts
+++ b/packages/sqle/src/hooks/useServiceEnvironment/index.ts
@@ -39,6 +39,7 @@ const useServiceEnvironment = () => {
           size: 'small'
         }),
         text: environment.name,
+        title: environment.name,
         value: environment.uid
       })) ?? []
     );

--- a/packages/sqle/src/page/CustomRule/CreateCustomRule/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/CustomRule/CreateCustomRule/__snapshots__/index.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -318,7 +318,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -461,7 +461,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -555,7 +555,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -649,7 +649,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -766,7 +766,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 1`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -877,7 +877,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2466,7 +2466,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2571,7 +2571,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -2714,7 +2714,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2808,7 +2808,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2902,7 +2902,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -3019,7 +3019,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 2`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -3130,7 +3130,7 @@ exports[`sqle/CustomRule/CreateCustomRule create custom rule 2`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -4727,7 +4727,7 @@ exports[`sqle/CustomRule/CreateCustomRule return to custom list page 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -4820,7 +4820,7 @@ exports[`sqle/CustomRule/CreateCustomRule return to custom list page 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -4926,7 +4926,7 @@ exports[`sqle/CustomRule/CreateCustomRule return to custom list page 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -5019,7 +5019,7 @@ exports[`sqle/CustomRule/CreateCustomRule return to custom list page 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -5112,7 +5112,7 @@ exports[`sqle/CustomRule/CreateCustomRule return to custom list page 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -5228,7 +5228,7 @@ exports[`sqle/CustomRule/CreateCustomRule return to custom list page 1`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -5320,7 +5320,7 @@ exports[`sqle/CustomRule/CreateCustomRule return to custom list page 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"

--- a/packages/sqle/src/page/CustomRule/CustomRuleForm/test/__snapshots__/CustomRuleForm.test.tsx.snap
+++ b/packages/sqle/src/page/CustomRule/CustomRuleForm/test/__snapshots__/CustomRuleForm.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`sqle/CustomRule/Form should match snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -234,7 +234,7 @@ exports[`sqle/CustomRule/Form should match snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -340,7 +340,7 @@ exports[`sqle/CustomRule/Form should match snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -433,7 +433,7 @@ exports[`sqle/CustomRule/Form should match snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -526,7 +526,7 @@ exports[`sqle/CustomRule/Form should match snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -642,7 +642,7 @@ exports[`sqle/CustomRule/Form should match snap 1`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -734,7 +734,7 @@ exports[`sqle/CustomRule/Form should match snap 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1013,7 +1013,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -1119,7 +1119,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -1304,7 +1304,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1398,7 +1398,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1492,7 +1492,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1609,7 +1609,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 1`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1701,7 +1701,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1980,7 +1980,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -2086,7 +2086,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -2271,7 +2271,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2365,7 +2365,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2459,7 +2459,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2576,7 +2576,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 2`] = `
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2668,7 +2668,7 @@ exports[`sqle/CustomRule/Form should match snap when provide defaultData 2`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"

--- a/packages/sqle/src/page/CustomRule/CustomRuleList/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/CustomRule/CustomRuleList/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`sqle/CustomRuleList click rule item 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       style="width: 200px;"
                     >
                       <div
@@ -1128,7 +1128,7 @@ exports[`sqle/CustomRuleList should match snap shot 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       style="width: 200px;"
                     >
                       <div
@@ -1834,7 +1834,7 @@ exports[`sqle/CustomRuleList should render empty tips when request return null 1
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       style="width: 200px;"
                     >
                       <div

--- a/packages/sqle/src/page/CustomRule/UpdateCustomRule/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/CustomRule/UpdateCustomRule/__snapshots__/index.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`sqle/CustomRule/UpdateCustomRule return to custom list page 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -312,7 +312,7 @@ exports[`sqle/CustomRule/UpdateCustomRule return to custom list page 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -497,7 +497,7 @@ exports[`sqle/CustomRule/UpdateCustomRule return to custom list page 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -591,7 +591,7 @@ exports[`sqle/CustomRule/UpdateCustomRule return to custom list page 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -685,7 +685,7 @@ exports[`sqle/CustomRule/UpdateCustomRule return to custom list page 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -802,7 +802,7 @@ exports[`sqle/CustomRule/UpdateCustomRule return to custom list page 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -894,7 +894,7 @@ exports[`sqle/CustomRule/UpdateCustomRule return to custom list page 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -1677,7 +1677,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -1783,7 +1783,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2010,7 +2010,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2104,7 +2104,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2198,7 +2198,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2315,7 +2315,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2426,7 +2426,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3996,7 +3996,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 2`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4102,7 +4102,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 2`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4329,7 +4329,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 2`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4423,7 +4423,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 2`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4517,7 +4517,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 2`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4634,7 +4634,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 2`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4745,7 +4745,7 @@ exports[`sqle/CustomRule/UpdateCustomRule update custom rule 2`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"

--- a/packages/sqle/src/page/GlobalDashboard/__tests__/__snapshots__/index.sqle.test.tsx.snap
+++ b/packages/sqle/src/page/GlobalDashboard/__tests__/__snapshots__/index.sqle.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`GlobalDashboard should render workflow tab by default 1`] = `
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -163,7 +163,7 @@ exports[`GlobalDashboard should render workflow tab by default 1`] = `
                 class="ant-space-item"
               >
                 <div
-                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/sqle/src/page/GlobalDashboard/components/TableFilter/index.tsx
+++ b/packages/sqle/src/page/GlobalDashboard/components/TableFilter/index.tsx
@@ -1,4 +1,4 @@
-import { Form, Space } from 'antd';
+import { Form, Space, SelectProps } from 'antd';
 import { CustomSelect } from '@actiontech/dms-kit';
 import { useTranslation } from 'react-i18next';
 import { GlobalDashboardFilterStyleWrapper } from '../../style';
@@ -24,7 +24,9 @@ const GlobalDashboardTableFilter: React.FC<GlobalDashboardTableFilterProps> = ({
               placeholder={t('common.all')}
               suffixIcon={null}
               options={projectOptions}
-              onChange={(value) => {
+              onChange={(
+                value: Parameters<NonNullable<SelectProps['onChange']>>[0]
+              ) => {
                 onProjectChange?.(value as string);
               }}
             />

--- a/packages/sqle/src/page/GlobalRuleTemplate/CreateRuleTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/GlobalRuleTemplate/CreateRuleTemplate/__snapshots__/index.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate create global rule template 
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -353,7 +353,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate create global rule template 
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -604,7 +604,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate create global rule template 
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -662,7 +662,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate create global rule template 
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -720,7 +720,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate create global rule template 
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -778,7 +778,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate create global rule template 
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -842,7 +842,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate create global rule template 
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2038,7 +2038,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2161,7 +2161,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2412,7 +2412,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2470,7 +2470,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2528,7 +2528,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2586,7 +2586,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2650,7 +2650,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4097,7 +4097,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate rule list action 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4474,7 +4474,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate should match snap shot 1`] =
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -4567,7 +4567,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate should match snap shot 1`] =
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -4802,7 +4802,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate should match snap shot 1`] =
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4860,7 +4860,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate should match snap shot 1`] =
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4918,7 +4918,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate should match snap shot 1`] =
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4976,7 +4976,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate should match snap shot 1`] =
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -5040,7 +5040,7 @@ exports[`sqle/GlobalRuleTemplate/CreateRuleTemplate should match snap shot 1`] =
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/GlobalRuleTemplate/ImportRuleTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/GlobalRuleTemplate/ImportRuleTemplate/__snapshots__/index.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate import global rule template 
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -340,7 +340,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate import global rule template 
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -574,7 +574,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate import global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -632,7 +632,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate import global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -690,7 +690,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate import global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -748,7 +748,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate import global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -812,7 +812,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate import global rule template 
                               style="margin-right: 4px;"
                             >
                               <div
-                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -3331,7 +3331,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3437,7 +3437,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3671,7 +3671,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3729,7 +3729,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3787,7 +3787,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3845,7 +3845,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3909,7 +3909,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                               style="margin-right: 4px;"
                             >
                               <div
-                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -5184,7 +5184,7 @@ exports[`sqle/GlobalRuleTemplate/ImportRuleTemplate rule list action 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/GlobalRuleTemplate/RuleTemplateDetail/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/GlobalRuleTemplate/RuleTemplateDetail/__snapshots__/index.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`sqle/GlobalRuleTemplate/RuleTemplateDetail should match snap shot 1`] =
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -360,7 +360,7 @@ exports[`sqle/GlobalRuleTemplate/RuleTemplateDetail should match snap shot 1`] =
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -418,7 +418,7 @@ exports[`sqle/GlobalRuleTemplate/RuleTemplateDetail should match snap shot 1`] =
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -476,7 +476,7 @@ exports[`sqle/GlobalRuleTemplate/RuleTemplateDetail should match snap shot 1`] =
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"
@@ -540,7 +540,7 @@ exports[`sqle/GlobalRuleTemplate/RuleTemplateDetail should match snap shot 1`] =
                         style="margin-right: 4px;"
                       >
                         <div
-                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                         >
                           <div
                             class="ant-select-selector"

--- a/packages/sqle/src/page/GlobalRuleTemplate/UpdateRuleTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/GlobalRuleTemplate/UpdateRuleTemplate/__snapshots__/index.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -343,7 +343,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -577,7 +577,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -635,7 +635,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -693,7 +693,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -751,7 +751,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -815,7 +815,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                               style="margin-right: 4px;"
                             >
                               <div
-                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -2090,7 +2090,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2474,7 +2474,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate should match snap shot 1`] =
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2580,7 +2580,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate should match snap shot 1`] =
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2838,7 +2838,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate should match snap shot 1`] =
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2896,7 +2896,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate should match snap shot 1`] =
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2954,7 +2954,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate should match snap shot 1`] =
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3012,7 +3012,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate should match snap shot 1`] =
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3076,7 +3076,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate should match snap shot 1`] =
                               style="margin-right: 4px;"
                             >
                               <div
-                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -4082,7 +4082,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate update global rule template 
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4188,7 +4188,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate update global rule template 
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4423,7 +4423,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate update global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4481,7 +4481,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate update global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4539,7 +4539,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate update global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4597,7 +4597,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate update global rule template 
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4661,7 +4661,7 @@ exports[`sqle/GlobalRuleTemplate/UpdateRuleTemplate update global rule template 
                               style="margin-right: 4px;"
                             >
                               <div
-                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"

--- a/packages/sqle/src/page/OperationRecord/List/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/OperationRecord/List/__snapshots__/index.test.tsx.snap
@@ -257,7 +257,7 @@ exports[`sqle/OperationRecord/List render action when filter item show 1`] = `
           style="padding-bottom: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"

--- a/packages/sqle/src/page/PipelineConfiguration/Common/ConfigurationForm/PipelineNodeField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/PipelineConfiguration/Common/ConfigurationForm/PipelineNodeField/__tests__/__snapshots__/index.test.tsx.snap
@@ -386,7 +386,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add offline node  1
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -491,7 +491,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add offline node  1
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -644,7 +644,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add offline node  1
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -737,7 +737,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add offline node  1
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -841,7 +841,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add offline node  1
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1341,7 +1341,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add online node  1`
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1446,7 +1446,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add online node  1`
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1600,7 +1600,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add online node  1`
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1704,7 +1704,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add online node  1`
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1808,7 +1808,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render add online node  1`
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2911,7 +2911,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render update node  1`] = 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3016,7 +3016,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render update node  1`] = 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3170,7 +3170,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render update node  1`] = 
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3263,7 +3263,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render update node  1`] = 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3397,7 +3397,7 @@ exports[`sqle/PipelineConfiguration/PipelineNodeField render update node  1`] = 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/PipelineConfiguration/Common/ConfigurationForm/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/PipelineConfiguration/Common/ConfigurationForm/__tests__/__snapshots__/index.test.tsx.snap
@@ -1227,7 +1227,7 @@ exports[`sqle//PipelineConfiguration/Form render node modal 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1332,7 +1332,7 @@ exports[`sqle//PipelineConfiguration/Form render node modal 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1485,7 +1485,7 @@ exports[`sqle//PipelineConfiguration/Form render node modal 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1578,7 +1578,7 @@ exports[`sqle//PipelineConfiguration/Form render node modal 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1682,7 +1682,7 @@ exports[`sqle//PipelineConfiguration/Form render node modal 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/PipelineConfiguration/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/PipelineConfiguration/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -592,7 +592,7 @@ exports[`sqle//PipelineConfiguration/Create render create pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -697,7 +697,7 @@ exports[`sqle//PipelineConfiguration/Create render create pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -850,7 +850,7 @@ exports[`sqle//PipelineConfiguration/Create render create pipeline 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -943,7 +943,7 @@ exports[`sqle//PipelineConfiguration/Create render create pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1047,7 +1047,7 @@ exports[`sqle//PipelineConfiguration/Create render create pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/PipelineConfiguration/Update/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/PipelineConfiguration/Update/__tests__/__snapshots__/index.test.tsx.snap
@@ -1200,7 +1200,7 @@ exports[`sqle//PipelineConfiguration/Update render update pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1305,7 +1305,7 @@ exports[`sqle//PipelineConfiguration/Update render update pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1459,7 +1459,7 @@ exports[`sqle//PipelineConfiguration/Update render update pipeline 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1552,7 +1552,7 @@ exports[`sqle//PipelineConfiguration/Update render update pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1686,7 +1686,7 @@ exports[`sqle//PipelineConfiguration/Update render update pipeline 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/PushRuleConfiguration/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/PushRuleConfiguration/__snapshots__/index.test.tsx.snap
@@ -438,7 +438,7 @@ exports[`test PushRuleConfiguration should match snapshot 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-loading ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -489,26 +489,26 @@ exports[`test PushRuleConfiguration should match snapshot 1`] = `
                             </div>
                             <span
                               aria-hidden="true"
-                              class="ant-select-arrow ant-select-arrow-loading"
+                              class="ant-select-arrow"
                               style="user-select: none;"
                               unselectable="on"
                             >
                               <span
-                                aria-label="loading"
-                                class="anticon anticon-loading anticon-spin"
+                                aria-label="down"
+                                class="anticon anticon-down ant-select-suffix"
                                 role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  data-icon="loading"
+                                  data-icon="down"
                                   fill="currentColor"
                                   focusable="false"
                                   height="1em"
-                                  viewBox="0 0 1024 1024"
+                                  viewBox="64 64 896 896"
                                   width="1em"
                                 >
                                   <path
-                                    d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
                                   />
                                 </svg>
                               </span>

--- a/packages/sqle/src/page/PushRuleConfiguration/components/SqlManagementIssuePush/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/PushRuleConfiguration/components/SqlManagementIssuePush/__tests__/__snapshots__/index.test.tsx.snap
@@ -227,7 +227,7 @@ exports[`test SqlManagementIssuePush should call onSubmit function correctly whe
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"
@@ -718,7 +718,7 @@ exports[`test SqlManagementIssuePush should render the component and display ini
                 >
                   <div
                     aria-required="true"
-                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                   >
                     <div
                       class="ant-select-selector"
@@ -1244,7 +1244,7 @@ exports[`test SqlManagementIssuePush should set the form to edit state and fill 
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-loading ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-loading ant-select-show-search"
                     >
                       <div
                         class="ant-select-selector"

--- a/packages/sqle/src/page/PushRuleConfiguration/index.test.tsx
+++ b/packages/sqle/src/page/PushRuleConfiguration/index.test.tsx
@@ -3,6 +3,7 @@ import { mockUseCurrentProject } from '@actiontech/shared/lib/testUtil/mockHook/
 import PushRuleConfiguration from '.';
 import { sqleSuperRender } from '../../testUtils/superRender';
 import MockReportPushConfigService from '@actiontech/shared/lib/testUtil/mockApi/sqle/reportPushConfigService';
+import user from '@actiontech/shared/lib/testUtil/mockApi/sqle/user';
 import { mockUseCurrentUser } from '@actiontech/shared/lib/testUtil/mockHook/mockUseCurrentUser';
 import { mockProjectInfo } from '@actiontech/shared/lib/testUtil/mockHook/data';
 import { act } from '@testing-library/react';
@@ -17,6 +18,7 @@ jest.mock('react-redux', () => {
 
 describe('test PushRuleConfiguration', () => {
   let mockGetReportPushConfigList: jest.SpyInstance;
+  let mockGetUserTipList: jest.SpyInstance;
   beforeEach(() => {
     jest.useFakeTimers();
     MockDate.set('2024-12-12:12:00:00');
@@ -25,6 +27,7 @@ describe('test PushRuleConfiguration', () => {
     mockUsePermission(undefined, { mockSelector: true });
     mockGetReportPushConfigList =
       MockReportPushConfigService.GetReportPushConfigList();
+    mockGetUserTipList = user.getUserTipList();
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -37,6 +40,9 @@ describe('test PushRuleConfiguration', () => {
     expect(mockGetReportPushConfigList).toHaveBeenCalledTimes(1);
     expect(mockGetReportPushConfigList).toHaveBeenCalledWith({
       project_name: mockProjectInfo.projectName
+    });
+    expect(mockGetUserTipList).toHaveBeenCalledWith({
+      filter_project: mockProjectInfo.projectName
     });
 
     await act(async () => jest.advanceTimersByTime(3000));

--- a/packages/sqle/src/page/Rule/RuleListFilter/CustomSelectField.tsx
+++ b/packages/sqle/src/page/Rule/RuleListFilter/CustomSelectField.tsx
@@ -1,4 +1,5 @@
 import { CustomSelect, CustomSelectProps } from '@actiontech/dms-kit';
+import { SelectProps } from 'antd';
 
 const CustomSelectField: React.FC<
   CustomSelectProps & { onAfterChange: (v: string) => void }
@@ -6,9 +7,12 @@ const CustomSelectField: React.FC<
   return (
     <CustomSelect
       {...props}
-      onChange={(v, option) => {
+      onChange={(
+        v: Parameters<NonNullable<SelectProps['onChange']>>[0],
+        option: Parameters<NonNullable<SelectProps['onChange']>>[1]
+      ) => {
         onChange?.(v, option);
-        onAfterChange(v);
+        onAfterChange(v as string);
       }}
     />
   );

--- a/packages/sqle/src/page/Rule/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/Rule/__snapshots__/index.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow ant-select-disabled"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow ant-select-disabled"
                   >
                     <div
                       class="ant-select-selector"
@@ -212,32 +212,19 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                       <span
                         class="ant-select-selection-item"
                       >
-                        <span
-                          class="custom-select-option-content css-17mg133"
+                        <div
+                          class="css-1uw16ge"
                         >
+                          <img
+                            alt=""
+                            src=""
+                          />
                           <span
-                            class="custom-select-option-content-prefix"
+                            title="MySQL"
                           >
-                            数据库类型
+                            MySQL
                           </span>
-                          <span
-                            class="custom-select-option-content-label"
-                          >
-                            <div
-                              class="css-1uw16ge"
-                            >
-                              <img
-                                alt=""
-                                src=""
-                              />
-                              <span
-                                title="MySQL"
-                              >
-                                MySQL
-                              </span>
-                            </div>
-                          </span>
-                        </span>
+                        </div>
                       </span>
                     </div>
                     <span
@@ -253,7 +240,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow ant-select-disabled"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow ant-select-disabled"
                   >
                     <div
                       class="ant-select-selector"
@@ -284,7 +271,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -292,7 +279,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                             规则版本
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             v2
                           </span>
@@ -312,7 +299,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <span
                       aria-live="polite"
@@ -348,7 +335,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -356,7 +343,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                             项目
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             default
                           </span>
@@ -394,7 +381,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -424,7 +411,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -432,7 +419,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                             规则模板
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             default_MySQL
                           </span>
@@ -477,7 +464,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -535,7 +522,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -593,7 +580,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -651,7 +638,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -715,7 +702,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1002,7 +989,7 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -1224,7 +1211,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -1253,32 +1240,19 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                       <span
                         class="ant-select-selection-item"
                       >
-                        <span
-                          class="custom-select-option-content css-17mg133"
+                        <div
+                          class="css-1uw16ge"
                         >
+                          <img
+                            alt=""
+                            src=""
+                          />
                           <span
-                            class="custom-select-option-content-prefix"
+                            title="MySQL"
                           >
-                            数据库类型
+                            MySQL
                           </span>
-                          <span
-                            class="custom-select-option-content-label"
-                          >
-                            <div
-                              class="css-1uw16ge"
-                            >
-                              <img
-                                alt=""
-                                src=""
-                              />
-                              <span
-                                title="MySQL"
-                              >
-                                MySQL
-                              </span>
-                            </div>
-                          </span>
-                        </span>
+                        </div>
                       </span>
                     </div>
                     <span
@@ -1294,7 +1268,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -1324,7 +1298,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -1332,7 +1306,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                             规则版本
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             v1
                           </span>
@@ -1352,7 +1326,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <span
                       aria-live="polite"
@@ -1388,7 +1362,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -1396,7 +1370,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                             项目
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             default
                           </span>
@@ -1434,7 +1408,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -1499,7 +1473,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1557,7 +1531,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1615,7 +1589,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1673,7 +1647,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1737,7 +1711,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1896,7 +1870,7 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -2118,7 +2092,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -2147,32 +2121,19 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                       <span
                         class="ant-select-selection-item"
                       >
-                        <span
-                          class="custom-select-option-content css-17mg133"
+                        <div
+                          class="css-1uw16ge"
                         >
+                          <img
+                            alt=""
+                            src=""
+                          />
                           <span
-                            class="custom-select-option-content-prefix"
+                            title="MySQL"
                           >
-                            数据库类型
+                            MySQL
                           </span>
-                          <span
-                            class="custom-select-option-content-label"
-                          >
-                            <div
-                              class="css-1uw16ge"
-                            >
-                              <img
-                                alt=""
-                                src=""
-                              />
-                              <span
-                                title="MySQL"
-                              >
-                                MySQL
-                              </span>
-                            </div>
-                          </span>
-                        </span>
+                        </div>
                       </span>
                     </div>
                     <span
@@ -2188,7 +2149,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -2218,7 +2179,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -2226,7 +2187,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                             规则版本
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             v1
                           </span>
@@ -2246,7 +2207,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <span
                       aria-live="polite"
@@ -2282,7 +2243,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -2290,7 +2251,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                             项目
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             default
                           </span>
@@ -2328,7 +2289,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -2393,7 +2354,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2451,7 +2412,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2509,7 +2470,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2567,7 +2528,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2631,7 +2592,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2782,7 +2743,7 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -3004,7 +2965,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -3033,32 +2994,19 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                       <span
                         class="ant-select-selection-item"
                       >
-                        <span
-                          class="custom-select-option-content css-17mg133"
+                        <div
+                          class="css-1uw16ge"
                         >
+                          <img
+                            alt=""
+                            src=""
+                          />
                           <span
-                            class="custom-select-option-content-prefix"
+                            title="MySQL"
                           >
-                            数据库类型
+                            MySQL
                           </span>
-                          <span
-                            class="custom-select-option-content-label"
-                          >
-                            <div
-                              class="css-1uw16ge"
-                            >
-                              <img
-                                alt=""
-                                src=""
-                              />
-                              <span
-                                title="MySQL"
-                              >
-                                MySQL
-                              </span>
-                            </div>
-                          </span>
-                        </span>
+                        </div>
                       </span>
                     </div>
                     <span
@@ -3074,7 +3022,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -3104,7 +3052,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -3112,7 +3060,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                             规则版本
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             v1
                           </span>
@@ -3132,7 +3080,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -3190,7 +3138,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -3255,7 +3203,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -3313,7 +3261,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -3371,7 +3319,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -3429,7 +3377,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -3493,7 +3441,7 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4093,7 +4041,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -4122,32 +4070,19 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                       <span
                         class="ant-select-selection-item"
                       >
-                        <span
-                          class="custom-select-option-content css-17mg133"
+                        <div
+                          class="css-1uw16ge"
                         >
+                          <img
+                            alt=""
+                            src=""
+                          />
                           <span
-                            class="custom-select-option-content-prefix"
+                            title="MySQL"
                           >
-                            数据库类型
+                            MySQL
                           </span>
-                          <span
-                            class="custom-select-option-content-label"
-                          >
-                            <div
-                              class="css-1uw16ge"
-                            >
-                              <img
-                                alt=""
-                                src=""
-                              />
-                              <span
-                                title="MySQL"
-                              >
-                                MySQL
-                              </span>
-                            </div>
-                          </span>
-                        </span>
+                        </div>
                       </span>
                     </div>
                     <span
@@ -4163,7 +4098,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -4193,7 +4128,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                         class="ant-select-selection-item"
                       >
                         <span
-                          class="custom-select-option-content css-17mg133"
+                          class="custom-select-option-content css-1xzd9w3"
                         >
                           <span
                             class="custom-select-option-content-prefix"
@@ -4201,7 +4136,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                             规则版本
                           </span>
                           <span
-                            class="custom-select-option-content-label"
+                            class="custom-select-option-content-label is-text-label"
                           >
                             v1
                           </span>
@@ -4221,7 +4156,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -4279,7 +4214,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                   style="margin-right: 12px; padding-bottom: 8px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -4344,7 +4279,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4402,7 +4337,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4460,7 +4395,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4518,7 +4453,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4582,7 +4517,7 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/Rule/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/Rule/__snapshots__/index.test.tsx.snap
@@ -223,7 +223,19 @@ exports[`sqle/Rule should filter list based on project name correctly 1`] = `
                           <span
                             class="custom-select-option-content-label"
                           >
-                            MySQL
+                            <div
+                              class="css-1uw16ge"
+                            >
+                              <img
+                                alt=""
+                                src=""
+                              />
+                              <span
+                                title="MySQL"
+                              >
+                                MySQL
+                              </span>
+                            </div>
                           </span>
                         </span>
                       </span>
@@ -1252,7 +1264,19 @@ exports[`sqle/Rule should filter list based on project name correctly 2`] = `
                           <span
                             class="custom-select-option-content-label"
                           >
-                            MySQL
+                            <div
+                              class="css-1uw16ge"
+                            >
+                              <img
+                                alt=""
+                                src=""
+                              />
+                              <span
+                                title="MySQL"
+                              >
+                                MySQL
+                              </span>
+                            </div>
                           </span>
                         </span>
                       </span>
@@ -2134,7 +2158,19 @@ exports[`sqle/Rule should hide empty list tips for archived projects 1`] = `
                           <span
                             class="custom-select-option-content-label"
                           >
-                            MySQL
+                            <div
+                              class="css-1uw16ge"
+                            >
+                              <img
+                                alt=""
+                                src=""
+                              />
+                              <span
+                                title="MySQL"
+                              >
+                                MySQL
+                              </span>
+                            </div>
                           </span>
                         </span>
                       </span>
@@ -3008,7 +3044,19 @@ exports[`sqle/Rule should render Rule component correctly and match snapshot 1`]
                           <span
                             class="custom-select-option-content-label"
                           >
-                            MySQL
+                            <div
+                              class="css-1uw16ge"
+                            >
+                              <img
+                                alt=""
+                                src=""
+                              />
+                              <span
+                                title="MySQL"
+                              >
+                                MySQL
+                              </span>
+                            </div>
                           </span>
                         </span>
                       </span>
@@ -4085,7 +4133,19 @@ exports[`sqle/Rule should show empty state when request returns no data 1`] = `
                           <span
                             class="custom-select-option-content-label"
                           >
-                            MySQL
+                            <div
+                              class="css-1uw16ge"
+                            >
+                              <img
+                                alt=""
+                                src=""
+                              />
+                              <span
+                                title="MySQL"
+                              >
+                                MySQL
+                              </span>
+                            </div>
                           </span>
                         </span>
                       </span>

--- a/packages/sqle/src/page/RuleManager/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleManager/__tests__/__snapshots__/index.test.tsx.snap
@@ -903,7 +903,7 @@ exports[`sqle/RuleManager should render custom rule list 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             style="width: 200px;"
                           >
                             <div

--- a/packages/sqle/src/page/RuleTemplate/CreateRuleTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/CreateRuleTemplate/__snapshots__/index.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate create rule template 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -353,7 +353,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate create rule template 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -604,7 +604,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate create rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -662,7 +662,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate create rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -720,7 +720,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate create rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -778,7 +778,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate create rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -842,7 +842,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate create rule template 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2038,7 +2038,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2161,7 +2161,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -2412,7 +2412,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2470,7 +2470,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2528,7 +2528,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2586,7 +2586,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2650,7 +2650,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4097,7 +4097,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate rule list action 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4474,7 +4474,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate should match snap shot 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -4567,7 +4567,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate should match snap shot 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -4802,7 +4802,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4860,7 +4860,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4918,7 +4918,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4976,7 +4976,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -5040,7 +5040,7 @@ exports[`sqle/RuleTemplate/CreateRuleTemplate should match snap shot 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/EditRuleTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/EditRuleTemplate/__snapshots__/index.test.tsx.snap
@@ -559,7 +559,7 @@ exports[`sqle/RuleTemplate/EditRuleTemplate should match snap shot 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1004,7 +1004,7 @@ exports[`sqle/RuleTemplate/EditRuleTemplate when dataSource is empty object 1`] 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1677,7 +1677,7 @@ exports[`sqle/RuleTemplate/EditRuleTemplate when param type is boolean 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/ImportRuleTemplate/FileUpload/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/ImportRuleTemplate/FileUpload/__snapshots__/index.test.tsx.snap
@@ -442,7 +442,7 @@ exports[`test FileUpload should render the DownloadTemplateModal component when 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -746,7 +746,7 @@ exports[`test FileUpload should render the DownloadTemplateModal component when 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/ImportRuleTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/ImportRuleTemplate/__snapshots__/index.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate import rule template 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -340,7 +340,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate import rule template 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -574,7 +574,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate import rule template 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -632,7 +632,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate import rule template 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -690,7 +690,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate import rule template 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -748,7 +748,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate import rule template 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -812,7 +812,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate import rule template 1`] = `
                               style="margin-right: 4px;"
                             >
                               <div
-                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -3331,7 +3331,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3437,7 +3437,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3671,7 +3671,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3729,7 +3729,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3787,7 +3787,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3845,7 +3845,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                           style="margin-right: 12px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3909,7 +3909,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                               style="margin-right: 4px;"
                             >
                               <div
-                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -5184,7 +5184,7 @@ exports[`sqle/RuleTemplate/ImportRuleTemplate rule list action 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/RuleTemplateDetail/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/RuleTemplateDetail/__snapshots__/index.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`sqle/RuleTemplate/RuleTemplateDetail should match snap shot 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -359,7 +359,7 @@ exports[`sqle/RuleTemplate/RuleTemplateDetail should match snap shot 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -417,7 +417,7 @@ exports[`sqle/RuleTemplate/RuleTemplateDetail should match snap shot 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -475,7 +475,7 @@ exports[`sqle/RuleTemplate/RuleTemplateDetail should match snap shot 1`] = `
                     style="margin-right: 12px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -539,7 +539,7 @@ exports[`sqle/RuleTemplate/RuleTemplateDetail should match snap shot 1`] = `
                         style="margin-right: 4px;"
                       >
                         <div
-                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                          class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/RuleTemplateForm/BaseInfoForm/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/RuleTemplateForm/BaseInfoForm/__snapshots__/index.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`sqle/RuleTemplate/BaseInfoForm should match snap shot 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -218,7 +218,7 @@ exports[`sqle/RuleTemplate/BaseInfoForm should match snap shot 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/RuleTemplateForm/RuleSelect/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/RuleTemplateForm/RuleSelect/__snapshots__/index.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`sqle/RuleTemplate/RuleSelect should match snap shot 1`] = `
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                 >
                   <div
                     class="ant-select-selector"
@@ -215,7 +215,7 @@ exports[`sqle/RuleTemplate/RuleSelect should match snap shot 1`] = `
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                 >
                   <div
                     class="ant-select-selector"
@@ -273,7 +273,7 @@ exports[`sqle/RuleTemplate/RuleSelect should match snap shot 1`] = `
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                 >
                   <div
                     class="ant-select-selector"
@@ -331,7 +331,7 @@ exports[`sqle/RuleTemplate/RuleSelect should match snap shot 1`] = `
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                 >
                   <div
                     class="ant-select-selector"
@@ -395,7 +395,7 @@ exports[`sqle/RuleTemplate/RuleSelect should match snap shot 1`] = `
                     style="margin-right: 4px;"
                   >
                     <div
-                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                      class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                     >
                       <div
                         class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/RuleTemplateForm/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/RuleTemplateForm/__snapshots__/index.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`sqle/RuleTemplate/RuleTemplateForm should match snap shot 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -252,7 +252,7 @@ exports[`sqle/RuleTemplate/RuleTemplateForm should match snap shot 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -486,7 +486,7 @@ exports[`sqle/RuleTemplate/RuleTemplateForm should match snap shot 1`] = `
                   style="margin-right: 12px;"
                 >
                   <div
-                    class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                    class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                   >
                     <div
                       class="ant-select-selector"
@@ -544,7 +544,7 @@ exports[`sqle/RuleTemplate/RuleTemplateForm should match snap shot 1`] = `
                   style="margin-right: 12px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                   >
                     <div
                       class="ant-select-selector"
@@ -602,7 +602,7 @@ exports[`sqle/RuleTemplate/RuleTemplateForm should match snap shot 1`] = `
                   style="margin-right: 12px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                   >
                     <div
                       class="ant-select-selector"
@@ -660,7 +660,7 @@ exports[`sqle/RuleTemplate/RuleTemplateForm should match snap shot 1`] = `
                   style="margin-right: 12px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                   >
                     <div
                       class="ant-select-selector"
@@ -724,7 +724,7 @@ exports[`sqle/RuleTemplate/RuleTemplateForm should match snap shot 1`] = `
                       style="margin-right: 4px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                       >
                         <div
                           class="ant-select-selector"

--- a/packages/sqle/src/page/RuleTemplate/UpdateRuleTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/RuleTemplate/UpdateRuleTemplate/__snapshots__/index.test.tsx.snap
@@ -231,7 +231,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -337,7 +337,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -571,7 +571,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -629,7 +629,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -687,7 +687,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -745,7 +745,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -809,7 +809,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2082,7 +2082,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate rule list action 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2460,7 +2460,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate should match snap shot 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -2566,7 +2566,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate should match snap shot 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -2824,7 +2824,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2882,7 +2882,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2940,7 +2940,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -2998,7 +2998,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate should match snap shot 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -3062,7 +3062,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate should match snap shot 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4060,7 +4060,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate update rule template 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -4166,7 +4166,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate update rule template 1`] = `
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"
@@ -4401,7 +4401,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate update rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4459,7 +4459,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate update rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4517,7 +4517,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate update rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4575,7 +4575,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate update rule template 1`] = `
                       style="margin-right: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4639,7 +4639,7 @@ exports[`sqle/RuleTemplate/UpdateRuleTemplate update rule template 1`] = `
                           style="margin-right: 4px;"
                         >
                           <div
-                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/SqlAudit/Create/SQLInfoForm/DatabaseInfo.tsx
+++ b/packages/sqle/src/page/SqlAudit/Create/SQLInfoForm/DatabaseInfo.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { AuditTypeEnum, DatabaseInfoProps } from './index.type';
 import { FormItemLabel, FormItemNoLabel } from '@actiontech/dms-kit';
 import { useCallback, useContext, useMemo, useState } from 'react';
-import { Form, Space } from 'antd';
+import { Form, Space, SelectProps } from 'antd';
 import { CustomSelect } from '@actiontech/dms-kit';
 import useInstanceSchema from '../../../../hooks/useInstanceSchema';
 import { IInstanceResV2 } from '@actiontech/shared/lib/api/sqle/service/common';
@@ -152,7 +152,9 @@ const DatabaseInfo = ({
             disabled={submitLoading}
             loading={instanceLoading}
             options={instanceOptions}
-            onChange={(value) => handleInstanceNameChange(value)}
+            onChange={(
+              value: Parameters<NonNullable<SelectProps['onChange']>>[0]
+            ) => handleInstanceNameChange(value as string)}
           />
         </FormItemNoLabel>
         <FormItemNoLabel

--- a/packages/sqle/src/page/SqlAudit/Create/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAudit/Create/__snapshots__/index.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`sqle/SqlAudit/Create enter default content to create sql audit 1`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-open ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-open ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -325,7 +325,7 @@ exports[`sqle/SqlAudit/Create enter default content to create sql audit 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -453,7 +453,7 @@ exports[`sqle/SqlAudit/Create enter default content to create sql audit 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -576,7 +576,7 @@ exports[`sqle/SqlAudit/Create enter default content to create sql audit 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -735,7 +735,7 @@ exports[`sqle/SqlAudit/Create enter default content to create sql audit 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"
@@ -1649,7 +1649,7 @@ exports[`sqle/SqlAudit/Create select static audit type 1`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -1858,7 +1858,7 @@ exports[`sqle/SqlAudit/Create select static audit type 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1988,7 +1988,7 @@ exports[`sqle/SqlAudit/Create select static audit type 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2109,7 +2109,7 @@ exports[`sqle/SqlAudit/Create select static audit type 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2268,7 +2268,7 @@ exports[`sqle/SqlAudit/Create select static audit type 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"
@@ -3011,7 +3011,7 @@ exports[`sqle/SqlAudit/Create select static audit type 2`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -3220,7 +3220,7 @@ exports[`sqle/SqlAudit/Create select static audit type 2`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -3362,7 +3362,7 @@ exports[`sqle/SqlAudit/Create select static audit type 2`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3483,7 +3483,7 @@ exports[`sqle/SqlAudit/Create select static audit type 2`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3642,7 +3642,7 @@ exports[`sqle/SqlAudit/Create select static audit type 2`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-open"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-open"
                       >
                         <div
                           class="ant-select-selector"
@@ -4567,7 +4567,7 @@ exports[`sqle/SqlAudit/Create upload sql file 1`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -4776,7 +4776,7 @@ exports[`sqle/SqlAudit/Create upload sql file 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -4918,7 +4918,7 @@ exports[`sqle/SqlAudit/Create upload sql file 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -5039,7 +5039,7 @@ exports[`sqle/SqlAudit/Create upload sql file 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -5198,7 +5198,7 @@ exports[`sqle/SqlAudit/Create upload sql file 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -6066,7 +6066,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -6274,7 +6274,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -6403,7 +6403,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -6435,38 +6435,12 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                                   title="mysql-1(10.186.62.13:33061)"
                                 >
                                   <span
-                                    class="custom-select-option-content css-17mg133"
+                                    class="instance-option-label"
                                   >
                                     <span
-                                      class="custom-select-option-content-prefix"
+                                      style="white-space: nowrap;"
                                     >
-                                      <span
-                                        class="css-u3jcp4"
-                                      >
-                                        <svg
-                                          color="#4583FF"
-                                          height="18"
-                                          viewBox="0 0 18 18"
-                                          width="18"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                            fill="currentColor"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      class="custom-select-option-content-label"
-                                    >
-                                      <span
-                                        class="instance-option-label"
-                                      >
-                                        <span>
-                                          mysql-1(10.186.62.13:33061)
-                                        </span>
-                                      </span>
+                                      mysql-1(10.186.62.13:33061)
                                     </span>
                                   </span>
                                 </span>
@@ -6534,7 +6508,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <span
                                 aria-live="polite"
@@ -6571,7 +6545,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                                   class="ant-select-selection-item"
                                 >
                                   <span
-                                    class="custom-select-option-content css-17mg133"
+                                    class="custom-select-option-content css-1xzd9w3"
                                   >
                                     <span
                                       class="custom-select-option-content-prefix"
@@ -6594,7 +6568,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                                       </span>
                                     </span>
                                     <span
-                                      class="custom-select-option-content-label"
+                                      class="custom-select-option-content-label is-text-label"
                                     >
                                       testSchema
                                     </span>
@@ -6726,7 +6700,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                       >
                         <div
                           class="ant-select-selector"
@@ -7290,7 +7264,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -7376,7 +7350,9 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -7401,7 +7377,9 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -7426,7 +7404,9 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -7451,7 +7431,9 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -7497,7 +7479,9 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -7543,7 +7527,9 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -7566,7 +7552,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -7843,7 +7829,7 @@ exports[`sqle/SqlAudit/Create upload zip file 1`] = `
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                         >
                           <div
                             class="ant-select-selector"
@@ -8052,7 +8038,7 @@ exports[`sqle/SqlAudit/Create upload zip file 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -8194,7 +8180,7 @@ exports[`sqle/SqlAudit/Create upload zip file 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -8315,7 +8301,7 @@ exports[`sqle/SqlAudit/Create upload zip file 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -8474,7 +8460,7 @@ exports[`sqle/SqlAudit/Create upload zip file 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"

--- a/packages/sqle/src/page/SqlAudit/Create/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAudit/Create/__snapshots__/index.test.tsx.snap
@@ -6432,6 +6432,7 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                                 </span>
                                 <span
                                   class="ant-select-selection-item"
+                                  title="mysql-1(10.186.62.13:33061)"
                                 >
                                   <span
                                     class="custom-select-option-content css-17mg133"
@@ -6459,7 +6460,13 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                                     <span
                                       class="custom-select-option-content-label"
                                     >
-                                      mysql-1(10.186.62.13:33061)
+                                      <span
+                                        class="instance-option-label"
+                                      >
+                                        <span>
+                                          mysql-1(10.186.62.13:33061)
+                                        </span>
+                                      </span>
                                     </span>
                                   </span>
                                 </span>
@@ -7366,7 +7373,13 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -7385,7 +7398,13 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -7404,7 +7423,13 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -7423,7 +7448,13 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -7463,7 +7494,13 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -7503,7 +7540,13 @@ exports[`sqle/SqlAudit/Create upload xml file 1`] = `
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"

--- a/packages/sqle/src/page/SqlAudit/List/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAudit/List/__snapshots__/index.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`sqle/SqlAudit/List render action when filter item show 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"
@@ -239,7 +239,7 @@ exports[`sqle/SqlAudit/List render action when filter item show 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/AuditResultList/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -1178,7 +1178,7 @@ exports[`sqle/ExecWorkflow/Common/AuditResultList/List render allowSwitchBackupP
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.ce.test.tsx.snap
@@ -297,7 +297,7 @@ exports[`sqle/SqlExecWorkflow/Create ce should snapshot render initial workflow 
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow ant-select-loading"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow ant-select-loading"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -419,7 +419,7 @@ exports[`sqle/SqlExecWorkflow/Create ce should snapshot render initial workflow 
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                                     >
                                       <div
                                         class="ant-select-selector"

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -342,6 +342,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -369,7 +370,13 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -1531,7 +1538,6 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -1580,7 +1586,13 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -2100,6 +2112,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -2127,7 +2140,13 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -3293,7 +3312,6 @@ from
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -3342,7 +3360,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -3862,6 +3886,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -3889,7 +3914,13 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -5625,7 +5656,6 @@ from
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -5674,7 +5704,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -6196,6 +6232,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -6223,7 +6260,13 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -8232,6 +8275,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -8259,7 +8303,13 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -10642,6 +10692,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-2(10.186.62.14:33062)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -10669,7 +10720,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-2(10.186.62.14:33062)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-2(10.186.62.14:33062)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -12557,7 +12614,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -12565,7 +12621,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
               mysql-1
             </div>
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_2"
               role="option"
@@ -12614,7 +12669,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -12631,7 +12692,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -12648,7 +12715,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -12665,7 +12738,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -12702,7 +12781,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -12739,7 +12824,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -13261,6 +13352,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-2(10.186.62.14:33062)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -13288,7 +13380,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-2(10.186.62.14:33062)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-2(10.186.62.14:33062)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -15176,7 +15274,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -15184,7 +15281,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
               mysql-1
             </div>
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_2"
               role="option"
@@ -15233,7 +15329,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -15250,7 +15352,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -15267,7 +15375,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -15284,7 +15398,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -15321,7 +15441,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -15358,7 +15484,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -17206,6 +17338,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-2(10.186.62.14:33062)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -17233,7 +17366,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-2(10.186.62.14:33062)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-2(10.186.62.14:33062)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -19592,7 +19731,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -19600,7 +19738,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
               mysql-1
             </div>
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_2"
               role="option"
@@ -19649,7 +19786,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -19666,7 +19809,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -19683,7 +19832,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -19700,7 +19855,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -19737,7 +19898,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -19774,7 +19941,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -20338,6 +20511,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                             </span>
                                             <span
                                               class="ant-select-selection-item"
+                                              title="mysql-2(10.186.62.14:33062)"
                                             >
                                               <span
                                                 class="custom-select-option-content css-17mg133"
@@ -20365,7 +20539,13 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                                 <span
                                                   class="custom-select-option-content-label"
                                                 >
-                                                  mysql-2(10.186.62.14:33062)
+                                                  <span
+                                                    class="instance-option-label"
+                                                  >
+                                                    <span>
+                                                      mysql-2(10.186.62.14:33062)
+                                                    </span>
+                                                  </span>
                                                 </span>
                                               </span>
                                             </span>
@@ -23286,6 +23466,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -23313,7 +23494,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -24475,7 +24662,6 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -24483,7 +24669,6 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
               mysql-1
             </div>
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_2"
               role="option"
@@ -24532,7 +24717,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -24549,7 +24740,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -24566,7 +24763,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -24583,7 +24786,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -24620,7 +24829,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -24657,7 +24872,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -25177,6 +25398,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -25204,7 +25426,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -26370,7 +26598,6 @@ from
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -26378,7 +26605,6 @@ from
               mysql-1
             </div>
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_2"
               role="option"
@@ -26427,7 +26653,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -26444,7 +26676,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -26461,7 +26699,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -26478,7 +26722,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -26515,7 +26765,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -26552,7 +26808,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -27156,6 +27418,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -27183,7 +27446,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -28919,7 +29188,6 @@ from
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="true"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -28927,7 +29195,6 @@ from
               mysql-1
             </div>
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_2"
               role="option"
@@ -28976,7 +29243,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -28993,7 +29266,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -29010,7 +29289,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -29027,7 +29312,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -29064,7 +29355,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -29101,7 +29398,13 @@ from
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -30952,6 +31255,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -30979,7 +31283,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -31303,6 +31613,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -31330,7 +31641,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -31654,6 +31971,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -31681,7 +31999,13 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              mysql-1(10.186.62.13:33061)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  mysql-1(10.186.62.13:33061)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -34723,6 +35047,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                         </span>
                                         <span
                                           class="ant-select-selection-item"
+                                          title="xin-test-database(10.186.62.15:33063)"
                                         >
                                           <span
                                             class="custom-select-option-content css-17mg133"
@@ -34750,7 +35075,13 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                             <span
                                               class="custom-select-option-content-label"
                                             >
-                                              xin-test-database(10.186.62.15:33063)
+                                              <span
+                                                class="instance-option-label"
+                                              >
+                                                <span>
+                                                  xin-test-database(10.186.62.15:33063)
+                                                </span>
+                                              </span>
                                             </span>
                                           </span>
                                         </span>
@@ -36027,7 +36358,6 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
               role="presentation"
             />
             <div
-              aria-label="mysql-1(10.186.62.13:33061)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_1"
               role="option"
@@ -36035,7 +36365,6 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
               mysql-1
             </div>
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="false"
               id="databaseInfo_0_instanceName_list_2"
               role="option"
@@ -36084,7 +36413,13 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-1(10.186.62.13:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-1(10.186.62.13:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -36101,7 +36436,13 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -36118,7 +36459,13 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -36135,7 +36482,13 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-5(139.196.241.182:33061)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-5(139.196.241.182:33061)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -36172,7 +36525,13 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                     <div
                       class="ant-select-item-option-content"
                     >
-                      progres-1(10.186.62.16:5432)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          progres-1(10.186.62.16:5432)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -36209,7 +36568,13 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                     <div
                       class="ant-select-item-option-content"
                     >
-                      tidb-1(10.186.62.17:4000)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          tidb-1(10.186.62.17:4000)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -313,7 +313,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -345,38 +345,12 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -443,7 +417,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -479,7 +453,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -502,7 +476,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test123
                                             </span>
@@ -1490,7 +1464,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -1589,7 +1563,9 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -1612,7 +1588,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -2083,7 +2059,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -2115,38 +2091,12 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -2213,7 +2163,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -2249,7 +2199,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -2272,7 +2222,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test123
                                             </span>
@@ -3264,7 +3214,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -3363,7 +3313,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -3386,7 +3338,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -3857,7 +3809,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -3889,38 +3841,12 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -3987,7 +3913,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -4023,7 +3949,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -4046,7 +3972,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test123
                                             </span>
@@ -5608,7 +5534,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -5707,7 +5633,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -5730,7 +5658,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -6203,7 +6131,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -6235,38 +6163,12 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -6333,7 +6235,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -6363,7 +6265,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -6386,7 +6288,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test
                                             </span>
@@ -8246,7 +8148,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -8278,38 +8180,12 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -8376,7 +8252,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -8406,7 +8282,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -8429,7 +8305,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test
                                             </span>
@@ -10663,7 +10539,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -10695,38 +10571,12 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                           title="mysql-2(10.186.62.14:33062)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-2(10.186.62.14:33062)
-                                                </span>
-                                              </span>
+                                              mysql-2(10.186.62.14:33062)
                                             </span>
                                           </span>
                                         </span>
@@ -10793,7 +10643,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -10829,7 +10679,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -10852,7 +10702,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               sqle
                                             </span>
@@ -12566,7 +12416,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -12672,7 +12522,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -12695,7 +12547,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -12718,7 +12572,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -12741,7 +12597,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -12784,7 +12642,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -12827,7 +12687,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -12850,7 +12712,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -13323,7 +13185,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -13355,38 +13217,12 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                           title="mysql-2(10.186.62.14:33062)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-2(10.186.62.14:33062)
-                                                </span>
-                                              </span>
+                                              mysql-2(10.186.62.14:33062)
                                             </span>
                                           </span>
                                         </span>
@@ -13453,7 +13289,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -13489,7 +13325,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -13512,7 +13348,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               sqle
                                             </span>
@@ -15226,7 +15062,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -15332,7 +15168,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -15355,7 +15193,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -15378,7 +15218,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -15401,7 +15243,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -15444,7 +15288,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -15487,7 +15333,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -15510,7 +15358,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -16028,7 +15876,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                       >
                                         <div
                                           aria-required="true"
-                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow ant-select-loading"
+                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow ant-select-loading"
                                         >
                                           <div
                                             class="ant-select-selector"
@@ -16124,7 +15972,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                         class="ant-form-item-control-input-content"
                                       >
                                         <div
-                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                         >
                                           <div
                                             class="ant-select-selector"
@@ -16154,7 +16002,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                               class="ant-select-selection-item"
                                             >
                                               <span
-                                                class="custom-select-option-content css-17mg133"
+                                                class="custom-select-option-content css-1xzd9w3"
                                               >
                                                 <span
                                                   class="custom-select-option-content-prefix"
@@ -16177,7 +16025,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                                   </span>
                                                 </span>
                                                 <span
-                                                  class="custom-select-option-content-label"
+                                                  class="custom-select-option-content-label is-text-label"
                                                 >
                                                   sqle
                                                 </span>
@@ -17309,7 +17157,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -17341,38 +17189,12 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                           title="mysql-2(10.186.62.14:33062)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-2(10.186.62.14:33062)
-                                                </span>
-                                              </span>
+                                              mysql-2(10.186.62.14:33062)
                                             </span>
                                           </span>
                                         </span>
@@ -17439,7 +17261,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -17475,7 +17297,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -17498,7 +17320,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               sqle
                                             </span>
@@ -19683,7 +19505,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -19789,7 +19611,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -19812,7 +19636,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -19835,7 +19661,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -19858,7 +19686,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -19901,7 +19731,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -19944,7 +19776,9 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -19967,7 +19801,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -20482,7 +20316,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                       >
                                         <div
                                           aria-required="true"
-                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                         >
                                           <div
                                             class="ant-select-selector"
@@ -20514,38 +20348,12 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                               title="mysql-2(10.186.62.14:33062)"
                                             >
                                               <span
-                                                class="custom-select-option-content css-17mg133"
+                                                class="instance-option-label"
                                               >
                                                 <span
-                                                  class="custom-select-option-content-prefix"
+                                                  style="white-space: nowrap;"
                                                 >
-                                                  <span
-                                                    class="css-u3jcp4"
-                                                  >
-                                                    <svg
-                                                      color="#4583FF"
-                                                      height="18"
-                                                      viewBox="0 0 18 18"
-                                                      width="18"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                        fill="currentColor"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </span>
-                                                <span
-                                                  class="custom-select-option-content-label"
-                                                >
-                                                  <span
-                                                    class="instance-option-label"
-                                                  >
-                                                    <span>
-                                                      mysql-2(10.186.62.14:33062)
-                                                    </span>
-                                                  </span>
+                                                  mysql-2(10.186.62.14:33062)
                                                 </span>
                                               </span>
                                             </span>
@@ -20612,7 +20420,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                         class="ant-form-item-control-input-content"
                                       >
                                         <div
-                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                          class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                         >
                                           <div
                                             class="ant-select-selector"
@@ -20642,7 +20450,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                               class="ant-select-selection-item"
                                             >
                                               <span
-                                                class="custom-select-option-content css-17mg133"
+                                                class="custom-select-option-content css-1xzd9w3"
                                               >
                                                 <span
                                                   class="custom-select-option-content-prefix"
@@ -20665,7 +20473,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                                   </span>
                                                 </span>
                                                 <span
-                                                  class="custom-select-option-content-label"
+                                                  class="custom-select-option-content-label is-text-label"
                                                 >
                                                   sqle
                                                 </span>
@@ -22115,7 +21923,7 @@ exports[`sqle/SqlExecWorkflow/Create should reset form fields and snapshot UI af
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -22237,7 +22045,7 @@ exports[`sqle/SqlExecWorkflow/Create should reset form fields and snapshot UI af
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -23437,7 +23245,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -23469,38 +23277,12 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -23567,7 +23349,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -23603,7 +23385,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -23626,7 +23408,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test123
                                             </span>
@@ -24614,7 +24396,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -24720,7 +24502,9 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -24743,7 +24527,9 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -24766,7 +24552,9 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -24789,7 +24577,9 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -24832,7 +24622,9 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -24875,7 +24667,9 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -24898,7 +24692,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -25369,7 +25163,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -25401,38 +25195,12 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -25499,7 +25267,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -25535,7 +25303,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -25558,7 +25326,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test123
                                             </span>
@@ -26550,7 +26318,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -26656,7 +26424,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -26679,7 +26449,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -26702,7 +26474,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -26725,7 +26499,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -26768,7 +26544,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -26811,7 +26589,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -26834,7 +26614,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -27389,7 +27169,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -27421,38 +27201,12 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -27519,7 +27273,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -27555,7 +27309,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -27578,7 +27332,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test123
                                             </span>
@@ -29140,7 +28894,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -29246,7 +29000,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -29269,7 +29025,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -29292,7 +29050,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -29315,7 +29075,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -29358,7 +29120,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -29401,7 +29165,9 @@ from
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -29424,7 +29190,7 @@ from
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -29963,7 +29729,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow ant-select-loading"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow ant-select-loading"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -30085,7 +29851,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -31226,7 +30992,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -31258,38 +31024,12 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -31356,7 +31096,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -31386,7 +31126,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -31409,7 +31149,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test
                                             </span>
@@ -31584,7 +31324,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -31616,38 +31356,12 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -31714,7 +31428,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -31744,7 +31458,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -31767,7 +31481,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test
                                             </span>
@@ -31942,7 +31656,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -31974,38 +31688,12 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                           title="mysql-1(10.186.62.13:33061)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  mysql-1(10.186.62.13:33061)
-                                                </span>
-                                              </span>
+                                              mysql-1(10.186.62.13:33061)
                                             </span>
                                           </span>
                                         </span>
@@ -32072,7 +31760,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -32102,7 +31790,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -32125,7 +31813,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test
                                             </span>
@@ -34407,7 +34095,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -35018,7 +34706,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                   >
                                     <div
                                       aria-required="true"
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                     >
                                       <div
                                         class="ant-select-selector"
@@ -35050,38 +34738,12 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                           title="xin-test-database(10.186.62.15:33063)"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="instance-option-label"
                                           >
                                             <span
-                                              class="custom-select-option-content-prefix"
+                                              style="white-space: nowrap;"
                                             >
-                                              <span
-                                                class="css-u3jcp4"
-                                              >
-                                                <svg
-                                                  color="#4583FF"
-                                                  height="18"
-                                                  viewBox="0 0 18 18"
-                                                  width="18"
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                    fill="currentColor"
-                                                  />
-                                                </svg>
-                                              </span>
-                                            </span>
-                                            <span
-                                              class="custom-select-option-content-label"
-                                            >
-                                              <span
-                                                class="instance-option-label"
-                                              >
-                                                <span>
-                                                  xin-test-database(10.186.62.15:33063)
-                                                </span>
-                                              </span>
+                                              xin-test-database(10.186.62.15:33063)
                                             </span>
                                           </span>
                                         </span>
@@ -35148,7 +34810,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                     class="ant-form-item-control-input-content"
                                   >
                                     <div
-                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                     >
                                       <span
                                         aria-live="polite"
@@ -35184,7 +34846,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                           class="ant-select-selection-item"
                                         >
                                           <span
-                                            class="custom-select-option-content css-17mg133"
+                                            class="custom-select-option-content css-1xzd9w3"
                                           >
                                             <span
                                               class="custom-select-option-content-prefix"
@@ -35207,7 +34869,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                               </span>
                                             </span>
                                             <span
-                                              class="custom-select-option-content-label"
+                                              class="custom-select-option-content-label is-text-label"
                                             >
                                               test
                                             </span>
@@ -36310,7 +35972,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -36416,7 +36078,9 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-1(10.186.62.13:33061)
                         </span>
                       </span>
@@ -36439,7 +36103,9 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -36462,7 +36128,9 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -36485,7 +36153,9 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-5(139.196.241.182:33061)
                         </span>
                       </span>
@@ -36528,7 +36198,9 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           progres-1(10.186.62.16:5432)
                         </span>
                       </span>
@@ -36571,7 +36243,9 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           tidb-1(10.186.62.17:4000)
                         </span>
                       </span>
@@ -36594,7 +36268,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/__snapshots__/index.test.tsx.snap
@@ -1540,7 +1540,7 @@ exports[`test AuditResultStep render switch data source backup policy 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/__tests__/__snapshots__/index.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`test DatabaseSelectionItems cloudbeaver navigate should decompress comp
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow ant-select-loading"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow ant-select-loading"
                       >
                         <div
                           class="ant-select-selector"
@@ -195,7 +195,7 @@ exports[`test DatabaseSelectionItems cloudbeaver navigate should decompress comp
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -508,7 +508,7 @@ exports[`test DatabaseSelectionItems should match snapshot 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -630,7 +630,7 @@ exports[`test DatabaseSelectionItems should match snapshot 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"
@@ -953,7 +953,7 @@ exports[`test DatabaseSelectionItems should match snapshot when isAssociationVer
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1075,7 +1075,7 @@ exports[`test DatabaseSelectionItems should match snapshot when isAssociationVer
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/FormStep/SqlAuditInfoForm/SqlAuditInfoFormItem/DatabaseSelectionItems/index.tsx
@@ -222,7 +222,11 @@ const DatabaseSelectionItem: React.FC<DatabaseSelectionItemProps> = ({
                               ? versionFirstStageInstanceOptions
                               : instanceOptions
                           }
-                          onChange={(name) => {
+                          onChange={(
+                            name: Parameters<
+                              NonNullable<SelectProps['onChange']>
+                            >[0]
+                          ) => {
                             form.setFieldValue(
                               ['databaseInfo', field.name, 'instanceSchema'],
                               undefined
@@ -240,8 +244,15 @@ const DatabaseSelectionItem: React.FC<DatabaseSelectionItemProps> = ({
                             !form.getFieldValue('databaseInfo')?.[index]
                               ?.instanceName
                           }
-                          onChange={(value) =>
-                            handleInstanceSchemaChange(fieldKey, value)
+                          onChange={(
+                            value: Parameters<
+                              NonNullable<SelectProps['onChange']>
+                            >[0]
+                          ) =>
+                            handleInstanceSchemaChange(
+                              fieldKey,
+                              value as string
+                            )
                           }
                           prefix={
                             <CommonIconStyleWrapper>

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/SqlRollback/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/SqlRollback/__tests__/__snapshots__/index.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`sqle/ExecWorkflow/Detail/SqlRollback render isAtRollbackStep is true 1`
                       style="margin-right: 12px; padding-bottom: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -154,7 +154,7 @@ exports[`sqle/ExecWorkflow/Detail/SqlRollback render isAtRollbackStep is true 1`
                       style="padding-bottom: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1168,7 +1168,7 @@ exports[`sqle/ExecWorkflow/Detail/SqlRollback render select rollback sql 1`] = `
                       style="margin-right: 12px; padding-bottom: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -1226,7 +1226,7 @@ exports[`sqle/ExecWorkflow/Detail/SqlRollback render select rollback sql 1`] = `
                       style="padding-bottom: 12px;"
                     >
                       <div
-                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"

--- a/packages/sqle/src/page/SqlInsights/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlInsights/__tests__/__snapshots__/index.test.tsx.snap
@@ -52,7 +52,13 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                   class="ant-select-selection-item"
                   title="mysql-1(10.186.62.13:33061)"
                 >
-                  mysql-1(10.186.62.13:33061)
+                  <span
+                    class="instance-option-label"
+                  >
+                    <span>
+                      mysql-1(10.186.62.13:33061)
+                    </span>
+                  </span>
                 </span>
               </div>
               <span
@@ -2937,7 +2943,13 @@ exports[`SqlInsights should get related sql list when current date range is exit
                   class="ant-select-selection-item"
                   title="mysql-1(10.186.62.13:33061)"
                 >
-                  mysql-1(10.186.62.13:33061)
+                  <span
+                    class="instance-option-label"
+                  >
+                    <span>
+                      mysql-1(10.186.62.13:33061)
+                    </span>
+                  </span>
                 </span>
               </div>
               <span
@@ -3901,7 +3913,13 @@ exports[`SqlInsights should render component correctly 1`] = `
                   class="ant-select-selection-item"
                   title="mysql-1(10.186.62.13:33061)"
                 >
-                  mysql-1(10.186.62.13:33061)
+                  <span
+                    class="instance-option-label"
+                  >
+                    <span>
+                      mysql-1(10.186.62.13:33061)
+                    </span>
+                  </span>
                 </span>
               </div>
               <span

--- a/packages/sqle/src/page/SqlInsights/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlInsights/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
             class="ant-space-item"
           >
             <div
-              class="ant-select ant-select-sm basic-select-wrapper instance-select css-x5nat1 ant-select-single ant-select-show-arrow"
+              class="ant-select ant-select-sm basic-select-wrapper instance-select css-16awv9j ant-select-single ant-select-show-arrow"
               style="width: 240px;"
             >
               <div
@@ -55,7 +55,9 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                   <span
                     class="instance-option-label"
                   >
-                    <span>
+                    <span
+                      style="white-space: nowrap;"
+                    >
                       mysql-1(10.186.62.13:33061)
                     </span>
                   </span>
@@ -2206,7 +2208,7 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace auto-refresh-interval-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace auto-refresh-interval-select css-15f13hq ant-select-single ant-select-show-arrow"
                   style="width: 200px;"
                 >
                   <div
@@ -2237,7 +2239,7 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                       class="ant-select-selection-item"
                     >
                       <span
-                        class="custom-select-option-content css-17mg133"
+                        class="custom-select-option-content css-1xzd9w3"
                       >
                         <span
                           class="custom-select-option-content-prefix"
@@ -2245,7 +2247,7 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                           自动刷新时间间隔
                         </span>
                         <span
-                          class="custom-select-option-content-label"
+                          class="custom-select-option-content-label is-text-label"
                         >
                           1m
                         </span>
@@ -2608,7 +2610,7 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                 style="padding-bottom: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -2638,7 +2640,7 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                       class="ant-select-selection-item"
                     >
                       <span
-                        class="custom-select-option-content css-17mg133"
+                        class="custom-select-option-content css-1xzd9w3"
                       >
                         <span
                           class="custom-select-option-content-prefix"
@@ -2646,7 +2648,7 @@ exports[`SqlInsights should disable future time in date picker 1`] = `
                           来源
                         </span>
                         <span
-                          class="custom-select-option-content-label"
+                          class="custom-select-option-content-label is-text-label"
                         >
                           工单
                         </span>
@@ -2912,7 +2914,7 @@ exports[`SqlInsights should get related sql list when current date range is exit
             class="ant-space-item"
           >
             <div
-              class="ant-select ant-select-sm basic-select-wrapper instance-select css-x5nat1 ant-select-single ant-select-show-arrow"
+              class="ant-select ant-select-sm basic-select-wrapper instance-select css-16awv9j ant-select-single ant-select-show-arrow"
               style="width: 240px;"
             >
               <div
@@ -2946,7 +2948,9 @@ exports[`SqlInsights should get related sql list when current date range is exit
                   <span
                     class="instance-option-label"
                   >
-                    <span>
+                    <span
+                      style="white-space: nowrap;"
+                    >
                       mysql-1(10.186.62.13:33061)
                     </span>
                   </span>
@@ -3085,7 +3089,7 @@ exports[`SqlInsights should get related sql list when current date range is exit
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace auto-refresh-interval-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace auto-refresh-interval-select css-15f13hq ant-select-single ant-select-show-arrow"
                   style="width: 200px;"
                 >
                   <div
@@ -3116,7 +3120,7 @@ exports[`SqlInsights should get related sql list when current date range is exit
                       class="ant-select-selection-item"
                     >
                       <span
-                        class="custom-select-option-content css-17mg133"
+                        class="custom-select-option-content css-1xzd9w3"
                       >
                         <span
                           class="custom-select-option-content-prefix"
@@ -3124,7 +3128,7 @@ exports[`SqlInsights should get related sql list when current date range is exit
                           自动刷新时间间隔
                         </span>
                         <span
-                          class="custom-select-option-content-label"
+                          class="custom-select-option-content-label is-text-label"
                         >
                           1m
                         </span>
@@ -3361,7 +3365,7 @@ exports[`SqlInsights should get related sql list when current date range is exit
                 style="padding-bottom: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -3391,7 +3395,7 @@ exports[`SqlInsights should get related sql list when current date range is exit
                       class="ant-select-selection-item"
                     >
                       <span
-                        class="custom-select-option-content css-17mg133"
+                        class="custom-select-option-content css-1xzd9w3"
                       >
                         <span
                           class="custom-select-option-content-prefix"
@@ -3399,7 +3403,7 @@ exports[`SqlInsights should get related sql list when current date range is exit
                           来源
                         </span>
                         <span
-                          class="custom-select-option-content-label"
+                          class="custom-select-option-content-label is-text-label"
                         >
                           工单
                         </span>
@@ -3882,7 +3886,7 @@ exports[`SqlInsights should render component correctly 1`] = `
             class="ant-space-item"
           >
             <div
-              class="ant-select ant-select-sm basic-select-wrapper instance-select css-x5nat1 ant-select-single ant-select-show-arrow"
+              class="ant-select ant-select-sm basic-select-wrapper instance-select css-16awv9j ant-select-single ant-select-show-arrow"
               style="width: 240px;"
             >
               <div
@@ -3916,7 +3920,9 @@ exports[`SqlInsights should render component correctly 1`] = `
                   <span
                     class="instance-option-label"
                   >
-                    <span>
+                    <span
+                      style="white-space: nowrap;"
+                    >
                       mysql-1(10.186.62.13:33061)
                     </span>
                   </span>
@@ -4055,7 +4061,7 @@ exports[`SqlInsights should render component correctly 1`] = `
                 style="margin-right: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace auto-refresh-interval-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-sm basic-select-wrapper custom-select-namespace auto-refresh-interval-select css-15f13hq ant-select-single ant-select-show-arrow"
                   style="width: 200px;"
                 >
                   <div
@@ -4086,7 +4092,7 @@ exports[`SqlInsights should render component correctly 1`] = `
                       class="ant-select-selection-item"
                     >
                       <span
-                        class="custom-select-option-content css-17mg133"
+                        class="custom-select-option-content css-1xzd9w3"
                       >
                         <span
                           class="custom-select-option-content-prefix"
@@ -4094,7 +4100,7 @@ exports[`SqlInsights should render component correctly 1`] = `
                           自动刷新时间间隔
                         </span>
                         <span
-                          class="custom-select-option-content-label"
+                          class="custom-select-option-content-label is-text-label"
                         >
                           1m
                         </span>
@@ -4329,7 +4335,7 @@ exports[`SqlInsights should render component correctly 1`] = `
                 style="padding-bottom: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -4359,7 +4365,7 @@ exports[`SqlInsights should render component correctly 1`] = `
                       class="ant-select-selection-item"
                     >
                       <span
-                        class="custom-select-option-content css-17mg133"
+                        class="custom-select-option-content css-1xzd9w3"
                       >
                         <span
                           class="custom-select-option-content-prefix"
@@ -4367,7 +4373,7 @@ exports[`SqlInsights should render component correctly 1`] = `
                           来源
                         </span>
                         <span
-                          class="custom-select-option-content-label"
+                          class="custom-select-option-content-label is-text-label"
                         >
                           工单
                         </span>

--- a/packages/sqle/src/page/SqlInsights/components/RelatedSqlList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlInsights/components/RelatedSqlList/__tests__/__snapshots__/index.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`RelatedSqlList should render component with date range selected 1`] = `
           style="padding-bottom: 12px;"
         >
           <div
-            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-show-arrow"
+            class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-show-arrow"
           >
             <div
               class="ant-select-selector"
@@ -72,7 +72,7 @@ exports[`RelatedSqlList should render component with date range selected 1`] = `
                 class="ant-select-selection-item"
               >
                 <span
-                  class="custom-select-option-content css-17mg133"
+                  class="custom-select-option-content css-1xzd9w3"
                 >
                   <span
                     class="custom-select-option-content-prefix"
@@ -80,7 +80,7 @@ exports[`RelatedSqlList should render component with date range selected 1`] = `
                     来源
                   </span>
                   <span
-                    class="custom-select-option-content-label"
+                    class="custom-select-option-content-label is-text-label"
                   >
                     工单
                   </span>

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/AssignmentBatch/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/AssignmentBatch/__snapshots__/index.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`page/SqlManagement/AssignmentBatch close modal by click button 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -259,7 +259,7 @@ exports[`page/SqlManagement/AssignmentBatch update batch assign and submit chang
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/AssignmentForm/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/AssignmentForm/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`page/SqlManagement/AssignmentForm disable select 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -135,7 +135,7 @@ exports[`page/SqlManagement/AssignmentForm render form when init 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"
@@ -245,7 +245,7 @@ exports[`page/SqlManagement/AssignmentForm render form when not init 1`] = `
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/AssignmentSingle/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/AssignmentSingle/__snapshots__/index.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`page/SqlManagement/AssignmentSingle close modal by click button 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -259,7 +259,7 @@ exports[`page/SqlManagement/AssignmentSingle update single assign and submit cha
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/PushToCoding/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modals/PushToCoding/__tests__/__snapshots__/index.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`page/SqlManagement/PushToCodingModal render init snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -205,7 +205,7 @@ exports[`page/SqlManagement/PushToCodingModal render init snap 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
@@ -487,7 +487,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"
@@ -545,7 +545,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"
@@ -607,7 +607,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"
@@ -669,7 +669,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
             style="margin-right: 12px; padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
             >
               <div
                 class="ant-select-selector"
@@ -792,7 +792,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
             style="padding-bottom: 12px;"
           >
             <div
-              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-open"
+              class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-focused ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-open"
             >
               <div
                 class="ant-select-selector"
@@ -1579,7 +1579,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
   <div>
     <div
       class="ant-select-dropdown custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; padding: 0px; width: 400px; min-width: 0;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: max-content; padding: 0px; width: 400px;"
     >
       <div>
         <span

--- a/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/DataSourceSelection/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/DataSourceSelection/index.tsx
@@ -1,7 +1,8 @@
 import {
   CustomLabelContent,
   FormItemLabel,
-  FormItemSubTitle
+  FormItemSubTitle,
+  environmentTagSelectProps
 } from '@actiontech/dms-kit';
 import { useTranslation } from 'react-i18next';
 import { BasicSelect } from '@actiontech/dms-kit';
@@ -146,6 +147,7 @@ const DataSourceSelection: React.FC = () => {
         ]}
       >
         <BasicSelect
+          {...environmentTagSelectProps}
           loading={getEnvironmentListLoading}
           disabled={formItemDisabled}
           options={environmentOptions}
@@ -194,6 +196,7 @@ const DataSourceSelection: React.FC = () => {
         className="has-required-style has-label-tip"
       >
         <BasicSelect
+          {...environmentTagSelectProps}
           showSearch
           filterOption={filterOptionByLabel}
           disabled={formItemDisabled}

--- a/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/ScanTypesDynamicParams/HighPriorityConditions/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/ScanTypesDynamicParams/HighPriorityConditions/__tests__/__snapshots__/index.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`test HighPriorityConditions should match snapshot 2`] = `
                 >
                   <div
                     aria-required="true"
-                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     data-testid="audit_level_operator"
                   >
                     <div
@@ -281,7 +281,7 @@ exports[`test HighPriorityConditions should match snapshot 2`] = `
                 >
                   <div
                     aria-required="true"
-                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     data-testid="audit_level_value"
                   >
                     <div

--- a/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/DataSourceSelection.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/DataSourceSelection.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
               >
                 <div
                   class="ant-select-selector"
@@ -131,7 +131,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
               >
                 <div
                   class="ant-select-selector"
@@ -212,7 +212,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
               class="ant-form-item-control-input-content"
             >
               <div
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -315,7 +315,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
               >
                 <div
                   class="ant-select-selector"
@@ -419,7 +419,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
+                class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
               >
                 <div
                   class="ant-select-selector"
@@ -513,7 +513,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading"
+                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-loading"
               >
                 <div
                   class="ant-select-selector"
@@ -595,7 +595,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
               class="ant-form-item-control-input-content"
             >
               <div
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -698,7 +698,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should match
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
               >
                 <div
                   class="ant-select-selector"
@@ -803,7 +803,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
               >
                 <div
                   class="ant-select-selector"
@@ -836,12 +836,9 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
                     title="environment-1"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -910,7 +907,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
               >
                 <div
                   class="ant-select-selector"
@@ -993,7 +990,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
               class="ant-form-item-control-input-content"
             >
               <div
-                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -1026,7 +1023,9 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1(10.186.62.13:33061)
                       </span>
                     </span>
@@ -1103,7 +1102,7 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
             >
               <div
                 aria-required="true"
-                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
               >
                 <div
                   class="ant-select-selector"
@@ -1135,7 +1134,9 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1(10.186.62.13:33061)
                       </span>
                     </span>

--- a/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/DataSourceSelection.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/DataSourceSelection.test.tsx.snap
@@ -835,7 +835,19 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
                     class="ant-select-selection-item"
                     title="environment-1"
                   >
-                    environment-1
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-1
+                      </span>
+                    </span>
                   </span>
                 </div>
                 <span
@@ -1011,7 +1023,13 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
                     class="ant-select-selection-item"
                     title="mysql-1(10.186.62.13:33061)"
                   >
-                    mysql-1(10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1(10.186.62.13:33061)
+                      </span>
+                    </span>
                   </span>
                 </div>
                 <span
@@ -1114,7 +1132,13 @@ exports[`test SqlManagementConf/common/ConfForm/DataSourceSelection should set f
                     class="ant-select-selection-item"
                     title="mysql-1(10.186.62.13:33061)"
                   >
-                    mysql-1(10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1(10.186.62.13:33061)
+                      </span>
+                    </span>
                   </span>
                 </div>
                 <span

--- a/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/ScanTypesDynamicParams.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/ScanTypesDynamicParams.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render defaultValue is de
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -650,7 +650,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render defaultValue is de
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="query_time_avg_operator"
                         >
                           <div
@@ -851,7 +851,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render defaultValue is de
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="row_examined_avg_operator"
                         >
                           <div
@@ -1052,7 +1052,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render defaultValue is de
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="audit_level_operator"
                         >
                           <div
@@ -1140,7 +1140,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render defaultValue is de
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="audit_level_value"
                         >
                           <div
@@ -1295,7 +1295,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render defaultValue is de
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -1535,7 +1535,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render init snap shot 1`]
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -2077,7 +2077,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render init snap shot 1`]
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="query_time_avg_operator"
                         >
                           <div
@@ -2278,7 +2278,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render init snap shot 1`]
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="row_examined_avg_operator"
                         >
                           <div
@@ -2479,7 +2479,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render init snap shot 1`]
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="audit_level_operator"
                         >
                           <div
@@ -2567,7 +2567,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render init snap shot 1`]
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="audit_level_value"
                         >
                           <div
@@ -2722,7 +2722,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render init snap shot 1`]
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -3083,7 +3083,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render submitLoading is t
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"
@@ -3633,7 +3633,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render submitLoading is t
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="query_time_avg_operator"
                         >
                           <div
@@ -3835,7 +3835,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render submitLoading is t
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="row_examined_avg_operator"
                         >
                           <div
@@ -4037,7 +4037,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render submitLoading is t
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="audit_level_operator"
                         >
                           <div
@@ -4125,7 +4125,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render submitLoading is t
                         class="ant-form-item-control-input-content"
                       >
                         <div
-                          class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           data-testid="audit_level_value"
                         >
                           <div
@@ -4281,7 +4281,7 @@ exports[`test SqlManagementConf/ScanTypesDynamicParams render submitLoading is t
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                      class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                     >
                       <div
                         class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render init snap shot 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -165,7 +165,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render init snap shot 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -246,7 +246,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render init snap shot 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -349,7 +349,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render init snap shot 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                        class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"
@@ -552,7 +552,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"
@@ -585,12 +585,9 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                             title="environment-1"
                           >
                             <span
-                              class="css-14lkj40"
+                              class="css-1acawoa"
                               color="#8C8C8C"
                             >
-                              <span
-                                class="environment-tag-color-dot"
-                              />
                               <span
                                 class="environment-tag-name"
                               >
@@ -659,7 +656,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                       >
                         <div
                           class="ant-select-selector"
@@ -742,7 +739,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"
@@ -775,7 +772,9 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                             <span
                               class="instance-option-label"
                             >
-                              <span>
+                              <span
+                                style="white-space: nowrap;"
+                              >
                                 mysql-1(10.186.62.13:33061)
                               </span>
                             </span>
@@ -852,7 +851,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
                       >
                         <div
                           class="ant-select-selector"
@@ -884,7 +883,9 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                             <span
                               class="instance-option-label"
                             >
-                              <span>
+                              <span
+                                style="white-space: nowrap;"
+                              >
                                 mysql-1(10.186.62.13:33061)
                               </span>
                             </span>
@@ -1305,7 +1306,7 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                        class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                       >
                         <div
                           class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Common/ConfForm/__tests__/__snapshots__/index.test.tsx.snap
@@ -584,7 +584,19 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                             class="ant-select-selection-item"
                             title="environment-1"
                           >
-                            environment-1
+                            <span
+                              class="css-14lkj40"
+                              color="#8C8C8C"
+                            >
+                              <span
+                                class="environment-tag-color-dot"
+                              />
+                              <span
+                                class="environment-tag-name"
+                              >
+                                environment-1
+                              </span>
+                            </span>
                           </span>
                         </div>
                         <span
@@ -760,7 +772,13 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                             class="ant-select-selection-item"
                             title="mysql-1(10.186.62.13:33061)"
                           >
-                            mysql-1(10.186.62.13:33061)
+                            <span
+                              class="instance-option-label"
+                            >
+                              <span>
+                                mysql-1(10.186.62.13:33061)
+                              </span>
+                            </span>
                           </span>
                         </div>
                         <span
@@ -863,7 +881,13 @@ exports[`test sqle/SqlManagementConf/ConfForm render snap shot when defaultValue
                             class="ant-select-selection-item"
                             title="mysql-1(10.186.62.13:33061)"
                           >
-                            mysql-1(10.186.62.13:33061)
+                            <span
+                              class="instance-option-label"
+                            >
+                              <span>
+                                mysql-1(10.186.62.13:33061)
+                              </span>
+                            </span>
                           </span>
                         </div>
                         <span

--- a/packages/sqle/src/page/SqlManagementConf/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -353,7 +353,13 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -456,7 +462,13 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -901,7 +913,13 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -1004,7 +1022,13 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -2559,7 +2583,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                                 class="ant-select-selection-item"
                                 title="environment-1"
                               >
-                                environment-1
+                                <span
+                                  class="css-14lkj40"
+                                  color="#8C8C8C"
+                                >
+                                  <span
+                                    class="environment-tag-color-dot"
+                                  />
+                                  <span
+                                    class="environment-tag-name"
+                                  >
+                                    environment-1
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -2752,7 +2788,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -2854,7 +2896,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -3105,7 +3153,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
           style="height: 0px; width: 0px; overflow: hidden;"
         >
           <div
-            aria-label="environment-1"
             aria-selected="true"
             id="environmentTag_list_0"
             role="option"
@@ -3113,7 +3160,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
             1
           </div>
           <div
-            aria-label="environment-2"
             aria-selected="false"
             id="environmentTag_list_1"
             role="option"
@@ -3142,7 +3188,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-1
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-1
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3159,7 +3217,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-2
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-2
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3259,7 +3329,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
             role="presentation"
           />
           <div
-            aria-label="mysql-1(10.186.62.13:33061)"
             aria-selected="true"
             id="instanceId_list_1"
             role="option"
@@ -3267,7 +3336,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
             1739531854064652288
           </div>
           <div
-            aria-label="mysql-2(10.186.62.14:33062)"
             aria-selected="false"
             id="instanceId_list_2"
             role="option"
@@ -3313,7 +3381,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-1(10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1(10.186.62.13:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3330,7 +3404,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-2(10.186.62.14:33062)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-2(10.186.62.14:33062)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3347,7 +3427,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    xin-test-database(10.186.62.15:33063)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        xin-test-database(10.186.62.15:33063)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3364,7 +3450,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-5(139.196.241.182:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-5(139.196.241.182:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3398,7 +3490,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    progres-1(10.186.62.16:5432)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        progres-1(10.186.62.16:5432)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3432,7 +3530,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    tidb-1(10.186.62.17:4000)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        tidb-1(10.186.62.17:4000)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -3627,7 +3731,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                                 class="ant-select-selection-item"
                                 title="environment-1"
                               >
-                                environment-1
+                                <span
+                                  class="css-14lkj40"
+                                  color="#8C8C8C"
+                                >
+                                  <span
+                                    class="environment-tag-color-dot"
+                                  />
+                                  <span
+                                    class="environment-tag-name"
+                                  >
+                                    environment-1
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -3820,7 +3936,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -3922,7 +4044,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -5776,7 +5904,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
           style="height: 0px; width: 0px; overflow: hidden;"
         >
           <div
-            aria-label="environment-1"
             aria-selected="true"
             id="environmentTag_list_0"
             role="option"
@@ -5784,7 +5911,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
             1
           </div>
           <div
-            aria-label="environment-2"
             aria-selected="false"
             id="environmentTag_list_1"
             role="option"
@@ -5813,7 +5939,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-1
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-1
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -5830,7 +5968,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-2
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-2
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -5930,7 +6080,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
             role="presentation"
           />
           <div
-            aria-label="mysql-1(10.186.62.13:33061)"
             aria-selected="true"
             id="instanceId_list_1"
             role="option"
@@ -5938,7 +6087,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
             1739531854064652288
           </div>
           <div
-            aria-label="mysql-2(10.186.62.14:33062)"
             aria-selected="false"
             id="instanceId_list_2"
             role="option"
@@ -5984,7 +6132,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-1(10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1(10.186.62.13:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -6001,7 +6155,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-2(10.186.62.14:33062)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-2(10.186.62.14:33062)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -6018,7 +6178,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    xin-test-database(10.186.62.15:33063)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        xin-test-database(10.186.62.15:33063)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -6035,7 +6201,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-5(139.196.241.182:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-5(139.196.241.182:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -6069,7 +6241,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    progres-1(10.186.62.16:5432)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        progres-1(10.186.62.16:5432)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -6103,7 +6281,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    tidb-1(10.186.62.17:4000)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        tidb-1(10.186.62.17:4000)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -6268,7 +6452,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                                 class="ant-select-selection-item"
                                 title="environment-1"
                               >
-                                environment-1
+                                <span
+                                  class="css-14lkj40"
+                                  color="#8C8C8C"
+                                >
+                                  <span
+                                    class="environment-tag-color-dot"
+                                  />
+                                  <span
+                                    class="environment-tag-name"
+                                  >
+                                    environment-1
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -6461,7 +6657,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -6563,7 +6765,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -9510,7 +9718,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
           style="height: 0px; width: 0px; overflow: hidden;"
         >
           <div
-            aria-label="environment-1"
             aria-selected="true"
             id="environmentTag_list_0"
             role="option"
@@ -9518,7 +9725,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
             1
           </div>
           <div
-            aria-label="environment-2"
             aria-selected="false"
             id="environmentTag_list_1"
             role="option"
@@ -9547,7 +9753,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-1
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-1
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -9564,7 +9782,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-2
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-2
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -9664,7 +9894,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
             role="presentation"
           />
           <div
-            aria-label="mysql-1(10.186.62.13:33061)"
             aria-selected="true"
             id="instanceId_list_1"
             role="option"
@@ -9672,7 +9901,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
             1739531854064652288
           </div>
           <div
-            aria-label="mysql-2(10.186.62.14:33062)"
             aria-selected="false"
             id="instanceId_list_2"
             role="option"
@@ -9718,7 +9946,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-1(10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1(10.186.62.13:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -9735,7 +9969,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-2(10.186.62.14:33062)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-2(10.186.62.14:33062)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -9752,7 +9992,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    xin-test-database(10.186.62.15:33063)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        xin-test-database(10.186.62.15:33063)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -9769,7 +10015,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-5(139.196.241.182:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-5(139.196.241.182:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -9803,7 +10055,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    progres-1(10.186.62.16:5432)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        progres-1(10.186.62.16:5432)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -9837,7 +10095,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                   <div
                     class="ant-select-item-option-content"
                   >
-                    tidb-1(10.186.62.17:4000)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        tidb-1(10.186.62.17:4000)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -10230,7 +10494,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 class="ant-select-selection-item"
                                 title="environment-1"
                               >
-                                environment-1
+                                <span
+                                  class="css-14lkj40"
+                                  color="#8C8C8C"
+                                >
+                                  <span
+                                    class="environment-tag-color-dot"
+                                  />
+                                  <span
+                                    class="environment-tag-name"
+                                  >
+                                    environment-1
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -10423,7 +10699,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -10525,7 +10807,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -10915,7 +11203,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
           style="height: 0px; width: 0px; overflow: hidden;"
         >
           <div
-            aria-label="environment-1"
             aria-selected="true"
             id="environmentTag_list_0"
             role="option"
@@ -10923,7 +11210,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
             1
           </div>
           <div
-            aria-label="environment-2"
             aria-selected="false"
             id="environmentTag_list_1"
             role="option"
@@ -10952,7 +11238,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-1
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-1
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -10969,7 +11267,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-2
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-2
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -11069,7 +11379,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
             role="presentation"
           />
           <div
-            aria-label="mysql-1(10.186.62.13:33061)"
             aria-selected="true"
             id="instanceId_list_1"
             role="option"
@@ -11077,7 +11386,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
             1739531854064652288
           </div>
           <div
-            aria-label="mysql-2(10.186.62.14:33062)"
             aria-selected="false"
             id="instanceId_list_2"
             role="option"
@@ -11123,7 +11431,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-1(10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1(10.186.62.13:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -11140,7 +11454,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-2(10.186.62.14:33062)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-2(10.186.62.14:33062)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -11157,7 +11477,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    xin-test-database(10.186.62.15:33063)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        xin-test-database(10.186.62.15:33063)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -11174,7 +11500,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-5(139.196.241.182:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-5(139.196.241.182:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -11208,7 +11540,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    progres-1(10.186.62.16:5432)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        progres-1(10.186.62.16:5432)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -11242,7 +11580,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    tidb-1(10.186.62.17:4000)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        tidb-1(10.186.62.17:4000)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -11407,7 +11751,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 class="ant-select-selection-item"
                                 title="environment-1"
                               >
-                                environment-1
+                                <span
+                                  class="css-14lkj40"
+                                  color="#8C8C8C"
+                                >
+                                  <span
+                                    class="environment-tag-color-dot"
+                                  />
+                                  <span
+                                    class="environment-tag-name"
+                                  >
+                                    environment-1
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -11600,7 +11956,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -11702,7 +12064,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 class="ant-select-selection-item"
                                 title="mysql-1(10.186.62.13:33061)"
                               >
-                                mysql-1(10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1(10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -12528,7 +12896,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
           style="height: 0px; width: 0px; overflow: hidden;"
         >
           <div
-            aria-label="environment-1"
             aria-selected="true"
             id="environmentTag_list_0"
             role="option"
@@ -12536,7 +12903,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
             1
           </div>
           <div
-            aria-label="environment-2"
             aria-selected="false"
             id="environmentTag_list_1"
             role="option"
@@ -12565,7 +12931,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-1
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-1
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -12582,7 +12960,19 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    environment-2
+                    <span
+                      class="css-14lkj40"
+                      color="#8C8C8C"
+                    >
+                      <span
+                        class="environment-tag-color-dot"
+                      />
+                      <span
+                        class="environment-tag-name"
+                      >
+                        environment-2
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -12682,7 +13072,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
             role="presentation"
           />
           <div
-            aria-label="mysql-1(10.186.62.13:33061)"
             aria-selected="true"
             id="instanceId_list_1"
             role="option"
@@ -12690,7 +13079,6 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
             1739531854064652288
           </div>
           <div
-            aria-label="mysql-2(10.186.62.14:33062)"
             aria-selected="false"
             id="instanceId_list_2"
             role="option"
@@ -12736,7 +13124,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-1(10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1(10.186.62.13:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -12753,7 +13147,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-2(10.186.62.14:33062)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-2(10.186.62.14:33062)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -12770,7 +13170,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    xin-test-database(10.186.62.15:33063)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        xin-test-database(10.186.62.15:33063)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -12787,7 +13193,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-5(139.196.241.182:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-5(139.196.241.182:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -12821,7 +13233,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    progres-1(10.186.62.16:5432)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        progres-1(10.186.62.16:5432)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -12855,7 +13273,13 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                   <div
                     class="ant-select-item-option-content"
                   >
-                    tidb-1(10.186.62.17:4000)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        tidb-1(10.186.62.17:4000)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"

--- a/packages/sqle/src/page/SqlManagementConf/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -240,7 +240,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -323,7 +323,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -356,7 +356,9 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -433,7 +435,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -465,7 +467,9 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -705,7 +709,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -800,7 +804,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                           >
                             <div
                               class="ant-select-selector"
@@ -883,7 +887,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -916,7 +920,9 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -993,7 +999,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -1025,7 +1031,9 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -1761,7 +1769,7 @@ exports[`test sqle/SqlManagementConf/Create create audit plan when current url h
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2552,7 +2560,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2584,12 +2592,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                                 title="environment-1"
                               >
                                 <span
-                                  class="css-14lkj40"
+                                  class="css-1acawoa"
                                   color="#8C8C8C"
                                 >
-                                  <span
-                                    class="environment-tag-color-dot"
-                                  />
                                   <span
                                     class="environment-tag-name"
                                   >
@@ -2658,7 +2663,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2758,7 +2763,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -2791,7 +2796,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -2868,7 +2875,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -2899,7 +2906,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -3143,58 +3152,39 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="environmentTag_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="true"
-            id="environmentTag_list_0"
-            role="option"
-          >
-            1
-          </div>
-          <div
-            aria-selected="false"
-            id="environmentTag_list_1"
-            role="option"
-          >
-            2
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="environmentTag_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                  id="environmentTag_list_0"
+                  role="option"
                   title="environment-1"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -3212,18 +3202,17 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
+                  id="environmentTag_list_1"
+                  role="option"
                   title="environment-2"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -3314,46 +3303,23 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="instanceId_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="false"
-            id="instanceId_list_0"
-            role="presentation"
-          />
-          <div
-            aria-selected="true"
-            id="instanceId_list_1"
-            role="option"
-          >
-            1739531854064652288
-          </div>
-          <div
-            aria-selected="false"
-            id="instanceId_list_2"
-            role="option"
-          >
-            1739531942258282496
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="instanceId_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
@@ -3376,6 +3342,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active ant-select-item-option-selected"
+                  id="instanceId_list_1"
+                  role="option"
                   title="mysql-1(10.186.62.13:33061)"
                 >
                   <div
@@ -3384,7 +3352,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1(10.186.62.13:33061)
                       </span>
                     </span>
@@ -3399,6 +3369,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_2"
+                  role="option"
                   title="mysql-2(10.186.62.14:33062)"
                 >
                   <div
@@ -3407,7 +3379,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-2(10.186.62.14:33062)
                       </span>
                     </span>
@@ -3422,6 +3396,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_3"
+                  role="option"
                   title="xin-test-database(10.186.62.15:33063)"
                 >
                   <div
@@ -3430,7 +3406,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         xin-test-database(10.186.62.15:33063)
                       </span>
                     </span>
@@ -3445,6 +3423,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_4"
+                  role="option"
                   title="mysql-5(139.196.241.182:33061)"
                 >
                   <div
@@ -3453,7 +3433,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-5(139.196.241.182:33061)
                       </span>
                     </span>
@@ -3485,6 +3467,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_6"
+                  role="option"
                   title="progres-1(10.186.62.16:5432)"
                 >
                   <div
@@ -3493,7 +3477,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         progres-1(10.186.62.16:5432)
                       </span>
                     </span>
@@ -3525,6 +3511,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_8"
+                  role="option"
                   title="tidb-1(10.186.62.17:4000)"
                 >
                   <div
@@ -3533,7 +3521,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 1`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         tidb-1(10.186.62.17:4000)
                       </span>
                     </span>
@@ -3700,7 +3690,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3732,12 +3722,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                                 title="environment-1"
                               >
                                 <span
-                                  class="css-14lkj40"
+                                  class="css-1acawoa"
                                   color="#8C8C8C"
                                 >
-                                  <span
-                                    class="environment-tag-color-dot"
-                                  />
                                   <span
                                     class="environment-tag-name"
                                   >
@@ -3806,7 +3793,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3906,7 +3893,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -3939,7 +3926,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -4016,7 +4005,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -4047,7 +4036,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -4495,7 +4486,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4631,7 +4622,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -4878,7 +4869,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -5427,7 +5418,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -5563,7 +5554,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -5697,7 +5688,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -5801,7 +5792,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -5894,58 +5885,39 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="environmentTag_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="true"
-            id="environmentTag_list_0"
-            role="option"
-          >
-            1
-          </div>
-          <div
-            aria-selected="false"
-            id="environmentTag_list_1"
-            role="option"
-          >
-            2
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="environmentTag_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                  id="environmentTag_list_0"
+                  role="option"
                   title="environment-1"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -5963,18 +5935,17 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
+                  id="environmentTag_list_1"
+                  role="option"
                   title="environment-2"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -6065,46 +6036,23 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="instanceId_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="false"
-            id="instanceId_list_0"
-            role="presentation"
-          />
-          <div
-            aria-selected="true"
-            id="instanceId_list_1"
-            role="option"
-          >
-            1739531854064652288
-          </div>
-          <div
-            aria-selected="false"
-            id="instanceId_list_2"
-            role="option"
-          >
-            1739531942258282496
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="instanceId_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
@@ -6127,6 +6075,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active ant-select-item-option-selected"
+                  id="instanceId_list_1"
+                  role="option"
                   title="mysql-1(10.186.62.13:33061)"
                 >
                   <div
@@ -6135,7 +6085,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1(10.186.62.13:33061)
                       </span>
                     </span>
@@ -6150,6 +6102,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_2"
+                  role="option"
                   title="mysql-2(10.186.62.14:33062)"
                 >
                   <div
@@ -6158,7 +6112,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-2(10.186.62.14:33062)
                       </span>
                     </span>
@@ -6173,6 +6129,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_3"
+                  role="option"
                   title="xin-test-database(10.186.62.15:33063)"
                 >
                   <div
@@ -6181,7 +6139,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         xin-test-database(10.186.62.15:33063)
                       </span>
                     </span>
@@ -6196,6 +6156,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_4"
+                  role="option"
                   title="mysql-5(139.196.241.182:33061)"
                 >
                   <div
@@ -6204,7 +6166,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-5(139.196.241.182:33061)
                       </span>
                     </span>
@@ -6236,6 +6200,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_6"
+                  role="option"
                   title="progres-1(10.186.62.16:5432)"
                 >
                   <div
@@ -6244,7 +6210,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         progres-1(10.186.62.16:5432)
                       </span>
                     </span>
@@ -6276,6 +6244,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_8"
+                  role="option"
                   title="tidb-1(10.186.62.17:4000)"
                 >
                   <div
@@ -6284,7 +6254,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 2`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         tidb-1(10.186.62.17:4000)
                       </span>
                     </span>
@@ -6421,7 +6393,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -6453,12 +6425,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                                 title="environment-1"
                               >
                                 <span
-                                  class="css-14lkj40"
+                                  class="css-1acawoa"
                                   color="#8C8C8C"
                                 >
-                                  <span
-                                    class="environment-tag-color-dot"
-                                  />
                                   <span
                                     class="environment-tag-name"
                                   >
@@ -6527,7 +6496,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -6627,7 +6596,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -6660,7 +6629,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -6737,7 +6708,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -6768,7 +6739,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -7216,7 +7189,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -7352,7 +7325,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -7599,7 +7572,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -8160,7 +8133,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                 data-testid="query_time_avg_operator"
                               >
                                 <div
@@ -8359,7 +8332,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                 data-testid="row_examined_avg_operator"
                               >
                                 <div
@@ -8561,7 +8534,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                 data-testid="audit_level_operator"
                               >
                                 <div
@@ -8650,7 +8623,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                 data-testid="audit_level_value"
                               >
                                 <div
@@ -8805,7 +8778,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -8941,7 +8914,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -9075,7 +9048,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -9179,7 +9152,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -9708,58 +9681,39 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="environmentTag_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="true"
-            id="environmentTag_list_0"
-            role="option"
-          >
-            1
-          </div>
-          <div
-            aria-selected="false"
-            id="environmentTag_list_1"
-            role="option"
-          >
-            2
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="environmentTag_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                  id="environmentTag_list_0"
+                  role="option"
                   title="environment-1"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -9777,18 +9731,17 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
+                  id="environmentTag_list_1"
+                  role="option"
                   title="environment-2"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -9879,46 +9832,23 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="instanceId_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="false"
-            id="instanceId_list_0"
-            role="presentation"
-          />
-          <div
-            aria-selected="true"
-            id="instanceId_list_1"
-            role="option"
-          >
-            1739531854064652288
-          </div>
-          <div
-            aria-selected="false"
-            id="instanceId_list_2"
-            role="option"
-          >
-            1739531942258282496
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="instanceId_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
@@ -9941,6 +9871,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active ant-select-item-option-selected"
+                  id="instanceId_list_1"
+                  role="option"
                   title="mysql-1(10.186.62.13:33061)"
                 >
                   <div
@@ -9949,7 +9881,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1(10.186.62.13:33061)
                       </span>
                     </span>
@@ -9964,6 +9898,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_2"
+                  role="option"
                   title="mysql-2(10.186.62.14:33062)"
                 >
                   <div
@@ -9972,7 +9908,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-2(10.186.62.14:33062)
                       </span>
                     </span>
@@ -9987,6 +9925,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_3"
+                  role="option"
                   title="xin-test-database(10.186.62.15:33063)"
                 >
                   <div
@@ -9995,7 +9935,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         xin-test-database(10.186.62.15:33063)
                       </span>
                     </span>
@@ -10010,6 +9952,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_4"
+                  role="option"
                   title="mysql-5(139.196.241.182:33061)"
                 >
                   <div
@@ -10018,7 +9962,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-5(139.196.241.182:33061)
                       </span>
                     </span>
@@ -10050,6 +9996,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_6"
+                  role="option"
                   title="progres-1(10.186.62.16:5432)"
                 >
                   <div
@@ -10058,7 +10006,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         progres-1(10.186.62.16:5432)
                       </span>
                     </span>
@@ -10090,6 +10040,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_8"
+                  role="option"
                   title="tidb-1(10.186.62.17:4000)"
                 >
                   <div
@@ -10098,7 +10050,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan 3`] = `
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         tidb-1(10.186.62.17:4000)
                       </span>
                     </span>
@@ -10463,7 +10417,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -10495,12 +10449,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 title="environment-1"
                               >
                                 <span
-                                  class="css-14lkj40"
+                                  class="css-1acawoa"
                                   color="#8C8C8C"
                                 >
-                                  <span
-                                    class="environment-tag-color-dot"
-                                  />
                                   <span
                                     class="environment-tag-name"
                                   >
@@ -10569,7 +10520,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -10669,7 +10620,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -10702,7 +10653,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -10779,7 +10732,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -10810,7 +10763,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -11193,58 +11148,39 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="environmentTag_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="true"
-            id="environmentTag_list_0"
-            role="option"
-          >
-            1
-          </div>
-          <div
-            aria-selected="false"
-            id="environmentTag_list_1"
-            role="option"
-          >
-            2
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="environmentTag_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                  id="environmentTag_list_0"
+                  role="option"
                   title="environment-1"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -11262,18 +11198,17 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
+                  id="environmentTag_list_1"
+                  role="option"
                   title="environment-2"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -11364,46 +11299,23 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="instanceId_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="false"
-            id="instanceId_list_0"
-            role="presentation"
-          />
-          <div
-            aria-selected="true"
-            id="instanceId_list_1"
-            role="option"
-          >
-            1739531854064652288
-          </div>
-          <div
-            aria-selected="false"
-            id="instanceId_list_2"
-            role="option"
-          >
-            1739531942258282496
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="instanceId_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
@@ -11426,6 +11338,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active ant-select-item-option-selected"
+                  id="instanceId_list_1"
+                  role="option"
                   title="mysql-1(10.186.62.13:33061)"
                 >
                   <div
@@ -11434,7 +11348,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1(10.186.62.13:33061)
                       </span>
                     </span>
@@ -11449,6 +11365,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_2"
+                  role="option"
                   title="mysql-2(10.186.62.14:33062)"
                 >
                   <div
@@ -11457,7 +11375,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-2(10.186.62.14:33062)
                       </span>
                     </span>
@@ -11472,6 +11392,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_3"
+                  role="option"
                   title="xin-test-database(10.186.62.15:33063)"
                 >
                   <div
@@ -11480,7 +11402,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         xin-test-database(10.186.62.15:33063)
                       </span>
                     </span>
@@ -11495,6 +11419,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_4"
+                  role="option"
                   title="mysql-5(139.196.241.182:33061)"
                 >
                   <div
@@ -11503,7 +11429,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-5(139.196.241.182:33061)
                       </span>
                     </span>
@@ -11535,6 +11463,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_6"
+                  role="option"
                   title="progres-1(10.186.62.16:5432)"
                 >
                   <div
@@ -11543,7 +11473,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         progres-1(10.186.62.16:5432)
                       </span>
                     </span>
@@ -11575,6 +11507,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_8"
+                  role="option"
                   title="tidb-1(10.186.62.17:4000)"
                 >
                   <div
@@ -11583,7 +11517,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         tidb-1(10.186.62.17:4000)
                       </span>
                     </span>
@@ -11720,7 +11656,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -11752,12 +11688,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 title="environment-1"
                               >
                                 <span
-                                  class="css-14lkj40"
+                                  class="css-1acawoa"
                                   color="#8C8C8C"
                                 >
-                                  <span
-                                    class="environment-tag-color-dot"
-                                  />
                                   <span
                                     class="environment-tag-name"
                                   >
@@ -11826,7 +11759,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -11926,7 +11859,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -11959,7 +11892,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -12036,7 +11971,7 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"
@@ -12067,7 +12002,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1(10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -12886,58 +12823,39 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="environmentTag_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="true"
-            id="environmentTag_list_0"
-            role="option"
-          >
-            1
-          </div>
-          <div
-            aria-selected="false"
-            id="environmentTag_list_1"
-            role="option"
-          >
-            2
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="environmentTag_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                  id="environmentTag_list_0"
+                  role="option"
                   title="environment-1"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -12955,18 +12873,17 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
+                  id="environmentTag_list_1"
+                  role="option"
                   title="environment-2"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
                     <span
-                      class="css-14lkj40"
+                      class="css-1acawoa"
                       color="#8C8C8C"
                     >
-                      <span
-                        class="environment-tag-color-dot"
-                      />
                       <span
                         class="environment-tag-name"
                       >
@@ -13057,46 +12974,23 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
   </div>
   <div>
     <div
-      class="ant-select-dropdown ant-select-dropdown-hidden ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: 0; width: 0px; pointer-events: none;"
+      class="ant-select-dropdown ant-select-dropdown-hidden environment-tag-select-dropdown ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; pointer-events: none;"
     >
       <div>
-        <div
-          id="instanceId_list"
-          role="listbox"
-          style="height: 0px; width: 0px; overflow: hidden;"
-        >
-          <div
-            aria-selected="false"
-            id="instanceId_list_0"
-            role="presentation"
-          />
-          <div
-            aria-selected="true"
-            id="instanceId_list_1"
-            role="option"
-          >
-            1739531854064652288
-          </div>
-          <div
-            aria-selected="false"
-            id="instanceId_list_2"
-            role="option"
-          >
-            1739531942258282496
-          </div>
-        </div>
         <div
           class="rc-virtual-list"
           style="position: relative;"
         >
           <div
             class="rc-virtual-list-holder"
-            style="max-height: 256px; overflow-y: hidden;"
+            style="max-height: 256px; overflow-y: auto;"
           >
             <div>
               <div
                 class="rc-virtual-list-holder-inner"
+                id="instanceId_list"
+                role="listbox"
                 style="display: flex; flex-direction: column;"
               >
                 <div
@@ -13119,6 +13013,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active ant-select-item-option-selected"
+                  id="instanceId_list_1"
+                  role="option"
                   title="mysql-1(10.186.62.13:33061)"
                 >
                   <div
@@ -13127,7 +13023,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1(10.186.62.13:33061)
                       </span>
                     </span>
@@ -13142,6 +13040,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_2"
+                  role="option"
                   title="mysql-2(10.186.62.14:33062)"
                 >
                   <div
@@ -13150,7 +13050,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-2(10.186.62.14:33062)
                       </span>
                     </span>
@@ -13165,6 +13067,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_3"
+                  role="option"
                   title="xin-test-database(10.186.62.15:33063)"
                 >
                   <div
@@ -13173,7 +13077,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         xin-test-database(10.186.62.15:33063)
                       </span>
                     </span>
@@ -13188,6 +13094,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_4"
+                  role="option"
                   title="mysql-5(139.196.241.182:33061)"
                 >
                   <div
@@ -13196,7 +13104,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-5(139.196.241.182:33061)
                       </span>
                     </span>
@@ -13228,6 +13138,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_6"
+                  role="option"
                   title="progres-1(10.186.62.16:5432)"
                 >
                   <div
@@ -13236,7 +13148,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         progres-1(10.186.62.16:5432)
                       </span>
                     </span>
@@ -13268,6 +13182,8 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  id="instanceId_list_8"
+                  role="option"
                   title="tidb-1(10.186.62.17:4000)"
                 >
                   <div
@@ -13276,7 +13192,9 @@ exports[`test sqle/SqlManagementConf/Create render create audit plan with perfor
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         tidb-1(10.186.62.17:4000)
                       </span>
                     </span>
@@ -13443,7 +13361,7 @@ exports[`test sqle/SqlManagementConf/Create render init snap shot 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                           >
                             <div
                               class="ant-select-selector"
@@ -13536,7 +13454,7 @@ exports[`test sqle/SqlManagementConf/Create render init snap shot 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                           >
                             <div
                               class="ant-select-selector"
@@ -13617,7 +13535,7 @@ exports[`test sqle/SqlManagementConf/Create render init snap shot 1`] = `
                           class="ant-form-item-control-input-content"
                         >
                           <div
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -13720,7 +13638,7 @@ exports[`test sqle/SqlManagementConf/Create render init snap shot 1`] = `
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-show-search"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-show-search"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                 style="margin-right: 12px; padding-bottom: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -336,7 +336,7 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                 style="margin-right: 12px; padding-bottom: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -394,7 +394,7 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                 style="margin-right: 12px; padding-bottom: 12px;"
               >
                 <div
-                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                  class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"
@@ -2555,7 +2555,7 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                   style="margin-right: 12px; padding-bottom: 12px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -2613,7 +2613,7 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                   style="margin-right: 12px; padding-bottom: 12px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -2671,7 +2671,7 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                   style="margin-right: 12px; padding-bottom: 12px;"
                 >
                   <div
-                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                    class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagementConf/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -624,7 +624,19 @@ exports[`test sqle/SqlManagementConf/List render close task type filter field 1`
                             <td
                               class="ant-table-cell"
                             >
-                              environment-1
+                              <span
+                                class="css-yuolwb"
+                                color="#8C8C8C"
+                              >
+                                <span
+                                  class="environment-tag-color-dot"
+                                />
+                                <span
+                                  class="environment-tag-name"
+                                >
+                                  environment-1
+                                </span>
+                              </span>
                             </td>
                             <td
                               class="ant-table-cell"
@@ -747,7 +759,19 @@ exports[`test sqle/SqlManagementConf/List render close task type filter field 1`
                             <td
                               class="ant-table-cell"
                             >
-                              environment-1
+                              <span
+                                class="css-yuolwb"
+                                color="#8C8C8C"
+                              >
+                                <span
+                                  class="environment-tag-color-dot"
+                                />
+                                <span
+                                  class="environment-tag-name"
+                                >
+                                  environment-1
+                                </span>
+                              </span>
                             </td>
                             <td
                               class="ant-table-cell"
@@ -915,7 +939,19 @@ exports[`test sqle/SqlManagementConf/List render close task type filter field 1`
                             <td
                               class="ant-table-cell"
                             >
-                              environment-2
+                              <span
+                                class="css-yuolwb"
+                                color="#8C8C8C"
+                              >
+                                <span
+                                  class="environment-tag-color-dot"
+                                />
+                                <span
+                                  class="environment-tag-name"
+                                >
+                                  environment-2
+                                </span>
+                              </span>
                             </td>
                             <td
                               class="ant-table-cell"
@@ -3071,7 +3107,19 @@ exports[`test sqle/SqlManagementConf/List render init snap shot 1`] = `
                             <td
                               class="ant-table-cell"
                             >
-                              environment-1
+                              <span
+                                class="css-yuolwb"
+                                color="#8C8C8C"
+                              >
+                                <span
+                                  class="environment-tag-color-dot"
+                                />
+                                <span
+                                  class="environment-tag-name"
+                                >
+                                  environment-1
+                                </span>
+                              </span>
                             </td>
                             <td
                               class="ant-table-cell"
@@ -3194,7 +3242,19 @@ exports[`test sqle/SqlManagementConf/List render init snap shot 1`] = `
                             <td
                               class="ant-table-cell"
                             >
-                              environment-1
+                              <span
+                                class="css-yuolwb"
+                                color="#8C8C8C"
+                              >
+                                <span
+                                  class="environment-tag-color-dot"
+                                />
+                                <span
+                                  class="environment-tag-name"
+                                >
+                                  environment-1
+                                </span>
+                              </span>
                             </td>
                             <td
                               class="ant-table-cell"
@@ -3362,7 +3422,19 @@ exports[`test sqle/SqlManagementConf/List render init snap shot 1`] = `
                             <td
                               class="ant-table-cell"
                             >
-                              environment-2
+                              <span
+                                class="css-yuolwb"
+                                color="#8C8C8C"
+                              >
+                                <span
+                                  class="environment-tag-color-dot"
+                                />
+                                <span
+                                  class="environment-tag-name"
+                                >
+                                  environment-2
+                                </span>
+                              </span>
                             </td>
                             <td
                               class="ant-table-cell"
@@ -4256,7 +4328,19 @@ exports[`test sqle/SqlManagementConf/List render sql management conf list with a
                             <td
                               class="ant-table-cell"
                             >
-                              environment-1
+                              <span
+                                class="css-yuolwb"
+                                color="#8C8C8C"
+                              >
+                                <span
+                                  class="environment-tag-color-dot"
+                                />
+                                <span
+                                  class="environment-tag-name"
+                                >
+                                  environment-1
+                                </span>
+                              </span>
                             </td>
                             <td
                               class="ant-table-cell"

--- a/packages/sqle/src/page/SqlManagementConf/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -625,12 +625,9 @@ exports[`test sqle/SqlManagementConf/List render close task type filter field 1`
                               class="ant-table-cell"
                             >
                               <span
-                                class="css-yuolwb"
+                                class="css-1xciw48"
                                 color="#8C8C8C"
                               >
-                                <span
-                                  class="environment-tag-color-dot"
-                                />
                                 <span
                                   class="environment-tag-name"
                                 >
@@ -760,12 +757,9 @@ exports[`test sqle/SqlManagementConf/List render close task type filter field 1`
                               class="ant-table-cell"
                             >
                               <span
-                                class="css-yuolwb"
+                                class="css-1xciw48"
                                 color="#8C8C8C"
                               >
-                                <span
-                                  class="environment-tag-color-dot"
-                                />
                                 <span
                                   class="environment-tag-name"
                                 >
@@ -940,12 +934,9 @@ exports[`test sqle/SqlManagementConf/List render close task type filter field 1`
                               class="ant-table-cell"
                             >
                               <span
-                                class="css-yuolwb"
+                                class="css-1xciw48"
                                 color="#8C8C8C"
                               >
-                                <span
-                                  class="environment-tag-color-dot"
-                                />
                                 <span
                                   class="environment-tag-name"
                                 >
@@ -1984,7 +1975,7 @@ exports[`test sqle/SqlManagementConf/List render filter list data by active stat
               style="margin-right: 12px; padding-bottom: 12px;"
             >
               <div
-                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -2042,7 +2033,7 @@ exports[`test sqle/SqlManagementConf/List render filter list data by active stat
               style="margin-right: 12px; padding-bottom: 12px;"
             >
               <div
-                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -2100,7 +2091,7 @@ exports[`test sqle/SqlManagementConf/List render filter list data by active stat
               style="padding-bottom: 12px;"
             >
               <div
-                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                class="ant-select ant-select-sm ant-select-borderless basic-select-wrapper custom-select-namespace css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
               >
                 <div
                   class="ant-select-selector"
@@ -3108,12 +3099,9 @@ exports[`test sqle/SqlManagementConf/List render init snap shot 1`] = `
                               class="ant-table-cell"
                             >
                               <span
-                                class="css-yuolwb"
+                                class="css-1xciw48"
                                 color="#8C8C8C"
                               >
-                                <span
-                                  class="environment-tag-color-dot"
-                                />
                                 <span
                                   class="environment-tag-name"
                                 >
@@ -3243,12 +3231,9 @@ exports[`test sqle/SqlManagementConf/List render init snap shot 1`] = `
                               class="ant-table-cell"
                             >
                               <span
-                                class="css-yuolwb"
+                                class="css-1xciw48"
                                 color="#8C8C8C"
                               >
-                                <span
-                                  class="environment-tag-color-dot"
-                                />
                                 <span
                                   class="environment-tag-name"
                                 >
@@ -3423,12 +3408,9 @@ exports[`test sqle/SqlManagementConf/List render init snap shot 1`] = `
                               class="ant-table-cell"
                             >
                               <span
-                                class="css-yuolwb"
+                                class="css-1xciw48"
                                 color="#8C8C8C"
                               >
-                                <span
-                                  class="environment-tag-color-dot"
-                                />
                                 <span
                                   class="environment-tag-name"
                                 >
@@ -4329,12 +4311,9 @@ exports[`test sqle/SqlManagementConf/List render sql management conf list with a
                               class="ant-table-cell"
                             >
                               <span
-                                class="css-yuolwb"
+                                class="css-1xciw48"
                                 color="#8C8C8C"
                               >
-                                <span
-                                  class="environment-tag-color-dot"
-                                />
                                 <span
                                   class="environment-tag-name"
                                 >

--- a/packages/sqle/src/page/SqlManagementConf/List/column.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/List/column.tsx
@@ -7,6 +7,7 @@ import { t } from '../../../locale';
 import { DatabaseTypeLogo, BasicToolTip, EmptyBox } from '@actiontech/dms-kit';
 import { TypedLink } from '@actiontech/shared';
 import { IInstanceAuditPlanResV1 } from '@actiontech/shared/lib/api/sqle/service/common';
+import { IEnvironmentTag } from '@actiontech/shared/lib/api/base/service/common';
 import { InstanceAuditPlanTableFilterParamType } from './index.type';
 import {
   formatTime,
@@ -26,6 +27,7 @@ import {
 import ScanTypeTagsCell from './ScanTypeTagsCell';
 import { InfoCircleOutlined } from '@actiontech/icons/';
 import { PlanListTaskTypeButtonStyleWrapper } from './style';
+import { EnvironmentTag } from '@actiontech/shared';
 export const ExtraFilterMeta: () => ActiontechTableFilterMeta<
   IInstanceAuditPlanResV1,
   InstanceAuditPlanTableFilterParamType
@@ -46,11 +48,12 @@ export const ExtraFilterMeta: () => ActiontechTableFilterMeta<
 };
 export const SqlManagementConfColumns: (
   projectID: string,
-  getLogoUrlByDbType: (dbType: string) => string
+  getLogoUrlByDbType: (dbType: string) => string,
+  environmentList: IEnvironmentTag[]
 ) => ActiontechTableColumn<
   IInstanceAuditPlanResV1,
   InstanceAuditPlanTableFilterParamType
-> = (projectID, getLogoUrlByDbType) => {
+> = (projectID, getLogoUrlByDbType, environmentList) => {
   return [
     {
       dataIndex: 'instance_name',
@@ -103,7 +106,20 @@ export const SqlManagementConfColumns: (
       dataIndex: 'environment',
       title: () => t('managementConf.list.table.column.environmentAttribute'),
       render: (environment) => {
-        return environment || '-';
+        if (!environment) {
+          return '-';
+        }
+
+        const matchedEnvironment = environmentList.find(
+          (item) => item.name === environment || item.uid === environment
+        );
+
+        return (
+          <EnvironmentTag
+            name={matchedEnvironment?.name ?? environment}
+            color={matchedEnvironment?.color}
+          />
+        );
       },
       filterCustomType: 'select',
       filterKey: 'filter_by_environment_tag'

--- a/packages/sqle/src/page/SqlManagementConf/List/hooks/useTableFilter.ts
+++ b/packages/sqle/src/page/SqlManagementConf/List/hooks/useTableFilter.ts
@@ -12,7 +12,8 @@ const useInstanceAuditPlanFilter = () => {
 
   const { updateInstanceList, instanceIDOptions } = useInstance();
 
-  const { environmentOptions, updateEnvironmentList } = useServiceEnvironment();
+  const { environmentList, environmentOptions, updateEnvironmentList } =
+    useServiceEnvironment();
 
   const filterCustomProps = useMemo(() => {
     return new Map<keyof IInstanceAuditPlanResV1, FilterCustomProps>([
@@ -61,7 +62,8 @@ const useInstanceAuditPlanFilter = () => {
     filterCustomData,
     setFilterCustomData,
     updateInstanceList,
-    updateEnvironmentList
+    updateEnvironmentList,
+    environmentList
   };
 };
 

--- a/packages/sqle/src/page/SqlManagementConf/List/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/List/index.tsx
@@ -48,10 +48,6 @@ const List: React.FC = () => {
     useTableRequestError();
   const [messageApi, contextMessageHolder] = message.useMessage();
   const { getLogoUrlByDbType } = useDbServiceDriver();
-  const columns = useMemo(
-    () => SqlManagementConfColumns(projectID, getLogoUrlByDbType),
-    [getLogoUrlByDbType, projectID]
-  );
   const {
     tableFilterInfo,
     tableChange,
@@ -65,15 +61,21 @@ const List: React.FC = () => {
     InstanceAuditPlanTableFilterParamType
   >();
   const { parse2TableActionPermissions } = usePermission();
-  const { filterButtonMeta, filterContainerMeta, updateAllSelectedFilterItem } =
-    useTableFilterContainer(columns, updateTableFilterInfo, ExtraFilterMeta());
   const {
     filterCustomData,
     filterCustomProps,
+    environmentList,
     setFilterCustomData,
     updateInstanceList,
     updateEnvironmentList
   } = useTableFilter();
+  const columns = useMemo(
+    () =>
+      SqlManagementConfColumns(projectID, getLogoUrlByDbType, environmentList),
+    [getLogoUrlByDbType, projectID, environmentList]
+  );
+  const { filterButtonMeta, filterContainerMeta, updateAllSelectedFilterItem } =
+    useTableFilterContainer(columns, updateTableFilterInfo, ExtraFilterMeta());
   const [
     taskTypeShowStatus,
     { setFalse: setTaskTypeHide, setTrue: setTaskTypeShow }

--- a/packages/sqle/src/page/SqlManagementConf/Update/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Update/__tests__/__snapshots__/index.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -181,12 +181,9 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                   title="environment-1"
                                 >
                                   <span
-                                    class="css-14lkj40"
+                                    class="css-1acawoa"
                                     color="#8C8C8C"
                                   >
-                                    <span
-                                      class="environment-tag-color-dot"
-                                    />
                                     <span
                                       class="environment-tag-name"
                                     >
@@ -255,7 +252,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -338,7 +335,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -371,7 +368,9 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                   <span
                                     class="instance-option-label"
                                   >
-                                    <span>
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
                                       mysql-1(10.186.62.13:33061)
                                     </span>
                                   </span>
@@ -448,7 +447,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -480,7 +479,9 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                   <span
                                     class="instance-option-label"
                                   >
-                                    <span>
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
                                       mysql-1(10.186.62.13:33061)
                                     </span>
                                   </span>
@@ -836,7 +837,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -1083,7 +1084,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -1585,7 +1586,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="query_time_avg_operator"
                                 >
                                   <div
@@ -1787,7 +1788,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="row_examined_avg_operator"
                                 >
                                   <div
@@ -1988,7 +1989,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                 class="ant-form-item-control-input-content"
                               >
                                 <div
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   data-testid="audit_level_operator"
                                 >
                                   <div
@@ -2076,7 +2077,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                 class="ant-form-item-control-input-content"
                               >
                                 <div
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   data-testid="audit_level_value"
                                 >
                                   <div
@@ -2231,7 +2232,7 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2474,7 +2475,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2507,12 +2508,9 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                                   title="environment-1"
                                 >
                                   <span
-                                    class="css-14lkj40"
+                                    class="css-1acawoa"
                                     color="#8C8C8C"
                                   >
-                                    <span
-                                      class="environment-tag-color-dot"
-                                    />
                                     <span
                                       class="environment-tag-name"
                                     >
@@ -2581,7 +2579,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2664,7 +2662,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2697,7 +2695,9 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                                   <span
                                     class="instance-option-label"
                                   >
-                                    <span>
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
                                       mysql-1(10.186.62.13:33061)
                                     </span>
                                   </span>
@@ -2774,7 +2774,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2806,7 +2806,9 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                                   <span
                                     class="instance-option-label"
                                   >
-                                    <span>
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
                                       mysql-1(10.186.62.13:33061)
                                     </span>
                                   </span>
@@ -3250,7 +3252,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3750,7 +3752,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="query_time_avg_operator"
                                 >
                                   <div
@@ -3951,7 +3953,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                                 class="ant-form-item-control-input-content"
                               >
                                 <div
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   data-testid="row_examined_avg_operator"
                                 >
                                   <div
@@ -4150,7 +4152,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="audit_level_operator"
                                 >
                                   <div
@@ -4239,7 +4241,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="audit_level_value"
                                 >
                                   <div
@@ -4394,7 +4396,7 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4753,7 +4755,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4786,12 +4788,9 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                                   title="environment-1"
                                 >
                                   <span
-                                    class="css-14lkj40"
+                                    class="css-1acawoa"
                                     color="#8C8C8C"
                                   >
-                                    <span
-                                      class="environment-tag-color-dot"
-                                    />
                                     <span
                                       class="environment-tag-name"
                                     >
@@ -4860,7 +4859,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4943,7 +4942,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -4976,7 +4975,9 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                                   <span
                                     class="instance-option-label"
                                   >
-                                    <span>
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
                                       mysql-1(10.186.62.13:33061)
                                     </span>
                                   </span>
@@ -5053,7 +5054,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper environment-tag-select css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
                             >
                               <div
                                 class="ant-select-selector"
@@ -5085,7 +5086,9 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                                   <span
                                     class="instance-option-label"
                                   >
-                                    <span>
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
                                       mysql-1(10.186.62.13:33061)
                                     </span>
                                   </span>
@@ -5529,7 +5532,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -6029,7 +6032,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="query_time_avg_operator"
                                 >
                                   <div
@@ -6230,7 +6233,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                                 class="ant-form-item-control-input-content"
                               >
                                 <div
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   data-testid="row_examined_avg_operator"
                                 >
                                   <div
@@ -6429,7 +6432,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="audit_level_operator"
                                 >
                                   <div
@@ -6518,7 +6521,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                               >
                                 <div
                                   aria-required="true"
-                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                   data-testid="audit_level_value"
                                 >
                                   <div
@@ -6673,7 +6676,7 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                           >
                             <div
                               aria-required="true"
-                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-allow-clear ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagementConf/Update/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Update/__tests__/__snapshots__/index.test.tsx.snap
@@ -180,7 +180,19 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                   class="ant-select-selection-item"
                                   title="environment-1"
                                 >
-                                  environment-1
+                                  <span
+                                    class="css-14lkj40"
+                                    color="#8C8C8C"
+                                  >
+                                    <span
+                                      class="environment-tag-color-dot"
+                                    />
+                                    <span
+                                      class="environment-tag-name"
+                                    >
+                                      environment-1
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -356,7 +368,13 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                   class="ant-select-selection-item"
                                   title="mysql-1(10.186.62.13:33061)"
                                 >
-                                  mysql-1(10.186.62.13:33061)
+                                  <span
+                                    class="instance-option-label"
+                                  >
+                                    <span>
+                                      mysql-1(10.186.62.13:33061)
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -459,7 +477,13 @@ exports[`test sqle/SqlManagementConf/Update render init snap shot 1`] = `
                                   class="ant-select-selection-item"
                                   title="mysql-1(10.186.62.13:33061)"
                                 >
-                                  mysql-1(10.186.62.13:33061)
+                                  <span
+                                    class="instance-option-label"
+                                  >
+                                    <span>
+                                      mysql-1(10.186.62.13:33061)
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -2482,7 +2506,19 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                                   class="ant-select-selection-item"
                                   title="environment-1"
                                 >
-                                  environment-1
+                                  <span
+                                    class="css-14lkj40"
+                                    color="#8C8C8C"
+                                  >
+                                    <span
+                                      class="environment-tag-color-dot"
+                                    />
+                                    <span
+                                      class="environment-tag-name"
+                                    >
+                                      environment-1
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -2658,7 +2694,13 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                                   class="ant-select-selection-item"
                                   title="mysql-1(10.186.62.13:33061)"
                                 >
-                                  mysql-1(10.186.62.13:33061)
+                                  <span
+                                    class="instance-option-label"
+                                  >
+                                    <span>
+                                      mysql-1(10.186.62.13:33061)
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -2761,7 +2803,13 @@ exports[`test sqle/SqlManagementConf/Update render update audit plan 1`] = `
                                   class="ant-select-selection-item"
                                   title="mysql-1(10.186.62.13:33061)"
                                 >
-                                  mysql-1(10.186.62.13:33061)
+                                  <span
+                                    class="instance-option-label"
+                                  >
+                                    <span>
+                                      mysql-1(10.186.62.13:33061)
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -4737,7 +4785,19 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                                   class="ant-select-selection-item"
                                   title="environment-1"
                                 >
-                                  environment-1
+                                  <span
+                                    class="css-14lkj40"
+                                    color="#8C8C8C"
+                                  >
+                                    <span
+                                      class="environment-tag-color-dot"
+                                    />
+                                    <span
+                                      class="environment-tag-name"
+                                    >
+                                      environment-1
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -4913,7 +4973,13 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                                   class="ant-select-selection-item"
                                   title="mysql-1(10.186.62.13:33061)"
                                 >
-                                  mysql-1(10.186.62.13:33061)
+                                  <span
+                                    class="instance-option-label"
+                                  >
+                                    <span>
+                                      mysql-1(10.186.62.13:33061)
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span
@@ -5016,7 +5082,13 @@ exports[`test sqle/SqlManagementConf/Update should not update the password field
                                   class="ant-select-selection-item"
                                   title="mysql-1(10.186.62.13:33061)"
                                 >
-                                  mysql-1(10.186.62.13:33061)
+                                  <span
+                                    class="instance-option-label"
+                                  >
+                                    <span>
+                                      mysql-1(10.186.62.13:33061)
+                                    </span>
+                                  </span>
                                 </span>
                               </div>
                               <span

--- a/packages/sqle/src/page/SqlManagementException/Common/Form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementException/Common/Form/__tests__/__snapshots__/index.test.tsx.snap
@@ -1265,7 +1265,7 @@ exports[`sqle/SqlManagementException/SqlManagementExceptionForm render switch ma
               >
                 <div
                   aria-required="true"
-                  class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                  class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                 >
                   <div
                     class="ant-select-selector"

--- a/packages/sqle/src/page/SqlManagementException/Drawer/__tests__/__snapshots__/Create.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementException/Drawer/__tests__/__snapshots__/Create.test.tsx.snap
@@ -1406,7 +1406,7 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item ant-select-status-validating basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item ant-select-status-validating basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"
@@ -1440,7 +1440,9 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                                 <span
                                   class="instance-option-label"
                                 >
-                                  <span>
+                                  <span
+                                    style="white-space: nowrap;"
+                                  >
                                     mysql-1 (10.186.62.13:33061)
                                   </span>
                                 </span>
@@ -1597,7 +1599,9 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-1 (10.186.62.13:33061)
                       </span>
                     </span>
@@ -1621,7 +1625,9 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-2 (10.186.62.14:33062)
                       </span>
                     </span>
@@ -1645,7 +1651,9 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         xin-test-database (10.186.62.15:33063)
                       </span>
                     </span>
@@ -1669,7 +1677,9 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         mysql-5 (139.196.241.182:33061)
                       </span>
                     </span>
@@ -1710,7 +1720,9 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         progres-1 (10.186.62.16:5432)
                       </span>
                     </span>
@@ -1751,7 +1763,9 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                     <span
                       class="instance-option-label"
                     >
-                      <span>
+                      <span
+                        style="white-space: nowrap;"
+                      >
                         tidb-1 (10.186.62.17:4000)
                       </span>
                     </span>

--- a/packages/sqle/src/page/SqlManagementException/Drawer/__tests__/__snapshots__/Create.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementException/Drawer/__tests__/__snapshots__/Create.test.tsx.snap
@@ -1437,7 +1437,13 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                                 class="ant-select-selection-item"
                                 title="mysql-1 (10.186.62.13:33061)"
                               >
-                                mysql-1 (10.186.62.13:33061)
+                                <span
+                                  class="instance-option-label"
+                                >
+                                  <span>
+                                    mysql-1 (10.186.62.13:33061)
+                                  </span>
+                                </span>
                               </span>
                             </div>
                             <span
@@ -1535,7 +1541,6 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
             role="presentation"
           />
           <div
-            aria-label="mysql-1 (10.186.62.13:33061)"
             aria-selected="true"
             id="instance_list_1"
             role="option"
@@ -1543,7 +1548,6 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
             mysql-1
           </div>
           <div
-            aria-label="mysql-2 (10.186.62.14:33062)"
             aria-selected="false"
             id="instance_list_2"
             role="option"
@@ -1584,12 +1588,19 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                 <div
                   aria-selected="true"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped ant-select-item-option-active ant-select-item-option-selected"
+                  label="mysql-1 (10.186.62.13:33061)"
                   title="mysql-1 (10.186.62.13:33061)"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-1 (10.186.62.13:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-1 (10.186.62.13:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -1601,12 +1612,19 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="mysql-2 (10.186.62.14:33062)"
                   title="mysql-2 (10.186.62.14:33062)"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-2 (10.186.62.14:33062)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-2 (10.186.62.14:33062)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -1618,12 +1636,19 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="xin-test-database (10.186.62.15:33063)"
                   title="xin-test-database (10.186.62.15:33063)"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    xin-test-database (10.186.62.15:33063)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        xin-test-database (10.186.62.15:33063)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -1635,12 +1660,19 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="mysql-5 (139.196.241.182:33061)"
                   title="mysql-5 (139.196.241.182:33061)"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    mysql-5 (139.196.241.182:33061)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        mysql-5 (139.196.241.182:33061)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -1669,12 +1701,19 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="progres-1 (10.186.62.16:5432)"
                   title="progres-1 (10.186.62.16:5432)"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    progres-1 (10.186.62.16:5432)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        progres-1 (10.186.62.16:5432)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"
@@ -1703,12 +1742,19 @@ exports[`slqe/SqlManagementException/CreateSqlManagementException render create 
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option ant-select-item-option-grouped"
+                  label="tidb-1 (10.186.62.17:4000)"
                   title="tidb-1 (10.186.62.17:4000)"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    tidb-1 (10.186.62.17:4000)
+                    <span
+                      class="instance-option-label"
+                    >
+                      <span>
+                        tidb-1 (10.186.62.17:4000)
+                      </span>
+                    </span>
                   </div>
                   <span
                     aria-hidden="true"

--- a/packages/sqle/src/page/SqlManagementException/Drawer/__tests__/__snapshots__/Update.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementException/Drawer/__tests__/__snapshots__/Update.test.tsx.snap
@@ -1492,7 +1492,7 @@ exports[`slqe/SqlManagementException/UpdateSqlManagementException render update 
                         >
                           <div
                             aria-required="true"
-                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                           >
                             <div
                               class="ant-select-selector"

--- a/packages/sqle/src/page/SqlOptimization/Create/SQLInfoForm/DatabaseInfo.tsx
+++ b/packages/sqle/src/page/SqlOptimization/Create/SQLInfoForm/DatabaseInfo.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { DatabaseInfoProps } from '../../index.type';
-import { Alert, Form, Space } from 'antd';
+import { Alert, Form, Space, SelectProps } from 'antd';
 import { CustomSelect } from '@actiontech/dms-kit';
 import useInstanceSchema from '../../../../hooks/useInstanceSchema';
 import { useCurrentProject } from '@actiontech/shared/lib/features';
@@ -82,7 +82,9 @@ const DatabaseInfo: React.FC<DatabaseInfoProps> = ({
             disabled={submitLoading}
             loading={instanceLoading}
             options={instanceOptions}
-            onChange={(value) => handleInstanceNameChange(value)}
+            onChange={(
+              value: Parameters<NonNullable<SelectProps['onChange']>>[0]
+            ) => handleInstanceNameChange(value as string)}
           />
         </FormItemNoLabel>
         <FormItemNoLabel

--- a/packages/sqle/src/page/SqlOptimization/Create/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlOptimization/Create/__snapshots__/index.test.tsx.snap
@@ -251,7 +251,7 @@ exports[`sqle/SqlOptimization/Create enter default content to create sql optimiz
                   class="ant-form-item-control-input-content"
                 >
                   <div
-                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                   >
                     <div
                       class="ant-select-selector"
@@ -379,7 +379,7 @@ exports[`sqle/SqlOptimization/Create enter default content to create sql optimiz
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                         >
                           <div
                             class="ant-select-selector"
@@ -501,7 +501,7 @@ exports[`sqle/SqlOptimization/Create enter default content to create sql optimiz
                       >
                         <div
                           aria-required="true"
-                          class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                          class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                         >
                           <div
                             class="ant-select-selector"

--- a/packages/sqle/src/page/VersionManagement/Common/VersionForm/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/VersionManagement/Common/VersionForm/__tests__/__snapshots__/index.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`sqle/VersionManagement/VersionForm render init snap shot 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -627,7 +627,7 @@ exports[`sqle/VersionManagement/VersionForm render init snap shot 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -844,7 +844,7 @@ exports[`sqle/VersionManagement/VersionForm render init snap shot 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"

--- a/packages/sqle/src/page/VersionManagement/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/VersionManagement/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -909,7 +909,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -1212,7 +1212,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -1426,7 +1426,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-loading"
+                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"

--- a/packages/sqle/src/page/VersionManagement/Detail/Modals/ReleaseDrawer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/VersionManagement/Detail/Modals/ReleaseDrawer/__tests__/__snapshots__/index.test.tsx.snap
@@ -342,7 +342,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render init snap s
                                                         >
                                                           <div
                                                             aria-required="true"
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -464,7 +464,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render init snap s
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -558,7 +558,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render init snap s
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -1160,7 +1160,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                         >
                                                           <div
                                                             aria-required="true"
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -1192,38 +1192,12 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
-                                                                  class="custom-select-option-content css-17mg133"
+                                                                  class="instance-option-label"
                                                                 >
                                                                   <span
-                                                                    class="custom-select-option-content-prefix"
+                                                                    style="white-space: nowrap;"
                                                                   >
-                                                                    <span
-                                                                      class="css-u3jcp4"
-                                                                    >
-                                                                      <svg
-                                                                        color="#4583FF"
-                                                                        height="18"
-                                                                        viewBox="0 0 18 18"
-                                                                        width="18"
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <path
-                                                                          d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                                          fill="currentColor"
-                                                                        />
-                                                                      </svg>
-                                                                    </span>
-                                                                  </span>
-                                                                  <span
-                                                                    class="custom-select-option-content-label"
-                                                                  >
-                                                                    <span
-                                                                      class="instance-option-label"
-                                                                    >
-                                                                      <span>
-                                                                        mysql-2(10.186.62.14:33062)
-                                                                      </span>
-                                                                    </span>
+                                                                    mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -1290,7 +1264,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -1323,7 +1297,9 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                 <span
                                                                   class="instance-option-label"
                                                                 >
-                                                                  <span>
+                                                                  <span
+                                                                    style="white-space: nowrap;"
+                                                                  >
                                                                     mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
@@ -1391,7 +1367,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -1991,7 +1967,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                         >
                                                           <div
                                                             aria-required="true"
-                                                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-focused ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-focused ant-select-single ant-select-show-arrow"
                                                           >
                                                             <span
                                                               aria-live="polite"
@@ -2029,38 +2005,12 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                 title="xin-test-database(10.186.62.15:33063)"
                                                               >
                                                                 <span
-                                                                  class="custom-select-option-content css-17mg133"
+                                                                  class="instance-option-label"
                                                                 >
                                                                   <span
-                                                                    class="custom-select-option-content-prefix"
+                                                                    style="white-space: nowrap;"
                                                                   >
-                                                                    <span
-                                                                      class="css-u3jcp4"
-                                                                    >
-                                                                      <svg
-                                                                        color="#4583FF"
-                                                                        height="18"
-                                                                        viewBox="0 0 18 18"
-                                                                        width="18"
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <path
-                                                                          d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                                          fill="currentColor"
-                                                                        />
-                                                                      </svg>
-                                                                    </span>
-                                                                  </span>
-                                                                  <span
-                                                                    class="custom-select-option-content-label"
-                                                                  >
-                                                                    <span
-                                                                      class="instance-option-label"
-                                                                    >
-                                                                      <span>
-                                                                        xin-test-database(10.186.62.15:33063)
-                                                                      </span>
-                                                                    </span>
+                                                                    xin-test-database(10.186.62.15:33063)
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -2127,7 +2077,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -2160,7 +2110,9 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                 <span
                                                                   class="instance-option-label"
                                                                 >
-                                                                  <span>
+                                                                  <span
+                                                                    style="white-space: nowrap;"
+                                                                  >
                                                                     xin-test-database(10.186.62.15:33063)
                                                                   </span>
                                                                 </span>
@@ -2228,7 +2180,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -2258,7 +2210,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                 class="ant-select-selection-item"
                                                               >
                                                                 <span
-                                                                  class="custom-select-option-content css-17mg133"
+                                                                  class="custom-select-option-content css-1xzd9w3"
                                                                 >
                                                                   <span
                                                                     class="custom-select-option-content-prefix"
@@ -2281,7 +2233,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                     </span>
                                                                   </span>
                                                                   <span
-                                                                    class="custom-select-option-content-label"
+                                                                    class="custom-select-option-content-label is-text-label"
                                                                   >
                                                                     testSchema
                                                                   </span>
@@ -2514,7 +2466,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; width: 0px; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; width: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -2621,7 +2573,9 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           mysql-2(10.186.62.14:33062)
                         </span>
                       </span>
@@ -2644,7 +2598,9 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                       <span
                         class="instance-option-label"
                       >
-                        <span>
+                        <span
+                          style="white-space: nowrap;"
+                        >
                           xin-test-database(10.186.62.15:33063)
                         </span>
                       </span>
@@ -2667,7 +2623,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
   <div>
     <div
       class="ant-select-dropdown ant-select-dropdown-hidden custom-select-popup-wrapper ant-select-dropdown-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; padding: 0px; min-width: 0; pointer-events: none;"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: 0px; top: 0px; box-sizing: border-box; min-width: max-content; padding: 0px; pointer-events: none;"
     >
       <div>
         <span
@@ -3167,7 +3123,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                         >
                                                           <div
                                                             aria-required="true"
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -3199,38 +3155,12 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
-                                                                  class="custom-select-option-content css-17mg133"
+                                                                  class="instance-option-label"
                                                                 >
                                                                   <span
-                                                                    class="custom-select-option-content-prefix"
+                                                                    style="white-space: nowrap;"
                                                                   >
-                                                                    <span
-                                                                      class="css-u3jcp4"
-                                                                    >
-                                                                      <svg
-                                                                        color="#4583FF"
-                                                                        height="18"
-                                                                        viewBox="0 0 18 18"
-                                                                        width="18"
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <path
-                                                                          d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                                          fill="currentColor"
-                                                                        />
-                                                                      </svg>
-                                                                    </span>
-                                                                  </span>
-                                                                  <span
-                                                                    class="custom-select-option-content-label"
-                                                                  >
-                                                                    <span
-                                                                      class="instance-option-label"
-                                                                    >
-                                                                      <span>
-                                                                        mysql-2(10.186.62.14:33062)
-                                                                      </span>
-                                                                    </span>
+                                                                    mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -3297,7 +3227,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -3330,7 +3260,9 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 <span
                                                                   class="instance-option-label"
                                                                 >
-                                                                  <span>
+                                                                  <span
+                                                                    style="white-space: nowrap;"
+                                                                  >
                                                                     mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
@@ -3398,7 +3330,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -4043,7 +3975,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                         >
                                                           <div
                                                             aria-required="true"
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -4075,38 +4007,12 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
-                                                                  class="custom-select-option-content css-17mg133"
+                                                                  class="instance-option-label"
                                                                 >
                                                                   <span
-                                                                    class="custom-select-option-content-prefix"
+                                                                    style="white-space: nowrap;"
                                                                   >
-                                                                    <span
-                                                                      class="css-u3jcp4"
-                                                                    >
-                                                                      <svg
-                                                                        color="#4583FF"
-                                                                        height="18"
-                                                                        viewBox="0 0 18 18"
-                                                                        width="18"
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <path
-                                                                          d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                                          fill="currentColor"
-                                                                        />
-                                                                      </svg>
-                                                                    </span>
-                                                                  </span>
-                                                                  <span
-                                                                    class="custom-select-option-content-label"
-                                                                  >
-                                                                    <span
-                                                                      class="instance-option-label"
-                                                                    >
-                                                                      <span>
-                                                                        mysql-2(10.186.62.14:33062)
-                                                                      </span>
-                                                                    </span>
+                                                                    mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -4173,7 +4079,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -4206,7 +4112,9 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 <span
                                                                   class="instance-option-label"
                                                                 >
-                                                                  <span>
+                                                                  <span
+                                                                    style="white-space: nowrap;"
+                                                                  >
                                                                     mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
@@ -4274,7 +4182,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -4919,7 +4827,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                         >
                                                           <div
                                                             aria-required="true"
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -4951,38 +4859,12 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
-                                                                  class="custom-select-option-content css-17mg133"
+                                                                  class="instance-option-label"
                                                                 >
                                                                   <span
-                                                                    class="custom-select-option-content-prefix"
+                                                                    style="white-space: nowrap;"
                                                                   >
-                                                                    <span
-                                                                      class="css-u3jcp4"
-                                                                    >
-                                                                      <svg
-                                                                        color="#4583FF"
-                                                                        height="18"
-                                                                        viewBox="0 0 18 18"
-                                                                        width="18"
-                                                                        xmlns="http://www.w3.org/2000/svg"
-                                                                      >
-                                                                        <path
-                                                                          d="M15.75 7.125v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375v-2.25C2.25 8.989 5.273 10.5 9 10.5s6.75-1.511 6.75-3.375m-13.5 3.75c0 1.864 3.023 3.375 6.75 3.375s6.75-1.511 6.75-3.375v2.25c0 1.864-3.023 3.375-6.75 3.375s-6.75-1.511-6.75-3.375zM9 9C5.273 9 2.25 7.489 2.25 5.625S5.273 2.25 9 2.25s6.75 1.511 6.75 3.375S12.727 9 9 9"
-                                                                          fill="currentColor"
-                                                                        />
-                                                                      </svg>
-                                                                    </span>
-                                                                  </span>
-                                                                  <span
-                                                                    class="custom-select-option-content-label"
-                                                                  >
-                                                                    <span
-                                                                      class="instance-option-label"
-                                                                    >
-                                                                      <span>
-                                                                        mysql-2(10.186.62.14:33062)
-                                                                      </span>
-                                                                    </span>
+                                                                    mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -5049,7 +4931,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"
@@ -5082,7 +4964,9 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 <span
                                                                   class="instance-option-label"
                                                                 >
-                                                                  <span>
+                                                                  <span
+                                                                    style="white-space: nowrap;"
+                                                                  >
                                                                     mysql-2(10.186.62.14:33062)
                                                                   </span>
                                                                 </span>
@@ -5150,7 +5034,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                           class="ant-form-item-control-input-content"
                                                         >
                                                           <div
-                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-d0rd34 ant-select-single ant-select-allow-clear ant-select-show-arrow"
+                                                            class="ant-select ant-select-in-form-item basic-select-wrapper custom-select-namespace data-source-row-select css-15f13hq ant-select-single ant-select-allow-clear ant-select-show-arrow"
                                                           >
                                                             <div
                                                               class="ant-select-selector"

--- a/packages/sqle/src/page/VersionManagement/Detail/Modals/ReleaseDrawer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/VersionManagement/Detail/Modals/ReleaseDrawer/__tests__/__snapshots__/index.test.tsx.snap
@@ -1189,6 +1189,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                               </span>
                                                               <span
                                                                 class="ant-select-selection-item"
+                                                                title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
                                                                   class="custom-select-option-content css-17mg133"
@@ -1216,7 +1217,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                   <span
                                                                     class="custom-select-option-content-label"
                                                                   >
-                                                                    mysql-2(10.186.62.14:33062)
+                                                                    <span
+                                                                      class="instance-option-label"
+                                                                    >
+                                                                      <span>
+                                                                        mysql-2(10.186.62.14:33062)
+                                                                      </span>
+                                                                    </span>
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -1313,7 +1320,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                 class="ant-select-selection-item"
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
-                                                                mysql-2(10.186.62.14:33062)
+                                                                <span
+                                                                  class="instance-option-label"
+                                                                >
+                                                                  <span>
+                                                                    mysql-2(10.186.62.14:33062)
+                                                                  </span>
+                                                                </span>
                                                               </span>
                                                             </div>
                                                             <span
@@ -2013,6 +2026,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                               </span>
                                                               <span
                                                                 class="ant-select-selection-item"
+                                                                title="xin-test-database(10.186.62.15:33063)"
                                                               >
                                                                 <span
                                                                   class="custom-select-option-content css-17mg133"
@@ -2040,7 +2054,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                   <span
                                                                     class="custom-select-option-content-label"
                                                                   >
-                                                                    xin-test-database(10.186.62.15:33063)
+                                                                    <span
+                                                                      class="instance-option-label"
+                                                                    >
+                                                                      <span>
+                                                                        xin-test-database(10.186.62.15:33063)
+                                                                      </span>
+                                                                    </span>
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -2137,7 +2157,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                                                                 class="ant-select-selection-item"
                                                                 title="xin-test-database(10.186.62.15:33063)"
                                                               >
-                                                                xin-test-database(10.186.62.15:33063)
+                                                                <span
+                                                                  class="instance-option-label"
+                                                                >
+                                                                  <span>
+                                                                    xin-test-database(10.186.62.15:33063)
+                                                                  </span>
+                                                                </span>
                                                               </span>
                                                             </div>
                                                             <span
@@ -2536,7 +2562,6 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
               role="presentation"
             />
             <div
-              aria-label="mysql-2(10.186.62.14:33062)"
               aria-selected="false"
               id="release_workflows_0_target_release_instances_0_target_instance_id_list_1"
               role="option"
@@ -2544,7 +2569,6 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
               1739531942258282496
             </div>
             <div
-              aria-label="xin-test-database(10.186.62.15:33063)"
               aria-selected="true"
               id="release_workflows_0_target_release_instances_0_target_instance_id_list_2"
               role="option"
@@ -2594,7 +2618,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                     <div
                       class="ant-select-item-option-content"
                     >
-                      mysql-2(10.186.62.14:33062)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          mysql-2(10.186.62.14:33062)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -2611,7 +2641,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render release for
                     <div
                       class="ant-select-item-option-content"
                     >
-                      xin-test-database(10.186.62.15:33063)
+                      <span
+                        class="instance-option-label"
+                      >
+                        <span>
+                          xin-test-database(10.186.62.15:33063)
+                        </span>
+                      </span>
                     </div>
                     <span
                       aria-hidden="true"
@@ -3160,6 +3196,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                               </span>
                                                               <span
                                                                 class="ant-select-selection-item"
+                                                                title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
                                                                   class="custom-select-option-content css-17mg133"
@@ -3187,7 +3224,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                   <span
                                                                     class="custom-select-option-content-label"
                                                                   >
-                                                                    mysql-2(10.186.62.14:33062)
+                                                                    <span
+                                                                      class="instance-option-label"
+                                                                    >
+                                                                      <span>
+                                                                        mysql-2(10.186.62.14:33062)
+                                                                      </span>
+                                                                    </span>
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -3284,7 +3327,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 class="ant-select-selection-item"
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
-                                                                mysql-2(10.186.62.14:33062)
+                                                                <span
+                                                                  class="instance-option-label"
+                                                                >
+                                                                  <span>
+                                                                    mysql-2(10.186.62.14:33062)
+                                                                  </span>
+                                                                </span>
                                                               </span>
                                                             </div>
                                                             <span
@@ -4023,6 +4072,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                               </span>
                                                               <span
                                                                 class="ant-select-selection-item"
+                                                                title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
                                                                   class="custom-select-option-content css-17mg133"
@@ -4050,7 +4100,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                   <span
                                                                     class="custom-select-option-content-label"
                                                                   >
-                                                                    mysql-2(10.186.62.14:33062)
+                                                                    <span
+                                                                      class="instance-option-label"
+                                                                    >
+                                                                      <span>
+                                                                        mysql-2(10.186.62.14:33062)
+                                                                      </span>
+                                                                    </span>
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -4147,7 +4203,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 class="ant-select-selection-item"
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
-                                                                mysql-2(10.186.62.14:33062)
+                                                                <span
+                                                                  class="instance-option-label"
+                                                                >
+                                                                  <span>
+                                                                    mysql-2(10.186.62.14:33062)
+                                                                  </span>
+                                                                </span>
                                                               </span>
                                                             </div>
                                                             <span
@@ -4886,6 +4948,7 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                               </span>
                                                               <span
                                                                 class="ant-select-selection-item"
+                                                                title="mysql-2(10.186.62.14:33062)"
                                                               >
                                                                 <span
                                                                   class="custom-select-option-content css-17mg133"
@@ -4913,7 +4976,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                   <span
                                                                     class="custom-select-option-content-label"
                                                                   >
-                                                                    mysql-2(10.186.62.14:33062)
+                                                                    <span
+                                                                      class="instance-option-label"
+                                                                    >
+                                                                      <span>
+                                                                        mysql-2(10.186.62.14:33062)
+                                                                      </span>
+                                                                    </span>
                                                                   </span>
                                                                 </span>
                                                               </span>
@@ -5010,7 +5079,13 @@ exports[`sqle/VersionManagement/Detail/AssociateWorkflowModal render test instan
                                                                 class="ant-select-selection-item"
                                                                 title="mysql-2(10.186.62.14:33062)"
                                                               >
-                                                                mysql-2(10.186.62.14:33062)
+                                                                <span
+                                                                  class="instance-option-label"
+                                                                >
+                                                                  <span>
+                                                                    mysql-2(10.186.62.14:33062)
+                                                                  </span>
+                                                                </span>
                                                               </span>
                                                             </div>
                                                             <span

--- a/packages/sqle/src/page/VersionManagement/Update/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/VersionManagement/Update/__tests__/__snapshots__/index.test.tsx.snap
@@ -395,7 +395,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -430,7 +430,9 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                         <span
                                           class="instance-option-label"
                                         >
-                                          <span>
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
                                             mysql-1(10.186.62.13:33061)
                                           </span>
                                         </span>
@@ -535,7 +537,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -570,7 +572,9 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                         <span
                                           class="instance-option-label"
                                         >
-                                          <span>
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
                                             mysql-2(10.186.62.14:33062)
                                           </span>
                                         </span>
@@ -849,7 +853,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -972,7 +976,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -1190,7 +1194,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                    class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   >
                                     <div
                                       class="ant-select-selector"
@@ -1279,7 +1283,7 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                 >
                                   <div
                                     aria-required="true"
-                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow ant-select-disabled"
+                                    class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-disabled"
                                   >
                                     <div
                                       class="ant-select-selector"

--- a/packages/sqle/src/page/VersionManagement/Update/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/VersionManagement/Update/__tests__/__snapshots__/index.test.tsx.snap
@@ -427,7 +427,13 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                         class="ant-select-selection-item"
                                         title="mysql-1(10.186.62.13:33061)"
                                       >
-                                        mysql-1(10.186.62.13:33061)
+                                        <span
+                                          class="instance-option-label"
+                                        >
+                                          <span>
+                                            mysql-1(10.186.62.13:33061)
+                                          </span>
+                                        </span>
                                       </span>
                                     </div>
                                     <span
@@ -561,7 +567,13 @@ exports[`sqle/VersionManagement/Create render init snap shot 1`] = `
                                         class="ant-select-selection-item"
                                         title="mysql-2(10.186.62.14:33062)"
                                       >
-                                        mysql-2(10.186.62.14:33062)
+                                        <span
+                                          class="instance-option-label"
+                                        >
+                                          <span>
+                                            mysql-2(10.186.62.14:33062)
+                                          </span>
+                                        </span>
                                       </span>
                                     </div>
                                     <span

--- a/packages/sqle/src/page/WorkflowTemplate/UpdateWorkflowTemplate/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/WorkflowTemplate/UpdateWorkflowTemplate/__snapshots__/index.test.tsx.snap
@@ -602,7 +602,7 @@ exports[`page/WorkflowTemplate/UpdateWorkflowTemplate change workflow template n
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -1637,7 +1637,7 @@ exports[`page/WorkflowTemplate/UpdateWorkflowTemplate no review node in template
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -2313,7 +2313,7 @@ exports[`page/WorkflowTemplate/UpdateWorkflowTemplate render update workflow tem
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -2989,7 +2989,7 @@ exports[`page/WorkflowTemplate/UpdateWorkflowTemplate render update workflow tem
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -3665,7 +3665,7 @@ exports[`page/WorkflowTemplate/UpdateWorkflowTemplate update workflow template i
                             >
                               <div
                                 aria-required="true"
-                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"

--- a/packages/sqle/src/page/WorkflowTemplate/UpdateWorkflowTemplate/components/BasicInfo/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/WorkflowTemplate/UpdateWorkflowTemplate/components/BasicInfo/__snapshots__/index.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`page/WorkflowTemplate/BasicInfo render basic info 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"
@@ -194,7 +194,7 @@ exports[`page/WorkflowTemplate/BasicInfo render basic info without default data 
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-single ant-select-show-arrow"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                     >
                       <div
                         class="ant-select-selector"

--- a/packages/sqle/src/page/WorkflowTemplate/UpdateWorkflowTemplate/components/ReviewNodeInfo/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/WorkflowTemplate/UpdateWorkflowTemplate/components/ReviewNodeInfo/__snapshots__/index.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`page/WorkflowTemplate/ReviewNodeInfo render normal exec node info 1`] =
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
                       data-testid="exec-user-select"
                     >
                       <div
@@ -466,7 +466,7 @@ exports[`page/WorkflowTemplate/ReviewNodeInfo render normal review node info 1`]
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
                       data-testid="exec-user-select"
                     >
                       <div
@@ -803,7 +803,7 @@ exports[`page/WorkflowTemplate/ReviewNodeInfo render review node and update revi
                     class="ant-form-item-control-input-content"
                   >
                     <div
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
                       data-testid="exec-user-select"
                     >
                       <div
@@ -1127,7 +1127,7 @@ exports[`page/WorkflowTemplate/ReviewNodeInfo render review node with default as
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                       data-testid="exec-user-select"
                     >
                       <div
@@ -1486,7 +1486,7 @@ exports[`page/WorkflowTemplate/ReviewNodeInfo validate assignee user number 1`] 
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-x5nat1 ant-select-multiple ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-multiple ant-select-show-arrow ant-select-show-search"
                       data-testid="exec-user-select"
                     >
                       <div


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2983

## 描述你的变更

实现环境标签带色展示的前端能力：管理员赋色、SQLE/DMS 选源与列表/筛选统一展示带色标签，降低误选生产库风险。

### 主要改动

**共用组件**
- 新增/增强 `EnvironmentTag` 组件（带色背景+边框，去掉左侧圆点）
- 增强 `EditableSelect`：环境标签编辑支持预设色（10 色）、自定义选色、实时预览、保存后提交
- 优化 `CustomSelect` / `BasicSelect`：ReactNode 标签不重复 icon、下拉宽度自适应避免截断

**环境标签管理**
- `EnvironmentField`：预设色板、四行编辑布局（名称/颜色/预设/预览）、移除前端 V2 二次合并

**SQLE 选源（useInstance）**
- 工单、快捷审核、SQL 优化、结构对比、管控配置等 tip 下拉统一展示带色标签

**DMS 选源（useDbService）**
- 数据导出等页面直接使用 tips 接口返回的 `environment_tag`，不再额外请求 V2 合并

**列表与筛选**
- 数据源列表「环境属性」列、全局/工单/管控等筛选下拉改为带色标签展示

### 兼容性
- 无色标签 → 中性灰；无标签 → 不展示；选 PROD **不阻断**
- CE/EE 构建均覆盖（含 snapshot 与 CE 测试用例更新）

### 依赖关系
- 依赖 **dms**（tips 返回 `environment_tag`）和 **sqle**（tip 返回 `environment_tag_color`）MR 合并后联调验收

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------