### PR TITLE
标准产品 UI：SQL 管控整改追踪提交闭环

### DIFF
--- a/packages/base/src/locale/en-US/dmsMenu.ts
+++ b/packages/base/src/locale/en-US/dmsMenu.ts
@@ -63,6 +63,7 @@ export default {
     title: 'Global settings',
     userCenter: 'User center',
     reportStatistics: 'Report statistics',
+    sqlManagementRemediationReport: 'SQL management remediation report',
     viewRule: 'View rule',
     ruleManage: 'Rule management',
     system: 'System settings',

--- a/packages/base/src/locale/zh-CN/dmsMenu.ts
+++ b/packages/base/src/locale/zh-CN/dmsMenu.ts
@@ -65,6 +65,7 @@ export default {
     title: '全局设置',
     userCenter: '用户中心',
     reportStatistics: '报表统计',
+    sqlManagementRemediationReport: 'SQL 管控整改报表',
     viewRule: '查看规则',
     ruleManage: '规则管理',
     system: '系统设置',

--- a/packages/base/src/page/Nav/SideMenu/UserMenu/components/GlobalSetting.tsx
+++ b/packages/base/src/page/Nav/SideMenu/UserMenu/components/GlobalSetting.tsx
@@ -6,8 +6,12 @@ import {
   UserShieldFilled,
   CenterCircleHexagonFilled,
   DatabaseFilled,
+  // #if [sqle]
+  ProfileSquareFilled,
+  SignalFilled,
   ProfileEditFilled,
-  OperateAuditFilled
+  ManagementFilled
+  // #endif
 } from '@actiontech/icons';
 import { ContextMenuItem } from './ContextMenu/index.type';
 import ContextMenu from './ContextMenu';
@@ -27,53 +31,129 @@ const GlobalSetting: React.FC = () => {
 
   const { checkPagePermission } = usePermission();
 
-  const menus: ContextMenuItem[] = useMemo(() => {
-    const handleClickItem = (path: string) => {
-      navigate(path);
-    };
-
-    const menusWithPermission: Array<
-      ContextMenuItem & { permission?: PermissionsConstantType }
-    > = [
-      {
-        key: 'user-center',
-        icon: <UserShieldFilled />,
-        text: t('menu.userCenter'),
-        onClick: () => handleClickItem(ROUTE_PATHS.BASE.USER_CENTER),
-        permission: PERMISSIONS.PAGES.BASE.USER_CENTER
-      },
-      {
-        key: 'data-source-management',
-        icon: <DatabaseFilled />,
-        text: t('dmsMenu.globalSettings.instanceManager'),
-        onClick: () =>
-          handleClickItem(ROUTE_PATHS.BASE.DATA_SOURCE_MANAGEMENT.index.path),
-        permission: PERMISSIONS.PAGES.BASE.DATA_SOURCE_MANAGEMENT
-      },
-      // #if [sqle]
-      {
-        key: 'rule-manager',
-        icon: <ProfileEditFilled />,
-        text: t('dmsMenu.globalSettings.ruleManage'),
-        onClick: () =>
-          handleClickItem(ROUTE_PATHS.SQLE.RULE_MANAGEMENT.index.path),
-        permission: PERMISSIONS.PAGES.SQLE.RULE_MANAGEMENT
-      },
-      // #endif
-      {
-        key: 'operationRecord',
-        icon: <OperateAuditFilled />,
-        text: t('dmsMenu.globalSettings.globalOperationRecord'),
-        onClick: () =>
-          handleClickItem(ROUTE_PATHS.SQLE.GLOBAL_OPERATION_LOG.index),
-        permission: PERMISSIONS.PAGES.SQLE.GLOBAL_OPERATION_RECORD
-      },
-      {
-        key: 'system',
-        icon: <GearFilled />,
-        text: t('dmsMenu.globalSettings.system'),
-        onClick: () => handleClickItem(ROUTE_PATHS.BASE.SYSTEM.index.path),
-        permission: PERMISSIONS.PAGES.BASE.SYSTEM_SETTING
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      trigger={['click']}
+      placement="topRight"
+      arrow={false}
+      content={
+        <PopoverInnerStyleWrapper>
+          <div className="header">{t('dmsMenu.globalSettings.title')}</div>
+          <div className="content">
+            <EmptyBox if={isAdmin}>
+              <div
+                className="content-item"
+                onClick={() => handleClickItem('/user-center')}
+              >
+                <UserShieldFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.userCenter')}
+                </span>
+              </div>
+            </EmptyBox>
+            <EmptyBox if={isAdmin || isCertainProjectManager}>
+              <div
+                className="content-item"
+                onClick={() => handleClickItem(`/data-source-management`)}
+              >
+                <DatabaseFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.instanceManager')}
+                </span>
+              </div>
+            </EmptyBox>
+            <EmptyBox if={!isAdmin}>
+              {/* #if [sqle]*/}
+              <div
+                className="content-item"
+                onClick={() => handleClickItem(`/sqle/rule`)}
+              >
+                <ProfileSquareFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.viewRule')}
+                </span>
+              </div>
+              {/* #endif */}
+            </EmptyBox>
+            <EmptyBox if={isAdmin}>
+              {/* #if [sqle] */}
+              <div
+                className="content-item"
+                onClick={() => handleClickItem('/sqle/report-statistics')}
+              >
+                <SignalFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.reportStatistics')}
+                </span>
+              </div>
+              <div
+                className="content-item"
+                onClick={() =>
+                  handleClickItem('/sqle/sql-management-remediation-report')
+                }
+              >
+                <ManagementFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.sqlManagementRemediationReport')}
+                </span>
+              </div>
+              <div
+                className="content-item"
+                onClick={() => handleClickItem(`/sqle/rule`)}
+              >
+                <ProfileSquareFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.viewRule')}
+                </span>
+              </div>
+              <div
+                className="content-item"
+                onClick={() => handleClickItem(`/sqle/rule-manager`)}
+              >
+                <ProfileEditFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.ruleManage')}
+                </span>
+              </div>
+              {/* #endif */}
+              <div
+                className="content-item"
+                onClick={() => handleClickItem(`/system`)}
+              >
+                <GearFilled />
+                <span className="content-item-text">
+                  {t('dmsMenu.globalSettings.system')}
+                </span>
+              </div>
+            </EmptyBox>
+          </div>
+          {/* todo: hide theme change in
+          <div className="footer">
+            <span className="footer-text">
+              {t('dmsMenu.globalSettings.changeTheme')}
+            </span>
+            <div className="footer-icon">
+              <span
+                onClick={() => updateTheme(SupportTheme.LIGHT)}
+                className={classNames('footer-icon-wrapper', {
+                  'footer-icon-active': theme === SupportTheme.LIGHT
+                })}
+              >
+                <IconSun />
+              </span>
+              <span
+                onClick={() => updateTheme(SupportTheme.DARK)}
+                className={classNames('footer-icon-wrapper', {
+                  'footer-icon-active': theme === SupportTheme.DARK
+                })}
+              >
+                <IconMoon />
+              </span>
+            </div>
+          </div> */}
+        </PopoverInnerStyleWrapper>
       }
     ];
 

--- a/packages/base/src/scripts/version.ts
+++ b/packages/base/src/scripts/version.ts
@@ -1,1 +1,1 @@
-export const UI_VERSION = 'sync/data-masking   417b194dd';
+export const UI_VERSION = 'zjrc_3.2408   a32b5993';

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
@@ -12,10 +12,12 @@ import {
   exportSqlManageV1FilterStatusEnum,
   exportSqlManageV1SortFieldEnum,
   exportSqlManageV1SortOrderEnum,
+  exportSqlManageRemediationV1ExportScopeEnum,
   GetSqlManageListV2FilterSourceEnum,
   GetSqlManageListV2FilterAuditLevelEnum,
   GetSqlManageListV2FilterStatusEnum,
   GetSqlManageListV2FilterPriorityEnum,
+  GetSqlManageListV2FilterRemediationStatusEnum,
   GetSqlManageListV2SortFieldEnum,
   GetSqlManageListV2SortOrderEnum,
   exportSqlManageV2FilterPriorityEnum,
@@ -41,10 +43,9 @@ import {
   IBatchUpdateSqlManageReq,
   IBaseRes,
   IGetSqlManageRuleTipsResp,
-  ISqlManageCodingReq,
-  IPostSqlManageCodingResp,
   IGetSqlManageSqlAnalysisResp,
-  ISqlManageAnalysisChartResp
+  IGetSqlManageRemediationResp,
+  IGetSqlManageRemediationOverviewResp
 } from '../common.d';
 
 export interface IGetGlobalSqlManageListParams {
@@ -162,6 +163,20 @@ export interface IExportSqlManageV1Params {
   sort_order?: exportSqlManageV1SortOrderEnum;
 }
 
+export interface IExportGlobalSqlManageRemediationV1Params {}
+
+export interface IExportSqlManageRemediationV1Params {
+  project_name: string;
+
+  export_scope: exportSqlManageRemediationV1ExportScopeEnum;
+
+  filter_instance_id?: string;
+
+  instance_audit_plan_id?: number;
+
+  audit_plan_type?: string;
+}
+
 export interface IGetSqlManageRuleTipsParams {
   project_name: string;
 }
@@ -222,6 +237,8 @@ export interface IGetSqlManageListV2Params {
 
   filter_status?: GetSqlManageListV2FilterStatusEnum;
 
+  filter_remediation_status?: GetSqlManageListV2FilterRemediationStatusEnum;
+
   filter_rule_name?: string;
 
   filter_db_type?: string;
@@ -247,82 +264,22 @@ export interface IGetSqlManageListV2Params {
 
 export interface IGetSqlManageListV2Return extends IGetSqlManageListResp {}
 
-export interface IExportSqlManageV2Params {
+export interface IGetSqlManageRemediationV1Params {
   project_name: string;
 
-  fuzzy_search_sql_fingerprint?: string;
-
-  filter_assignee?: string;
-
-  filter_by_environment_tag?: string;
-
-  filter_priority?: exportSqlManageV2FilterPriorityEnum;
-
-  filter_instance_id?: string;
-
-  filter_source?: exportSqlManageV2FilterSourceEnum;
-
-  filter_audit_level?: exportSqlManageV2FilterAuditLevelEnum;
-
-  filter_last_audit_start_time_from?: string;
-
-  filter_last_audit_start_time_to?: string;
-
-  filter_status?: exportSqlManageV2FilterStatusEnum;
-
-  filter_db_type?: string;
-
-  filter_rule_name?: string;
-
-  fuzzy_search_endpoint?: string;
-
-  fuzzy_search_schema_name?: string;
-
-  sort_field?: exportSqlManageV2SortFieldEnum;
-
-  sort_order?: exportSqlManageV2SortOrderEnum;
-
-  export_format?: exportSqlManageV2ExportFormatEnum;
+  sql_manage_id: string;
 }
 
-export interface IGetSqlManageListV3Params {
+export interface IGetSqlManageRemediationV1Return
+  extends IGetSqlManageRemediationResp {}
+
+export interface IGetSqlManageRemediationOverviewV1Params {
   project_name: string;
 
-  fuzzy_search_sql_fingerprint?: string;
+  instance_audit_plan_id?: number;
 
-  filter_assignee?: string;
-
-  filter_instance_id?: string;
-
-  filter_source?: GetSqlManageListV3FilterSourceEnum;
-
-  filter_audit_level?: GetSqlManageListV3FilterAuditLevelEnum;
-
-  filter_last_audit_start_time_from?: string;
-
-  filter_last_audit_start_time_to?: string;
-
-  filter_status?: GetSqlManageListV3FilterStatusEnum;
-
-  filter_rule_name?: string;
-
-  filter_db_type?: string;
-
-  filter_by_environment_tag?: string;
-
-  filter_priority?: GetSqlManageListV3FilterPriorityEnum;
-
-  fuzzy_search_endpoint?: string;
-
-  fuzzy_search_schema_name?: string;
-
-  sort_field?: GetSqlManageListV3SortFieldEnum;
-
-  sort_order?: GetSqlManageListV3SortOrderEnum;
-
-  page_index: number;
-
-  page_size: number;
+  audit_plan_type?: string;
 }
 
-export interface IGetSqlManageListV3Return extends IGetSqlManageListResp {}
+export interface IGetSqlManageRemediationOverviewV1Return
+  extends IGetSqlManageRemediationOverviewResp {}

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.enum.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.enum.ts
@@ -102,6 +102,14 @@ export enum exportSqlManageV1SortOrderEnum {
   'desc' = 'desc'
 }
 
+export enum exportSqlManageRemediationV1ExportScopeEnum {
+  'project' = 'project',
+
+  'data_source' = 'data_source',
+
+  'scan_task' = 'scan_task'
+}
+
 export enum GetSqlManageListV2FilterSourceEnum {
   'audit_plan' = 'audit_plan',
 
@@ -134,6 +142,18 @@ export enum GetSqlManageListV2FilterPriorityEnum {
   'high' = 'high',
 
   'low' = 'low'
+}
+
+export enum GetSqlManageListV2FilterRemediationStatusEnum {
+  'resolved' = 'resolved',
+
+  'partially_fixed' = 'partially_fixed',
+
+  'unchanged' = 'unchanged',
+
+  'deteriorated' = 'deteriorated',
+
+  'newly_discovered' = 'newly_discovered'
 }
 
 export enum GetSqlManageListV2SortFieldEnum {

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.ts
@@ -18,6 +18,8 @@ import {
   IBatchUpdateSqlManageParams,
   IBatchUpdateSqlManageReturn,
   IExportSqlManageV1Params,
+  IExportGlobalSqlManageRemediationV1Params,
+  IExportSqlManageRemediationV1Params,
   IGetSqlManageRuleTipsParams,
   IGetSqlManageRuleTipsReturn,
   ISendSqlManageParams,
@@ -28,9 +30,10 @@ import {
   IGetSqlManageSqlAnalysisChartV1Return,
   IGetSqlManageListV2Params,
   IGetSqlManageListV2Return,
-  IExportSqlManageV2Params,
-  IGetSqlManageListV3Params,
-  IGetSqlManageListV3Return
+  IGetSqlManageRemediationV1Params,
+  IGetSqlManageRemediationV1Return,
+  IGetSqlManageRemediationOverviewV1Params,
+  IGetSqlManageRemediationOverviewV1Return
 } from './index.d';
 
 class SqlManageService extends ServiceBase {
@@ -118,6 +121,34 @@ class SqlManageService extends ServiceBase {
     );
   }
 
+  public exportGlobalSqlManageRemediationV1(
+    params: IExportGlobalSqlManageRemediationV1Params = {},
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+
+    return this.get<any>(
+      `/v1/sql_manages/remediation_exports`,
+      paramsData,
+      options
+    );
+  }
+
+  public exportSqlManageRemediationV1(
+    params: IExportSqlManageRemediationV1Params,
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+    const project_name = paramsData.project_name;
+    delete paramsData.project_name;
+
+    return this.get<any>(
+      `/v1/projects/${project_name}/sql_manages/remediation_exports`,
+      paramsData,
+      options
+    );
+  }
+
   public GetSqlManageRuleTips(
     params: IGetSqlManageRuleTipsParams,
     options?: AxiosRequestConfig
@@ -199,31 +230,34 @@ class SqlManageService extends ServiceBase {
     );
   }
 
-  public exportSqlManageV2(
-    params: IExportSqlManageV2Params,
+  public GetSqlManageRemediationV1(
+    params: IGetSqlManageRemediationV1Params,
     options?: AxiosRequestConfig
   ) {
     const paramsData = this.cloneDeep(params);
     const project_name = paramsData.project_name;
     delete paramsData.project_name;
 
-    return this.get<any>(
-      `/v2/projects/${project_name}/sql_manages/exports`,
+    const sql_manage_id = paramsData.sql_manage_id;
+    delete paramsData.sql_manage_id;
+
+    return this.get<IGetSqlManageRemediationV1Return>(
+      `/v1/projects/${project_name}/sql_manages/${sql_manage_id}/remediation`,
       paramsData,
       options
     );
   }
 
-  public GetSqlManageListV3(
-    params: IGetSqlManageListV3Params,
+  public getSqlManageRemediationOverviewV1(
+    params: IGetSqlManageRemediationOverviewV1Params,
     options?: AxiosRequestConfig
   ) {
     const paramsData = this.cloneDeep(params);
     const project_name = paramsData.project_name;
     delete paramsData.project_name;
 
-    return this.get<IGetSqlManageListV3Return>(
-      `/v3/projects/${project_name}/sql_manages`,
+    return this.get<IGetSqlManageRemediationOverviewV1Return>(
+      `/v1/projects/${project_name}/sql_manages/remediation_overview`,
       paramsData,
       options
     );

--- a/packages/shared/lib/api/sqle/service/common.d.ts
+++ b/packages/shared/lib/api/sqle/service/common.d.ts
@@ -3597,6 +3597,16 @@ export interface ISqlManage {
 
   remark?: string;
 
+  remediation_status?: string;
+
+  first_audit_missing?: boolean;
+
+  first_audit_result?: IAuditResult[];
+
+  first_audit_time?: string;
+
+  rule_diff?: IRuleDiff;
+
   schema_name?: string;
 
   source?: ISource;
@@ -5094,12 +5104,76 @@ export interface IWorkflowStepResV2 {
   workflow_step_id?: number;
 }
 
-export interface IBatchCompleteWorkflowsReqV3 {
-  workflow_list?: ICompleteWorkflowReq[];
+export interface IRuleDiff {
+  new?: IAuditResult[];
+
+  resolved?: IAuditResult[];
+
+  unchanged?: IAuditResult[];
 }
 
-export interface ICompleteWorkflowReq {
-  desc?: string;
+export interface ISqlManageRemediation {
+  first_audit_missing?: boolean;
 
-  workflow_id?: string;
+  first_audit_result?: IAuditResult[];
+
+  first_audit_time?: string;
+
+  id?: number;
+
+  latest_audit_result?: IAuditResult[];
+
+  latest_audit_time?: string;
+
+  remediation_status?: string;
+
+  rule_diff?: IRuleDiff;
+
+  sql?: string;
+
+  sql_fingerprint?: string;
+}
+
+export interface IGetSqlManageRemediationResp {
+  code?: number;
+
+  data?: ISqlManageRemediation;
+
+  message?: string;
+}
+
+export interface ISqlManageRemediationOverviewStatusCount {
+  deteriorated?: number;
+
+  newly_discovered?: number;
+
+  partially_fixed?: number;
+
+  resolved?: number;
+
+  unchanged?: number;
+}
+
+export interface ISqlManageRemediationOverview {
+  first_audit_missing_num?: number;
+
+  first_score?: number;
+
+  latest_score?: number;
+
+  remediation_rate?: number;
+
+  score_change?: number;
+
+  sql_total_num?: number;
+
+  remediation_status_count?: ISqlManageRemediationOverviewStatusCount;
+}
+
+export interface IGetSqlManageRemediationOverviewResp {
+  code?: number;
+
+  data?: ISqlManageRemediationOverview;
+
+  message?: string;
 }

--- a/packages/sqle/src/data/EmitterKey.ts
+++ b/packages/sqle/src/data/EmitterKey.ts
@@ -27,6 +27,7 @@ enum EmitterKey {
   Refresh_Sql_Management_Conf_Overview_List = 'Refresh_Sql_Management_Conf_Overview_List',
   Refresh_Sql_Management_Conf_Detail_Sql_List = 'Refresh_Sql_Management_Conf_Detail_Sql_List',
   Export_Sql_Management_Conf_Detail_Sql_List = 'Export_Sql_Management_Conf_Detail_Sql_List',
+  Export_Sql_Management_Conf_Detail_Remediation = 'Export_Sql_Management_Conf_Detail_Remediation',
 
   Refresh_Sql_management_Exception_List = 'Refresh_Sql_management_Exception_List',
 

--- a/packages/sqle/src/locale/en-US/managementConf.ts
+++ b/packages/sqle/src/locale/en-US/managementConf.ts
@@ -111,6 +111,19 @@ export default {
     auditImmediately: 'Audit immediately',
     auditImmediatelySuccessTips: 'Audit successfully',
     exportTips: 'Exporting scan task details',
+    remediationExport: 'SQL remediation',
+    remediationExportTips: 'Exporting SQL management remediation report',
+    remediationExportSuccessTips:
+      'Export SQL management remediation report successfully',
+    remediationOverview: {
+      title: 'Remediation overview',
+      sqlTotal: 'SQL total',
+      firstScore: 'First score',
+      latestScore: 'Latest score',
+      scoreChange: 'Score change',
+      remediationRate: 'Remediation rate',
+      loadFailed: 'Failed to load remediation overview: {{message}}'
+    },
     overview: {
       title: 'Overview',
       column: {

--- a/packages/sqle/src/locale/en-US/sqlManagement.ts
+++ b/packages/sqle/src/locale/en-US/sqlManagement.ts
@@ -6,10 +6,24 @@ export default {
       export: 'Export',
       exporting: 'Exporting file',
       exportSuccessTips: 'Export file successfully',
-      exportFormatModal: {
-        title: 'Select export file format'
-      }
+      remediationExport: 'SQL remediation',
+      remediationExporting: 'Exporting SQL management remediation report',
+      remediationExportSuccessTips:
+        'Export SQL management remediation report successfully'
     }
+  },
+  remediationReport: {
+    pageTitle: 'SQL management remediation report',
+    description:
+      'Export SQL management remediation tracking data in global scope. The Excel file contains Overview, Rule summary and Details.',
+    exportButton: 'Export SQL management remediation report',
+    exporting: 'Exporting SQL management remediation report',
+    exportSuccessTips: 'Export SQL management remediation report successfully',
+    scopeTitle: 'Export scope',
+    scopeContent:
+      'Global scope: includes SQL management remediation data across all projects available to platform administrators.',
+    permissionTips:
+      'Only platform administrators / global operators can see and export this report.'
   },
   statistics: {
     SQLTotalNum: 'SQL total',
@@ -67,8 +81,16 @@ export default {
       occurrenceCount: 'Occurrence count',
       personInCharge: 'Person in charge',
       status: 'Status',
+      remediationStatus: 'Remediation status',
       comment: 'Comment',
       endpoints: 'Endpoint info'
+    },
+    remediationStatus: {
+      resolved: 'Resolved',
+      partially_fixed: 'Partially fixed',
+      unchanged: 'Unchanged',
+      deteriorated: 'Deteriorated',
+      newly_discovered: 'Newly discovered'
     },
     filter: {
       time: 'Time range',

--- a/packages/sqle/src/locale/zh-CN/managementConf.ts
+++ b/packages/sqle/src/locale/zh-CN/managementConf.ts
@@ -116,6 +116,18 @@ export default {
     auditImmediately: '立即审核',
     auditImmediatelySuccessTips: '审核成功',
     exportTips: '正在导出扫描任务详情',
+    remediationExport: 'SQL 管控整改',
+    remediationExportTips: '正在导出 SQL 管控整改报表',
+    remediationExportSuccessTips: 'SQL 管控整改报表导出成功',
+    remediationOverview: {
+      title: '整改概览',
+      sqlTotal: 'SQL 总数',
+      firstScore: '首次评分',
+      latestScore: '最末次评分',
+      scoreChange: '评分变化',
+      remediationRate: '整改率',
+      loadFailed: '整改概览加载失败：{{message}}'
+    },
     overview: {
       title: '概览',
       column: {

--- a/packages/sqle/src/locale/zh-CN/sqlManagement.ts
+++ b/packages/sqle/src/locale/zh-CN/sqlManagement.ts
@@ -6,10 +6,22 @@ export default {
       export: '导出',
       exporting: '正在导出文件',
       exportSuccessTips: '导出文件成功',
-      exportFormatModal: {
-        title: '选择导出文件格式'
-      }
+      remediationExport: 'SQL 管控整改',
+      remediationExporting: '正在导出 SQL 管控整改报表',
+      remediationExportSuccessTips: 'SQL 管控整改报表导出成功'
     }
+  },
+  remediationReport: {
+    pageTitle: 'SQL 管控整改报表',
+    description:
+      '导出全局范围内 SQL 管控整改追踪数据，Excel 包含概览、规则维度汇总和明细。',
+    exportButton: '导出 SQL 管控整改报表',
+    exporting: '正在导出 SQL 管控整改报表',
+    exportSuccessTips: 'SQL 管控整改报表导出成功',
+    scopeTitle: '导出范围',
+    scopeContent:
+      '全局范围：覆盖当前用户有平台管理权限的全部项目 SQL 管控整改数据',
+    permissionTips: '仅平台超管 / 全局运维可见并可导出。'
   },
   statistics: {
     SQLTotalNum: 'SQL总数',
@@ -92,8 +104,16 @@ export default {
       occurrenceCount: '出现数量',
       personInCharge: '负责人',
       status: '状态',
+      remediationStatus: '整改状态',
       comment: '备注',
       endpoints: '端点信息'
+    },
+    remediationStatus: {
+      resolved: '已整改',
+      partially_fixed: '部分整改',
+      unchanged: '未变化',
+      deteriorated: '恶化',
+      newly_discovered: '新发现'
     },
     filter: {
       time: '时间范围',
@@ -127,5 +147,18 @@ export default {
     statusReport: {
       title: 'SQL审核结果'
     }
+  },
+  remediationCompare: {
+    tab: '整改对比',
+    title: '整改对比',
+    description: '对比首次审核与最末次审核结果，展示规则整改变化',
+    firstAuditMissing: '无首次审核快照，当前按最末次结果展示新发现问题。',
+    firstAuditResult: '首次审核结果',
+    latestAuditResult: '最末次审核结果',
+    ruleDiffTitle: '规则差异',
+    resolved: '已解决规则',
+    new: '新增规则',
+    unchanged: '维持规则',
+    emptyRules: '无命中规则'
   }
 };

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/SqlAnalyze.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/SqlAnalyze.tsx
@@ -12,6 +12,8 @@ import { SqlAnalyzeContStyleWrapper, SqlContStyleWrapper } from './style';
 import useTableSchema from './useTableSchema';
 import useSQLExecPlan from './useSQLExecPlan';
 import { SqlAnalyzeProps } from '.';
+import RemediationCompare from '../SqlManage/RemediationCompare';
+
 const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
   const { t } = useTranslation();
   const {
@@ -20,22 +22,8 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
     errorMessage,
     loading = false,
     performanceStatistics,
-    errorType = 'error',
-    sqlExecPlanCostDataSource,
-    getSqlExecPlanCostDataSource,
-    getSqlExecPlanCostDataSourceLoading,
-    getSqlExecPlanCostDataSourceError,
-    showExecPlanCostChart,
-    initTime,
-    selectedPoint,
-    setSelectedPoint,
-    onCreateSqlOptimization,
-    onViewOptimizationResult,
-    optimizationRecordId,
-    createSqlOptimizationLoading,
-    allowSqlOptimization,
-    getPerformanceStatistics,
-    isPerformanceInfoLoaded
+    remediationCompare,
+    errorType = 'error'
   } = props;
   const { generateTableSchemaContent } = useTableSchema();
   const { generateSQLExecPlanContent } = useSQLExecPlan({
@@ -76,16 +64,18 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
       )
     ) {
       return [
+        { label: t('sqlAnalyze.sqlExplain'), value: 'sql' },
         {
-          label: t('sqlAnalyze.sqlExplain'),
-          value: 'sql'
+          label: t('sqlManagement.remediationCompare.tab'),
+          value: 'remediation'
         }
       ];
     }
     return [
+      { label: t('sqlAnalyze.sqlExplain'), value: 'sql' },
       {
-        label: t('sqlAnalyze.sqlExplain'),
-        value: 'sql'
+        label: t('sqlManagement.remediationCompare.tab'),
+        value: 'remediation'
       }
     ].concat(
       (tableMetas?.table_meta_items ?? []).map((table) => {
@@ -120,6 +110,9 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
                     ...sqlExplain,
                     ...performanceStatistics
                   })}
+                {tabStatus === 'remediation' && (
+                  <RemediationCompare data={remediationCompare} />
+                )}
                 {tableMetas?.table_meta_items?.map((table) => {
                   return (
                     <React.Fragment key={table.name}>

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/index.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/index.tsx
@@ -2,6 +2,7 @@ import { ResultStatusType } from 'antd/es/result';
 import SqlAnalyze from './SqlAnalyze';
 import {
   IPerformanceStatistics,
+  ISqlManageRemediation,
   ISQLExplain,
   ITableMeta,
   ITableMetas,
@@ -17,6 +18,7 @@ export type SqlAnalyzeProps = {
   tableMetas?: ITableMetas;
   sqlExplain?: ISQLExplain;
   performanceStatistics?: IPerformanceStatistics;
+  remediationCompare?: ISqlManageRemediation;
   loading?: boolean;
   sqlExecPlanCostDataSource?: IChartPoint[];
   getSqlExecPlanCostDataSourceLoading?: boolean;

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/style.ts
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/style.ts
@@ -102,37 +102,39 @@ export const SqlContStyleWrapper = styled('section')`
     }
   }
 
-  .diff-highlight {
-    color: ${({ theme }) => theme.sharedTheme.components.basicTag.Grape.color};
-  }
+  .remediation-compare-wrapper {
+    padding: 24px 40px;
 
-  .history-exec-plan-wrapper {
-    scroll-margin-top: 60px;
-  }
-`;
-
-export const SqlAnalyzeCostLineChartStyleWrapper = styled('section')`
-  .filter-wrapper {
-    margin-bottom: 16px;
-    display: flex;
-    padding: 24px 40px 12px;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    border-bottom: 1px solid
-      ${({ theme }) => theme.sharedTheme.uiToken.colorBorderSecondary};
-
-    h3 {
-      font-size: 16px;
-      font-style: normal;
-      font-weight: 600;
-      line-height: 24px;
-      color: ${({ theme }) => theme.sharedTheme.uiToken.colorText};
-      margin: 0;
+    .remediation-section-space {
+      width: 100%;
     }
-  }
 
-  .chart-wrapper {
-    padding: 10px 40px;
+    .remediation-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .remediation-title {
+      margin-bottom: 0;
+    }
+
+    .remediation-columns,
+    .remediation-diff-columns {
+      display: grid;
+      grid-column-gap: 16px;
+    }
+
+    .remediation-columns {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .remediation-diff-columns {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .ant-list-item {
+      align-items: flex-start;
+    }
   }
 `;

--- a/packages/sqle/src/page/SqlAnalyze/SqlManage/RemediationCompare.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlManage/RemediationCompare.tsx
@@ -1,0 +1,91 @@
+import { Empty, Alert, Card, Space, Typography } from 'antd';
+import { useTranslation } from 'react-i18next';
+import AuditResultMessage from '../../../components/AuditResultMessage';
+import { ISqlManageRemediation } from '@actiontech/shared/lib/api/sqle/service/common';
+import RemediationStatusTag from '../../SqlManagement/component/SQLEEIndex/RemediationStatusTag';
+
+type RemediationCompareProps = {
+  data?: ISqlManageRemediation;
+};
+
+const ruleNames = (rules?: ISqlManageRemediation['rule_diff']) => ({
+  resolved: rules?.resolved?.map((rule) => rule.rule_name).filter(Boolean),
+  newRules: rules?.new?.map((rule) => rule.rule_name).filter(Boolean),
+  unchanged: rules?.unchanged?.map((rule) => rule.rule_name).filter(Boolean)
+});
+
+const RuleList: React.FC<{ title: string; rules?: string[] }> = ({
+  title,
+  rules
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Space direction="vertical" size={4}>
+      <Typography.Text strong>{title}</Typography.Text>
+      {rules?.length ? (
+        rules.map((rule) => (
+          <Typography.Text key={rule}>{rule}</Typography.Text>
+        ))
+      ) : (
+        <Typography.Text type="secondary">
+          {t('sqlManagement.remediationCompare.emptyRules')}
+        </Typography.Text>
+      )}
+    </Space>
+  );
+};
+
+const RemediationCompare: React.FC<RemediationCompareProps> = ({ data }) => {
+  const { t } = useTranslation();
+
+  if (!data) {
+    return <Empty />;
+  }
+
+  const rules = ruleNames(data.rule_diff);
+
+  return (
+    <Space direction="vertical" size={16} className="full-width-element">
+      <Card title={t('sqlManagement.remediationCompare.title')}>
+        <Space direction="vertical" size={12} className="full-width-element">
+          <Typography.Paragraph type="secondary">
+            {t('sqlManagement.remediationCompare.description')}
+          </Typography.Paragraph>
+          {data.first_audit_missing && (
+            <Alert
+              type="warning"
+              showIcon
+              message={t('sqlManagement.remediationCompare.firstAuditMissing')}
+            />
+          )}
+          <RemediationStatusTag status={data.remediation_status} />
+        </Space>
+      </Card>
+      <Card title={t('sqlManagement.remediationCompare.ruleDiffTitle')}>
+        <Space size={48} align="start">
+          <RuleList
+            title={t('sqlManagement.remediationCompare.resolved')}
+            rules={rules.resolved}
+          />
+          <RuleList
+            title={t('sqlManagement.remediationCompare.new')}
+            rules={rules.newRules}
+          />
+          <RuleList
+            title={t('sqlManagement.remediationCompare.unchanged')}
+            rules={rules.unchanged}
+          />
+        </Space>
+      </Card>
+      <Card title={t('sqlManagement.remediationCompare.firstAuditResult')}>
+        <AuditResultMessage auditResult={data.first_audit_result ?? []} />
+      </Card>
+      <Card title={t('sqlManagement.remediationCompare.latestAuditResult')}>
+        <AuditResultMessage auditResult={data.latest_audit_result ?? []} />
+      </Card>
+    </Space>
+  );
+};
+
+export default RemediationCompare;

--- a/packages/sqle/src/page/SqlAnalyze/SqlManage/index.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlManage/index.tsx
@@ -5,6 +5,7 @@ import { ResponseCode } from '../../../data/common';
 import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 import {
   IPerformanceStatistics,
+  ISqlManageRemediation,
   ISQLExplain,
   ITableMetas
 } from '@actiontech/shared/lib/api/sqle/service/common';
@@ -30,65 +31,46 @@ const SQLManageAnalyze = () => {
   const [tableMetas, setTableMetas] = useState<ITableMetas>();
   const [performanceStatistics, setPerformancesStatistics] =
     useState<IPerformanceStatistics>();
-
+  const [remediationCompare, setRemediationCompare] =
+    useState<ISqlManageRemediation>();
   const [
     loading,
     { setTrue: startGetSqlAnalyze, setFalse: getSqlAnalyzeFinish }
   ] = useBoolean();
   const [errorType, setErrorType] = useState<ResultStatusType>('error');
 
-  const [isPerformanceInfoLoaded, { setTrue: setPerformanceInfoLoaded }] =
-    useBoolean();
-
-  const {
-    setOptimizationCreationParams,
-    onCreateSqlOptimization,
-    onViewOptimizationResult,
-    optimizationRecordId,
-    createSqlOptimizationLoading,
-    allowSqlOptimization
-  } = useSqlOptimization();
-
-  const getSqlAnalyze = useCallback(
-    async (affectRowsEnabled = false) => {
-      startGetSqlAnalyze();
-      try {
-        const res = await SqlManage.GetSqlManageSqlAnalysisV1({
+  const getSqlAnalyze = useCallback(async () => {
+    startGetSqlAnalyze();
+    try {
+      const [res, remediationRes] = await Promise.all([
+        SqlManage.GetSqlManageSqlAnalysisV1({
           sql_manage_id: urlParams.sqlManageId ?? '',
-          project_name: projectName,
-          affectRowsEnabled
-        });
-        if (res.data.code === ResponseCode.SUCCESS) {
-          if (affectRowsEnabled) {
-            setPerformanceInfoLoaded();
-          }
-          setErrorMessage('');
-          const { data } = res.data;
-          const queryParams = extractQueries(
-            ROUTE_PATHS.SQLE.SQL_MANAGEMENT.analyze
-          );
-          setSqlExplain(data?.sql_explain);
-          setTableMetas(data?.table_metas);
-          setPerformancesStatistics(data?.performance_statistics);
-          setOptimizationCreationParams({
-            instance_name: queryParams?.instance_name,
-            schema_name: queryParams?.schema,
-            sql_content: data?.sql_explain?.sql
-          });
-        } else {
+          project_name: projectName
+        }),
+        SqlManage.GetSqlManageRemediationV1({
+          sql_manage_id: urlParams.sqlManageId ?? '',
+          project_name: projectName
+        })
+      ]);
+
+      if (res.data.code !== ResponseCode.SUCCESS) {
+        if (remediationRes.data.code !== ResponseCode.SUCCESS) {
           if (res.data.code === ResponseCode.NotSupportDML) {
             setErrorType('info');
           } else {
-            if (res.data.code === ResponseCode.NotSupportDML) {
-              setErrorType('info');
-            } else {
-              setErrorType('error');
-            }
-            setErrorMessage(res.data.message ?? '');
+            setErrorType('error');
           }
+          setErrorMessage(res.data.message ?? '');
+          return;
         }
-      } finally {
-        getSqlAnalyzeFinish();
+      }
+
+      setErrorMessage('');
+      setSqlExplain(res.data.data?.sql_explain);
+      setTableMetas(res.data.data?.table_metas);
+      setPerformancesStatistics(res.data.data?.performance_statistics);
+      if (remediationRes.data.code === ResponseCode.SUCCESS) {
+        setRemediationCompare(remediationRes.data.data);
       }
     },
     [
@@ -125,34 +107,15 @@ const SQLManageAnalyze = () => {
   }, [getSqlAnalyze, getSqlExecPlanCostDataSource]);
 
   return (
-    <>
-      <SqlAnalyze
-        errorType={errorType}
-        tableMetas={tableMetas}
-        sqlExplain={sqlExplain}
-        errorMessage={errorMessage}
-        performanceStatistics={performanceStatistics}
-        loading={loading}
-        sqlExecPlanCostDataSource={data}
-        getSqlExecPlanCostDataSourceLoading={
-          getSqlExecPlanCostDataSourceLoading
-        }
-        getSqlExecPlanCostDataSource={getSqlExecPlanCostDataSource}
-        getSqlExecPlanCostDataSourceError={getSqlExecPlanCostDataSourceError}
-        showExecPlanCostChart
-        initTime={initTime}
-        selectedPoint={selectedPoint}
-        setSelectedPoint={setSelectedPoint}
-        onCreateSqlOptimization={onCreateSqlOptimization}
-        onViewOptimizationResult={onViewOptimizationResult}
-        optimizationRecordId={optimizationRecordId}
-        createSqlOptimizationLoading={createSqlOptimizationLoading}
-        allowSqlOptimization={allowSqlOptimization}
-        getPerformanceStatistics={getPerformanceStatistics}
-        isPerformanceInfoLoaded={isPerformanceInfoLoaded}
-      />
-      <SqlOptimizationResultDrawer />
-    </>
+    <SqlAnalyze
+      errorType={errorType}
+      tableMetas={tableMetas}
+      sqlExplain={sqlExplain}
+      errorMessage={errorMessage}
+      performanceStatistics={performanceStatistics}
+      remediationCompare={remediationCompare}
+      loading={loading}
+    />
   );
 };
 

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/RemediationStatusTag.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/RemediationStatusTag.tsx
@@ -1,0 +1,36 @@
+import { BasicTag } from '@actiontech/shared';
+import { t } from '../../../../locale';
+
+export const remediationStatusOptions = [
+  'resolved',
+  'partially_fixed',
+  'unchanged',
+  'deteriorated',
+  'newly_discovered'
+];
+
+type RemediationStatusTagProps = {
+  status?: string;
+};
+
+const remediationStatusColor: Record<string, string> = {
+  resolved: 'green',
+  partially_fixed: 'blue',
+  unchanged: 'gray',
+  deteriorated: 'red',
+  newly_discovered: 'orange'
+};
+
+const RemediationStatusTag: React.FC<RemediationStatusTagProps> = ({
+  status
+}) => {
+  const currentStatus = status || 'unchanged';
+
+  return (
+    <BasicTag color={remediationStatusColor[currentStatus] ?? 'gray'}>
+      {t(`sqlManagement.table.remediationStatus.${currentStatus}`)}
+    </BasicTag>
+  );
+};
+
+export default RemediationStatusTag;

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/column.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/column.tsx
@@ -13,14 +13,11 @@ import { BasicToolTip, CustomAvatar, EditText } from '@actiontech/dms-kit';
 import { SQLRenderer, TypedLink } from '@actiontech/shared';
 import { Avatar, Space } from 'antd';
 import StatusTag from './StatusTag';
-import { BasicTag, basicTooltipCommonProps } from '@actiontech/dms-kit';
-import { BasicTypographyEllipsis } from '@actiontech/shared';
-import { SqlManageAuditStatusEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
-import {
-  PERMISSIONS,
-  PermissionsConstantType
-} from '@actiontech/shared/lib/features';
-import { ROUTE_PATHS } from '@actiontech/dms-kit';
+import { BasicTag, BasicTypographyEllipsis } from '@actiontech/shared';
+import { ACTIONTECH_TABLE_ACTION_BUTTON_WIDTH } from '@actiontech/shared/lib/components/ActiontechTable/hooks/useTableAction';
+import { SQLAuditRecordListUrlParamsKey } from './index.data';
+import RemediationStatusTag from './RemediationStatusTag';
+
 export type SqlManagementTableFilterParamType = PageInfoWithoutIndexAndSize<
   IGetSqlManageListV3Params,
   'fuzzy_search_sql_fingerprint' | 'filter_status' | 'project_name'
@@ -31,6 +28,7 @@ export type ExtraFilterMetaType = ISqlManage & {
   filter_instance_id?: string;
   filter_audit_level?: string;
   filter_rule_name?: string;
+  filter_remediation_status?: string;
   time?: string;
 };
 export const ExtraFilterMeta: () => ActiontechTableFilterMeta<
@@ -95,6 +93,15 @@ export const ExtraFilterMeta: () => ActiontechTableFilterMeta<
         filterCustomType: 'select',
         filterKey: 'filter_rule_name',
         filterLabel: t('sqlManagement.table.filter.rule'),
+        checked: false
+      }
+    ],
+    [
+      'filter_remediation_status',
+      {
+        filterCustomType: 'select',
+        filterKey: 'filter_remediation_status',
+        filterLabel: t('sqlManagement.table.column.remediationStatus'),
         checked: false
       }
     ]
@@ -263,6 +270,11 @@ const sqlManagementColumn: (
         }
         return '-';
       }
+    },
+    {
+      dataIndex: 'remediation_status',
+      title: () => t('sqlManagement.table.column.remediationStatus'),
+      render: (status) => <RemediationStatusTag status={status} />
     },
     // {
     //   dataIndex: 'first_appear_timestamp',

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/hooks/useGetTableFilterInfo.ts
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/hooks/useGetTableFilterInfo.ts
@@ -6,14 +6,12 @@ import useInstance from '../../../../../hooks/useInstance';
 import useRuleTips from './useRuleTips';
 import { ExtraFilterMetaType } from '../column';
 import useSourceTips from './useSourceTips';
-import { useTypedQuery } from '@actiontech/shared';
-import { ROUTE_PATHS } from '@actiontech/dms-kit';
-import useServiceEnvironment from '../../../../../hooks/useServiceEnvironment';
+import { remediationStatusOptions } from '../RemediationStatusTag';
+import { useTranslation } from 'react-i18next';
 
 const useGetTableFilterInfo = () => {
-  const { projectName, projectID } = useCurrentProject();
-
-  const extractQueries = useTypedQuery();
+  const { t } = useTranslation();
+  const { projectName } = useCurrentProject();
 
   const { generateAuditLevelSelectOptions } = useStaticStatus();
 
@@ -82,6 +80,15 @@ const useGetTableFilterInfo = () => {
           loading: getRuleTipsLoading,
           popupMatchSelectWidth: 400
         }
+      ],
+      [
+        'filter_remediation_status',
+        {
+          options: remediationStatusOptions.map((status) => ({
+            label: t(`sqlManagement.table.remediationStatus.${status}`),
+            value: status
+          }))
+        }
       ]
     ]);
   }, [
@@ -94,7 +101,8 @@ const useGetTableFilterInfo = () => {
     getSourceTipsLoading,
     generateAuditLevelSelectOptions,
     generateRuleTipsSelectOptions,
-    getRuleTipsLoading
+    getRuleTipsLoading,
+    t
   ]);
 
   return {

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
@@ -1,11 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useBoolean, useRequest } from 'ahooks';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BasicButton, PageHeader } from '@actiontech/dms-kit';
-import { useTypedQuery } from '@actiontech/shared';
-import { useExportFormatModal } from '../../../../hooks/useExportFormatModal';
-import ExportFormatModal from '../../../../components/ExportFormatModal';
-import { GetAuditPlanSQLExportReqV1ExportFormatEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+import { BasicButton, EmptyBox, PageHeader } from '@actiontech/shared';
 import SQLStatistics, { ISQLStatisticsProps } from '../SQLStatistics';
 import {
   useTableFilterContainer,
@@ -28,13 +24,13 @@ import {
 import { ResponseCode } from '@actiontech/dms-kit';
 import StatusFilter, { TypeStatus } from './StatusFilter';
 import {
-  GetSqlManageListV3FilterPriorityEnum,
-  GetSqlManageListV3FilterStatusEnum,
-  GetSqlManageListV3SortFieldEnum,
-  GetSqlManageListV3SortOrderEnum,
-  exportSqlManageV2FilterPriorityEnum,
-  exportSqlManageV2FilterStatusEnum,
-  exportSqlManageV2ExportFormatEnum
+  GetSqlManageListV2FilterPriorityEnum,
+  GetSqlManageListV2FilterStatusEnum,
+  GetSqlManageListV2SortFieldEnum,
+  GetSqlManageListV2SortOrderEnum,
+  exportSqlManageV1FilterPriorityEnum,
+  exportSqlManageV1FilterStatusEnum,
+  exportSqlManageRemediationV1ExportScopeEnum
 } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
 import sqlManagementColumn, {
   ExtraFilterMeta,
@@ -48,8 +44,8 @@ import {
 import { ModalName } from '../../../../data/ModalName';
 import { SorterResult, TableRowSelection } from 'antd/es/table/interface';
 import { ISqlManage } from '@actiontech/shared/lib/api/sqle/service/common';
-import { Spin, message } from 'antd';
-import SqlManagementModals from './Modals';
+import { Space, Spin, message } from 'antd';
+import SqlManagementModal from './Modal';
 import EmitterKey from '../../../../data/EmitterKey';
 import EventEmitter from '../../../../utils/EventEmitter';
 import { DB_TYPE_RULE_NAME_SEPARATOR } from './hooks/useRuleTips';
@@ -369,13 +365,10 @@ const SQLEEIndex = () => {
     exportButtonDisabled,
     { setFalse: finishExport, setTrue: startExport }
   ] = useBoolean(false);
-  const {
-    exportFormatModalVisible,
-    showExportFormatModal,
-    hideExportFormatModal,
-    selectedExportFormat,
-    setSelectedExportFormat
-  } = useExportFormatModal(GetAuditPlanSQLExportReqV1ExportFormatEnum.csv);
+  const [
+    remediationExportButtonDisabled,
+    { setFalse: finishRemediationExport, setTrue: startRemediationExport }
+  ] = useBoolean(false);
   const handleExport = () => {
     hideExportFormatModal();
     startExport();
@@ -417,6 +410,36 @@ const SQLEEIndex = () => {
         finishExport();
       });
   };
+
+  const handleRemediationExport = () => {
+    if (!actionPermission || projectArchive) {
+      return;
+    }
+    startRemediationExport();
+    const hideLoading = messageApi.loading(
+      t('sqlManagement.pageHeader.action.remediationExporting')
+    );
+
+    SqlManage.exportSqlManageRemediationV1(
+      {
+        project_name: projectName,
+        export_scope: exportSqlManageRemediationV1ExportScopeEnum.project
+      },
+      { responseType: 'blob' }
+    )
+      .then((res) => {
+        if (res.status === 200) {
+          messageApi.success(
+            t('sqlManagement.pageHeader.action.remediationExportSuccessTips')
+          );
+        }
+      })
+      .finally(() => {
+        hideLoading();
+        finishRemediationExport();
+      });
+  };
+
   useEffect(() => {
     EventEmitter.subscribe(EmitterKey.Refresh_SQL_Management, refresh);
     return () => {
@@ -529,13 +552,24 @@ const SQLEEIndex = () => {
       <PageHeader
         title={t('sqlManagement.pageTitle')}
         extra={
-          <BasicButton
-            onClick={showExportFormatModal}
-            icon={<DownArrowLineOutlined />}
-            disabled={exportButtonDisabled}
-          >
-            {t('sqlManagement.pageHeader.action.export')}
-          </BasicButton>
+          <Space>
+            <EmptyBox if={actionPermission && !projectArchive}>
+              <BasicButton
+                onClick={handleRemediationExport}
+                icon={<DownArrowLineOutlined />}
+                disabled={remediationExportButtonDisabled}
+              >
+                {t('sqlManagement.pageHeader.action.remediationExport')}
+              </BasicButton>
+            </EmptyBox>
+            <BasicButton
+              onClick={handleExport}
+              icon={<DownArrowLineOutlined />}
+              disabled={exportButtonDisabled}
+            >
+              {t('sqlManagement.pageHeader.action.export')}
+            </BasicButton>
+          </Space>
         }
       />
       <ExportFormatModal

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.type.ts
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.type.ts
@@ -6,7 +6,8 @@ export type ScanTypeSqlCollectionProps = {
   instanceType: string;
   exportPending: () => void;
   exportDone: () => void;
-  instanceName: string;
+  remediationExportPending: () => void;
+  remediationExportDone: () => void;
 };
 
 export type ScanTypeSqlTableDataSourceItem = { [key in string]: string };

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/indx.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/indx.tsx
@@ -14,6 +14,7 @@ import {
   ScanTypeSqlCollectionTableStyleWrapper
 } from './style';
 import instance_audit_plan from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 import {
   useCurrentProject,
   useCurrentUser
@@ -38,12 +39,29 @@ import {
   IGetInstanceAuditPlanSQLDataV1Params,
   IGetInstanceAuditPlanSQLExportV1Params
 } from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan/index.d';
-import { GetAuditPlanSQLExportReqV1ExportFormatEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
-import { mergeFilterButtonMeta } from '@actiontech/dms-kit/es/components/ActiontechTable/hooks/useTableFilterContainer';
-import { ResponseCode } from '@actiontech/dms-kit';
-import { message } from 'antd';
-import { ROUTE_PATHS } from '@actiontech/dms-kit';
-import { ResultIconRenderProps } from '../../../../components/AuditResultMessage/index.type';
+import { mergeFilterButtonMeta } from '@actiontech/shared/lib/components/ActiontechTable/hooks/useTableFilterContainer';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { Card, Spin, message } from 'antd';
+import { Link } from 'react-router-dom';
+import { exportSqlManageRemediationV1ExportScopeEnum } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
+import { formatParamsBySeparator } from '@actiontech/shared/lib/utils/Tool';
+import RemediationStatusTag, {
+  remediationStatusOptions
+} from '../../../SqlManagement/component/SQLEEIndex/RemediationStatusTag';
+
+const formatOverviewNumber = (value?: number) => {
+  if (typeof value !== 'number') {
+    return '-';
+  }
+  return formatParamsBySeparator(value);
+};
+
+const formatRemediationRate = (value?: number) => {
+  if (typeof value !== 'number') {
+    return '-';
+  }
+  return `${(value * 100).toFixed(2)}%`;
+};
 
 const BEING_AUDITED = 'being_audited';
 const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
@@ -54,7 +72,8 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
   instanceType,
   exportDone,
   exportPending,
-  instanceName
+  remediationExportPending,
+  remediationExportDone
 }) => {
   const { t } = useTranslation();
   const { sortableTableColumnFactory, tableFilterMetaFactory } =
@@ -196,6 +215,28 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
       }
     }
   );
+
+  const {
+    data: remediationOverview,
+    loading: remediationOverviewLoading,
+    error: remediationOverviewError
+  } = useRequest(
+    () =>
+      SqlManage.getSqlManageRemediationOverviewV1({
+        project_name: projectName,
+        instance_audit_plan_id: Number(instanceAuditPlanId),
+        audit_plan_type: auditPlanType
+      }).then((res) => {
+        if (res.data.code === ResponseCode.SUCCESS) {
+          return res.data.data;
+        }
+      }),
+    {
+      ready:
+        activeTabKey === auditPlanId && !!instanceAuditPlanId && !!auditPlanType
+    }
+  );
+
   const recordAuditResult = useMemo<IAuditResult[]>(() => {
     try {
       return JSON.parse(
@@ -264,6 +305,54 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     projectName,
     t
   ]);
+
+  useEffect(() => {
+    const exportScanTypeRemediation = () => {
+      remediationExportPending();
+      const hideLoading = messageApi.loading(
+        t('managementConf.detail.remediationExportTips'),
+        0
+      );
+
+      SqlManage.exportSqlManageRemediationV1(
+        {
+          project_name: projectName,
+          export_scope: exportSqlManageRemediationV1ExportScopeEnum.scan_task,
+          instance_audit_plan_id: Number(instanceAuditPlanId),
+          audit_plan_type: auditPlanType
+        },
+        { responseType: 'blob' }
+      )
+        .then((res) => {
+          if (res.status === 200) {
+            messageApi.success(
+              t('managementConf.detail.remediationExportSuccessTips')
+            );
+          }
+        })
+        .finally(() => {
+          remediationExportDone();
+          hideLoading();
+        });
+    };
+    const { unsubscribe } = eventEmitter.subscribe(
+      EmitterKey.Export_Sql_Management_Conf_Detail_Remediation,
+      exportScanTypeRemediation
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [
+    auditPlanType,
+    instanceAuditPlanId,
+    messageApi,
+    projectName,
+    remediationExportDone,
+    remediationExportPending,
+    t
+  ]);
+
   const tableSetting = useMemo<ColumnsSettingProps>(() => {
     return {
       tableName: `sql_management_conf_${auditPlanType}`,
@@ -295,6 +384,81 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
   };
   return (
     <ScanTypeSqlCollectionStyleWrapper>
+      <Card
+        className="remediation-overview-card"
+        title={t('managementConf.detail.remediationOverview.title')}
+      >
+        <Spin spinning={remediationOverviewLoading}>
+          {remediationOverviewError ? (
+            <div className="remediation-overview-error">
+              {t('managementConf.detail.remediationOverview.loadFailed', {
+                message: getErrorMessage(remediationOverviewError)
+              })}
+            </div>
+          ) : (
+            <>
+              <div className="remediation-overview-metrics">
+                <div className="remediation-overview-metric">
+                  <strong>
+                    {formatOverviewNumber(remediationOverview?.sql_total_num)}
+                  </strong>
+                  <span>
+                    {t('managementConf.detail.remediationOverview.sqlTotal')}
+                  </span>
+                </div>
+                <div className="remediation-overview-metric">
+                  <strong>
+                    {formatOverviewNumber(remediationOverview?.first_score)}
+                  </strong>
+                  <span>
+                    {t('managementConf.detail.remediationOverview.firstScore')}
+                  </span>
+                </div>
+                <div className="remediation-overview-metric">
+                  <strong>
+                    {formatOverviewNumber(remediationOverview?.latest_score)}
+                  </strong>
+                  <span>
+                    {t('managementConf.detail.remediationOverview.latestScore')}
+                  </span>
+                </div>
+                <div className="remediation-overview-metric">
+                  <strong>
+                    {formatOverviewNumber(remediationOverview?.score_change)}
+                  </strong>
+                  <span>
+                    {t('managementConf.detail.remediationOverview.scoreChange')}
+                  </span>
+                </div>
+                <div className="remediation-overview-metric">
+                  <strong>
+                    {formatRemediationRate(
+                      remediationOverview?.remediation_rate
+                    )}
+                  </strong>
+                  <span>
+                    {t(
+                      'managementConf.detail.remediationOverview.remediationRate'
+                    )}
+                  </span>
+                </div>
+              </div>
+              <div className="remediation-overview-status-list">
+                {remediationStatusOptions.map((status) => (
+                  <div className="remediation-overview-status" key={status}>
+                    <RemediationStatusTag status={status} />
+                    <strong>
+                      {formatOverviewNumber(
+                        remediationOverview?.remediation_status_count?.[status]
+                      )}
+                    </strong>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </Spin>
+      </Card>
       <TableToolbar setting={tableSetting}>
         {tableMetas?.filter_meta_list?.length && (
           <TableFilterContainer

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/style.ts
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/style.ts
@@ -1,7 +1,61 @@
-import { styled } from '@mui/material';
-import { ActiontechTable } from '@actiontech/dms-kit/es/components/ActiontechTable';
+import { styled } from '@mui/material/styles';
 
 export const ScanTypeSqlCollectionStyleWrapper = styled('section')`
+  .remediation-overview-card {
+    margin-bottom: 16px;
+  }
+
+  .remediation-overview-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    margin: -8px;
+  }
+
+  .remediation-overview-metric {
+    min-width: 160px;
+    margin: 8px;
+    padding-right: 24px;
+
+    strong {
+      display: block;
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextBase};
+      font-size: 24px;
+      font-weight: 600;
+      line-height: 32px;
+    }
+
+    span {
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextTertiary};
+      font-size: 13px;
+    }
+  }
+
+  .remediation-overview-status-list {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 8px -8px -8px;
+    padding-top: 12px;
+    border-top: 1px solid
+      ${({ theme }) => theme.sharedTheme.uiToken.colorBorderSecondary};
+  }
+
+  .remediation-overview-status {
+    display: flex;
+    align-items: center;
+    margin: 8px;
+
+    strong {
+      margin-left: 8px;
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextBase};
+      font-size: 16px;
+      font-weight: 600;
+    }
+  }
+
+  .remediation-overview-error {
+    color: ${({ theme }) => theme.sharedTheme.uiToken.colorError};
+  }
+
   .table-describe-column {
     max-width: 600px;
   }

--- a/packages/sqle/src/page/SqlManagementConf/Detail/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/index.tsx
@@ -16,22 +16,30 @@ import { TableRefreshButton } from '@actiontech/dms-kit/es/components/Actiontech
 import { useCallback, useState } from 'react';
 import ScanTypeSqlCollection from './ScanTypeSqlCollection/indx';
 import { useBoolean, useRequest } from 'ahooks';
-import { useLocation } from 'react-router-dom';
-import { SqleApi } from '@actiontech/shared/lib/api';
-import { useCurrentProject } from '@actiontech/shared/lib/features';
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams
+} from 'react-router-dom';
+import instance_audit_plan from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
+import {
+  useCurrentProject,
+  useCurrentUser,
+  useUserOperationPermission
+} from '@actiontech/shared/lib/global';
 import { Result, Space } from 'antd';
 import { getErrorMessage } from '@actiontech/dms-kit';
 import { SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY } from './index.data';
 import eventEmitter from '../../../utils/EventEmitter';
 import EmitterKey from '../../../data/EmitterKey';
 import { message } from 'antd';
-import { ResponseCode } from '@actiontech/dms-kit';
-import { SqlManagementConfDetailPageHeaderActions } from './action';
-import { ROUTE_PATHS } from '@actiontech/dms-kit';
-import useScanTypeVerify from '../Common/ConfForm/useScanTypeVerify';
-import { GetAuditPlanSQLExportReqV1ExportFormatEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
-import { useExportFormatModal } from '../../../hooks/useExportFormatModal';
-import ExportFormatModal from '../../../components/ExportFormatModal';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { OpPermissionItemOpPermissionTypeEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+import { DownArrowLineOutlined } from '@actiontech/icons';
+import { exportSqlManageRemediationV1ExportScopeEnum } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
+
 const ConfDetail: React.FC = () => {
   const { t } = useTranslation();
   const { projectID } = useCurrentProject();
@@ -42,13 +50,20 @@ const ConfDetail: React.FC = () => {
     ROUTE_PATHS.SQLE.SQL_MANAGEMENT_CONF.detail
   );
   const location = useLocation();
-  const navigate = useTypedNavigate();
-  const { projectName } = useCurrentProject();
+  const navigate = useNavigate();
+  const { projectName, projectArchive } = useCurrentProject();
+  const { isAdmin, isProjectManager } = useCurrentUser();
+
   const [activeKey, setActiveKey] = useState(
     SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY
   );
   const [exporting, { setTrue: exportPending, setFalse: exportDone }] =
     useBoolean();
+  const [
+    remediationExporting,
+    { setTrue: remediationExportPending, setFalse: remediationExportDone }
+  ] = useBoolean();
+
   const [auditing, { setTrue: auditPending, setFalse: auditDone }] =
     useBoolean();
   const [messageApi, contextMessageHolder] = message.useMessage();
@@ -108,6 +123,22 @@ const ConfDetail: React.FC = () => {
       searchParams?.active_audit_plan_id
     ]
   );
+
+  const hasOpPermission = useMemo(() => {
+    return isHaveServicePermission(
+      OpPermissionItemOpPermissionTypeEnum.save_audit_plan,
+      data?.instance_id
+    );
+  }, [data?.instance_id, isHaveServicePermission]);
+
+  const actionPermission = useMemo(() => {
+    return isAdmin || isProjectManager(projectName);
+  }, [isAdmin, isProjectManager, projectName]);
+
+  const remediationExportPermission = useMemo(() => {
+    return (actionPermission || hasOpPermission) && !projectArchive;
+  }, [actionPermission, hasOpPermission, projectArchive]);
+
   const items: SegmentedTabsProps['items'] = [
     {
       label: t('managementConf.detail.overview.title'),
@@ -134,6 +165,8 @@ const ConfDetail: React.FC = () => {
           instanceName={data.instance_name ?? ''}
           exportPending={exportPending}
           exportDone={exportDone}
+          remediationExportPending={remediationExportPending}
+          remediationExportDone={remediationExportDone}
         />
       )
     })) ?? [])
@@ -152,6 +185,42 @@ const ConfDetail: React.FC = () => {
       selectedExportFormat
     );
   };
+
+  const exportScanTypeRemediation = () => {
+    eventEmitter.emit(EmitterKey.Export_Sql_Management_Conf_Detail_Remediation);
+  };
+
+  const exportDataSourceRemediation = () => {
+    if (!remediationExportPermission || !data?.instance_id) {
+      return;
+    }
+    remediationExportPending();
+    const hideLoading = messageApi.loading(
+      t('managementConf.detail.remediationExportTips'),
+      0
+    );
+
+    SqlManage.exportSqlManageRemediationV1(
+      {
+        project_name: projectName,
+        export_scope: exportSqlManageRemediationV1ExportScopeEnum.data_source,
+        filter_instance_id: data.instance_id
+      },
+      { responseType: 'blob' }
+    )
+      .then((res) => {
+        if (res.status === 200) {
+          messageApi.success(
+            t('managementConf.detail.remediationExportSuccessTips')
+          );
+        }
+      })
+      .finally(() => {
+        hideLoading();
+        remediationExportDone();
+      });
+  };
+
   const onAuditImmediately = () => {
     auditPending();
     SqleApi.InstanceAuditPlanService.auditPlanTriggerSqlAuditV1({
@@ -205,9 +274,45 @@ const ConfDetail: React.FC = () => {
             <Space>
               <EmptyBox if={activeKey !== SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY}>
                 <Space>
-                  {pageHeaderActions.export}
-                  {pageHeaderActions.immediately_audit}
+                  <BasicButton
+                    disabled={exporting}
+                    onClick={exportScanTypeSqlDetail}
+                  >
+                    {t('managementConf.detail.export')}
+                  </BasicButton>
+                  <EmptyBox if={remediationExportPermission}>
+                    <BasicButton
+                      disabled={remediationExporting}
+                      onClick={exportScanTypeRemediation}
+                      icon={<DownArrowLineOutlined />}
+                    >
+                      {t('managementConf.detail.remediationExport')}
+                    </BasicButton>
+                  </EmptyBox>
+                  {hasOpPermission && (
+                    <BasicButton
+                      loading={auditing}
+                      onClick={onAuditImmediately}
+                      type="primary"
+                    >
+                      {t('managementConf.detail.auditImmediately')}
+                    </BasicButton>
+                  )}
                 </Space>
+              </EmptyBox>
+              <EmptyBox
+                if={
+                  activeKey === SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY &&
+                  remediationExportPermission
+                }
+              >
+                <BasicButton
+                  disabled={remediationExporting}
+                  onClick={exportDataSourceRemediation}
+                  icon={<DownArrowLineOutlined />}
+                >
+                  {t('managementConf.detail.remediationExport')}
+                </BasicButton>
               </EmptyBox>
               <TableRefreshButton refresh={onRefresh} />
             </Space>

--- a/packages/sqle/src/page/SqlManagementRemediationReport/index.tsx
+++ b/packages/sqle/src/page/SqlManagementRemediationReport/index.tsx
@@ -1,0 +1,70 @@
+import { BasicButton, PageHeader } from '@actiontech/shared';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
+import { DownArrowLineOutlined } from '@actiontech/icons';
+import { Card, Space, Typography, message } from 'antd';
+import { useBoolean } from 'ahooks';
+import { useTranslation } from 'react-i18next';
+
+const SqlManagementRemediationReport = () => {
+  const { t } = useTranslation();
+  const [messageApi, messageContextHolder] = message.useMessage();
+  const [exporting, { setTrue: startExport, setFalse: finishExport }] =
+    useBoolean(false);
+
+  const handleExport = () => {
+    startExport();
+    const hideLoading = messageApi.loading(
+      t('sqlManagement.remediationReport.exporting')
+    );
+
+    SqlManage.exportGlobalSqlManageRemediationV1({}, { responseType: 'blob' })
+      .then((res) => {
+        if (res.status === 200) {
+          messageApi.success(
+            t('sqlManagement.remediationReport.exportSuccessTips')
+          );
+        }
+      })
+      .finally(() => {
+        hideLoading();
+        finishExport();
+      });
+  };
+
+  return (
+    <article>
+      {messageContextHolder}
+      <PageHeader
+        title={t('sqlManagement.remediationReport.pageTitle')}
+        extra={
+          <BasicButton
+            type="primary"
+            icon={<DownArrowLineOutlined />}
+            onClick={handleExport}
+            disabled={exporting}
+          >
+            {t('sqlManagement.remediationReport.exportButton')}
+          </BasicButton>
+        }
+      />
+      <Card>
+        <Space direction="vertical" size={12}>
+          <Typography.Title level={5}>
+            {t('sqlManagement.remediationReport.scopeTitle')}
+          </Typography.Title>
+          <Typography.Paragraph>
+            {t('sqlManagement.remediationReport.description')}
+          </Typography.Paragraph>
+          <Typography.Paragraph>
+            {t('sqlManagement.remediationReport.scopeContent')}
+          </Typography.Paragraph>
+          <Typography.Text type="secondary">
+            {t('sqlManagement.remediationReport.permissionTips')}
+          </Typography.Text>
+        </Space>
+      </Card>
+    </article>
+  );
+};
+
+export default SqlManagementRemediationReport;

--- a/packages/sqle/src/router/config.tsx
+++ b/packages/sqle/src/router/config.tsx
@@ -196,6 +196,10 @@ const UpdateCustomRule = React.lazy(
 );
 const ReportStatistics = React.lazy(() => import('../page/ReportStatistics'));
 
+const SqlManagementRemediationReport = React.lazy(
+  () => import('../page/SqlManagementRemediationReport')
+);
+
 const PushRuleConfiguration = React.lazy(
   () => import('../page/PushRuleConfiguration')
 );
@@ -499,7 +503,14 @@ export const projectDetailRouterConfig: RouterConfigItem[] = [
 
 export const globalRouterConfig: RouterConfigItem[] = [
   {
-    path: ROUTE_PATHS.SQLE.REPORT_STATISTICS.index.path,
+    path: 'sqle/sql-management-remediation-report',
+    element: <SqlManagementRemediationReport />,
+    key: 'sqlManagementRemediationReport',
+    role: [SystemRole.admin]
+  },
+  {
+    path: 'sqle/report-statistics',
+    label: 'menu.reportStatistics',
     element: <ReportStatistics />,
     key: 'reportStatistics',
     permission: PERMISSIONS.PAGES.SQLE.REPORT_STATISTICS


### PR DESCRIPTION
## 概述
完成 SQL 管控整改追踪双交付提交闭环，关联客户基线与标准产品交付结果。

Fixes #2988

## 门禁
- 等价门禁记录见工作区 docs/submit/merge_check.json
- 客户基线默认使用本机 mysql-for-sqle，不引入不可达远程 TDSQL 依赖
