### PR TITLE
标准产品 UI：SQL 管控整改追踪提交闭环

### DIFF
--- a/packages/base/src/locale/en-US/dmsMenu.ts
+++ b/packages/base/src/locale/en-US/dmsMenu.ts
@@ -63,6 +63,7 @@ export default {
     title: 'Global settings',
     userCenter: 'User center',
     reportStatistics: 'Report statistics',
+    sqlManagementRemediationReport: 'SQL management remediation report',
     viewRule: 'View rule',
     ruleManage: 'Rule management',
     system: 'System settings',

--- a/packages/base/src/locale/zh-CN/dmsMenu.ts
+++ b/packages/base/src/locale/zh-CN/dmsMenu.ts
@@ -65,6 +65,7 @@ export default {
     title: '全局设置',
     userCenter: '用户中心',
     reportStatistics: '报表统计',
+    sqlManagementRemediationReport: 'SQL 管控整改报表',
     viewRule: '查看规则',
     ruleManage: '规则管理',
     system: '系统设置',

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
@@ -44,7 +44,9 @@ import {
   ISqlManageCodingReq,
   IPostSqlManageCodingResp,
   IGetSqlManageSqlAnalysisResp,
-  ISqlManageAnalysisChartResp
+  ISqlManageAnalysisChartResp,
+  IGetSqlManageRemediationResp,
+  IGetSqlManageRemediationOverviewResp
 } from '../common.d';
 
 export interface IGetGlobalSqlManageListParams {
@@ -162,6 +164,8 @@ export interface IExportSqlManageV1Params {
   sort_order?: exportSqlManageV1SortOrderEnum;
 }
 
+export interface IExportGlobalSqlManageRemediationV1Params {}
+
 export interface IGetSqlManageRuleTipsParams {
   project_name: string;
 }
@@ -246,6 +250,26 @@ export interface IGetSqlManageListV2Params {
 }
 
 export interface IGetSqlManageListV2Return extends IGetSqlManageListResp {}
+
+export interface IGetSqlManageRemediationV1Params {
+  project_name: string;
+
+  sql_manage_id: string;
+}
+
+export interface IGetSqlManageRemediationV1Return
+  extends IGetSqlManageRemediationResp {}
+
+export interface IGetSqlManageRemediationOverviewV1Params {
+  project_name: string;
+
+  instance_audit_plan_id?: number;
+
+  audit_plan_type?: string;
+}
+
+export interface IGetSqlManageRemediationOverviewV1Return
+  extends IGetSqlManageRemediationOverviewResp {}
 
 export interface IExportSqlManageV2Params {
   project_name: string;

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.enum.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.enum.ts
@@ -102,6 +102,14 @@ export enum exportSqlManageV1SortOrderEnum {
   'desc' = 'desc'
 }
 
+export enum exportSqlManageRemediationV1ExportScopeEnum {
+  'project' = 'project',
+
+  'data_source' = 'data_source',
+
+  'scan_task' = 'scan_task'
+}
+
 export enum GetSqlManageListV2FilterSourceEnum {
   'audit_plan' = 'audit_plan',
 
@@ -134,6 +142,18 @@ export enum GetSqlManageListV2FilterPriorityEnum {
   'high' = 'high',
 
   'low' = 'low'
+}
+
+export enum GetSqlManageListV2FilterRemediationStatusEnum {
+  'resolved' = 'resolved',
+
+  'partially_fixed' = 'partially_fixed',
+
+  'unchanged' = 'unchanged',
+
+  'deteriorated' = 'deteriorated',
+
+  'newly_discovered' = 'newly_discovered'
 }
 
 export enum GetSqlManageListV2SortFieldEnum {

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.ts
@@ -18,6 +18,7 @@ import {
   IBatchUpdateSqlManageParams,
   IBatchUpdateSqlManageReturn,
   IExportSqlManageV1Params,
+  IExportGlobalSqlManageRemediationV1Params,
   IGetSqlManageRuleTipsParams,
   IGetSqlManageRuleTipsReturn,
   ISendSqlManageParams,
@@ -28,6 +29,10 @@ import {
   IGetSqlManageSqlAnalysisChartV1Return,
   IGetSqlManageListV2Params,
   IGetSqlManageListV2Return,
+  IGetSqlManageRemediationV1Params,
+  IGetSqlManageRemediationV1Return,
+  IGetSqlManageRemediationOverviewV1Params,
+  IGetSqlManageRemediationOverviewV1Return,
   IExportSqlManageV2Params,
   IGetSqlManageListV3Params,
   IGetSqlManageListV3Return
@@ -118,6 +123,19 @@ class SqlManageService extends ServiceBase {
     );
   }
 
+  public exportGlobalSqlManageRemediationV1(
+    params: IExportGlobalSqlManageRemediationV1Params = {},
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+
+    return this.get<any>(
+      `/v1/sql_manages/remediation_exports`,
+      paramsData,
+      options
+    );
+  }
+
   public GetSqlManageRuleTips(
     params: IGetSqlManageRuleTipsParams,
     options?: AxiosRequestConfig
@@ -194,6 +212,39 @@ class SqlManageService extends ServiceBase {
 
     return this.get<IGetSqlManageListV2Return>(
       `/v2/projects/${project_name}/sql_manages`,
+      paramsData,
+      options
+    );
+  }
+
+  public GetSqlManageRemediationV1(
+    params: IGetSqlManageRemediationV1Params,
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+    const project_name = paramsData.project_name;
+    delete paramsData.project_name;
+
+    const sql_manage_id = paramsData.sql_manage_id;
+    delete paramsData.sql_manage_id;
+
+    return this.get<IGetSqlManageRemediationV1Return>(
+      `/v1/projects/${project_name}/sql_manages/${sql_manage_id}/remediation`,
+      paramsData,
+      options
+    );
+  }
+
+  public getSqlManageRemediationOverviewV1(
+    params: IGetSqlManageRemediationOverviewV1Params,
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+    const project_name = paramsData.project_name;
+    delete paramsData.project_name;
+
+    return this.get<IGetSqlManageRemediationOverviewV1Return>(
+      `/v1/projects/${project_name}/sql_manages/remediation_overview`,
       paramsData,
       options
     );

--- a/packages/shared/lib/api/sqle/service/common.d.ts
+++ b/packages/shared/lib/api/sqle/service/common.d.ts
@@ -5103,3 +5103,77 @@ export interface ICompleteWorkflowReq {
 
   workflow_id?: string;
 }
+
+export interface IRuleDiff {
+  new?: IAuditResult[];
+
+  resolved?: IAuditResult[];
+
+  unchanged?: IAuditResult[];
+}
+
+export interface ISqlManageRemediation {
+  first_audit_missing?: boolean;
+
+  first_audit_result?: IAuditResult[];
+
+  first_audit_time?: string;
+
+  id?: number;
+
+  latest_audit_result?: IAuditResult[];
+
+  latest_audit_time?: string;
+
+  remediation_status?: string;
+
+  rule_diff?: IRuleDiff;
+
+  sql?: string;
+
+  sql_fingerprint?: string;
+}
+
+export interface IGetSqlManageRemediationResp {
+  code?: number;
+
+  data?: ISqlManageRemediation;
+
+  message?: string;
+}
+
+export interface ISqlManageRemediationOverviewStatusCount {
+  deteriorated?: number;
+
+  newly_discovered?: number;
+
+  partially_fixed?: number;
+
+  resolved?: number;
+
+  unchanged?: number;
+}
+
+export interface ISqlManageRemediationOverview {
+  first_audit_missing_num?: number;
+
+  first_score?: number;
+
+  latest_score?: number;
+
+  remediation_rate?: number;
+
+  score_change?: number;
+
+  sql_total_num?: number;
+
+  remediation_status_count?: ISqlManageRemediationOverviewStatusCount;
+}
+
+export interface IGetSqlManageRemediationOverviewResp {
+  code?: number;
+
+  data?: ISqlManageRemediationOverview;
+
+  message?: string;
+}

--- a/packages/sqle/src/data/EmitterKey.ts
+++ b/packages/sqle/src/data/EmitterKey.ts
@@ -27,6 +27,7 @@ enum EmitterKey {
   Refresh_Sql_Management_Conf_Overview_List = 'Refresh_Sql_Management_Conf_Overview_List',
   Refresh_Sql_Management_Conf_Detail_Sql_List = 'Refresh_Sql_Management_Conf_Detail_Sql_List',
   Export_Sql_Management_Conf_Detail_Sql_List = 'Export_Sql_Management_Conf_Detail_Sql_List',
+  Export_Sql_Management_Conf_Detail_Remediation = 'Export_Sql_Management_Conf_Detail_Remediation',
 
   Refresh_Sql_management_Exception_List = 'Refresh_Sql_management_Exception_List',
 

--- a/packages/sqle/src/locale/en-US/managementConf.ts
+++ b/packages/sqle/src/locale/en-US/managementConf.ts
@@ -111,6 +111,19 @@ export default {
     auditImmediately: 'Audit immediately',
     auditImmediatelySuccessTips: 'Audit successfully',
     exportTips: 'Exporting scan task details',
+    remediationExport: 'SQL remediation',
+    remediationExportTips: 'Exporting SQL management remediation report',
+    remediationExportSuccessTips:
+      'Export SQL management remediation report successfully',
+    remediationOverview: {
+      title: 'Remediation overview',
+      sqlTotal: 'SQL total',
+      firstScore: 'First score',
+      latestScore: 'Latest score',
+      scoreChange: 'Score change',
+      remediationRate: 'Remediation rate',
+      loadFailed: 'Failed to load remediation overview: {{message}}'
+    },
     overview: {
       title: 'Overview',
       column: {

--- a/packages/sqle/src/locale/en-US/sqlManagement.ts
+++ b/packages/sqle/src/locale/en-US/sqlManagement.ts
@@ -11,6 +11,19 @@ export default {
       }
     }
   },
+  remediationReport: {
+    pageTitle: 'SQL management remediation report',
+    description:
+      'Export SQL management remediation tracking data in global scope. The Excel file contains Overview, Rule summary and Details.',
+    exportButton: 'Export SQL management remediation report',
+    exporting: 'Exporting SQL management remediation report',
+    exportSuccessTips: 'Export SQL management remediation report successfully',
+    scopeTitle: 'Export scope',
+    scopeContent:
+      'Global scope: includes SQL management remediation data across all projects available to platform administrators.',
+    permissionTips:
+      'Only platform administrators / global operators can see and export this report.'
+  },
   statistics: {
     SQLTotalNum: 'SQL total',
     problemSQlNum: 'Problem SQL',
@@ -67,8 +80,16 @@ export default {
       occurrenceCount: 'Occurrence count',
       personInCharge: 'Person in charge',
       status: 'Status',
+      remediationStatus: 'Remediation status',
       comment: 'Comment',
       endpoints: 'Endpoint info'
+    },
+    remediationStatus: {
+      resolved: 'Resolved',
+      partially_fixed: 'Partially fixed',
+      unchanged: 'Unchanged',
+      deteriorated: 'Deteriorated',
+      newly_discovered: 'Newly discovered'
     },
     filter: {
       time: 'Time range',

--- a/packages/sqle/src/locale/zh-CN/managementConf.ts
+++ b/packages/sqle/src/locale/zh-CN/managementConf.ts
@@ -116,6 +116,18 @@ export default {
     auditImmediately: '立即审核',
     auditImmediatelySuccessTips: '审核成功',
     exportTips: '正在导出扫描任务详情',
+    remediationExport: 'SQL 管控整改',
+    remediationExportTips: '正在导出 SQL 管控整改报表',
+    remediationExportSuccessTips: 'SQL 管控整改报表导出成功',
+    remediationOverview: {
+      title: '整改概览',
+      sqlTotal: 'SQL 总数',
+      firstScore: '首次评分',
+      latestScore: '最末次评分',
+      scoreChange: '评分变化',
+      remediationRate: '整改率',
+      loadFailed: '整改概览加载失败：{{message}}'
+    },
     overview: {
       title: '概览',
       column: {

--- a/packages/sqle/src/locale/zh-CN/sqlManagement.ts
+++ b/packages/sqle/src/locale/zh-CN/sqlManagement.ts
@@ -11,6 +11,18 @@ export default {
       }
     }
   },
+  remediationReport: {
+    pageTitle: 'SQL 管控整改报表',
+    description:
+      '导出全局范围内 SQL 管控整改追踪数据，Excel 包含概览、规则维度汇总和明细。',
+    exportButton: '导出 SQL 管控整改报表',
+    exporting: '正在导出 SQL 管控整改报表',
+    exportSuccessTips: 'SQL 管控整改报表导出成功',
+    scopeTitle: '导出范围',
+    scopeContent:
+      '全局范围：覆盖当前用户有平台管理权限的全部项目 SQL 管控整改数据',
+    permissionTips: '仅平台超管 / 全局运维可见并可导出。'
+  },
   statistics: {
     SQLTotalNum: 'SQL总数',
     problemSQlNum: '问题SQL数',
@@ -92,8 +104,16 @@ export default {
       occurrenceCount: '出现数量',
       personInCharge: '负责人',
       status: '状态',
+      remediationStatus: '整改状态',
       comment: '备注',
       endpoints: '端点信息'
+    },
+    remediationStatus: {
+      resolved: '已整改',
+      partially_fixed: '部分整改',
+      unchanged: '未变化',
+      deteriorated: '恶化',
+      newly_discovered: '新发现'
     },
     filter: {
       time: '时间范围',
@@ -127,5 +147,18 @@ export default {
     statusReport: {
       title: 'SQL审核结果'
     }
+  },
+  remediationCompare: {
+    tab: '整改对比',
+    title: '整改对比',
+    description: '对比首次审核与最末次审核结果，展示规则整改变化',
+    firstAuditMissing: '无首次审核快照，当前按最末次结果展示新发现问题。',
+    firstAuditResult: '首次审核结果',
+    latestAuditResult: '最末次审核结果',
+    ruleDiffTitle: '规则差异',
+    resolved: '已解决规则',
+    new: '新增规则',
+    unchanged: '维持规则',
+    emptyRules: '无命中规则'
   }
 };

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/SqlAnalyze.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/SqlAnalyze.tsx
@@ -12,6 +12,7 @@ import { SqlAnalyzeContStyleWrapper, SqlContStyleWrapper } from './style';
 import useTableSchema from './useTableSchema';
 import useSQLExecPlan from './useSQLExecPlan';
 import { SqlAnalyzeProps } from '.';
+import RemediationCompare from '../SqlManage/RemediationCompare';
 const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
   const { t } = useTranslation();
   const {
@@ -20,6 +21,7 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
     errorMessage,
     loading = false,
     performanceStatistics,
+    remediationCompare,
     errorType = 'error',
     sqlExecPlanCostDataSource,
     getSqlExecPlanCostDataSource,
@@ -69,25 +71,27 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
     return <BasicResult status={errorType} title={errorMessage} />;
   };
   const getSegmentedOption = useMemo(() => {
+    const options = [
+      {
+        label: t('sqlAnalyze.sqlExplain'),
+        value: 'sql'
+      }
+    ];
+    if (remediationCompare) {
+      options.push({
+        label: t('sqlAnalyze.remediationCompare'),
+        value: 'remediation'
+      });
+    }
     if (
       !(
         Array.isArray(tableMetas?.table_meta_items) &&
         tableMetas?.table_meta_items.length
       )
     ) {
-      return [
-        {
-          label: t('sqlAnalyze.sqlExplain'),
-          value: 'sql'
-        }
-      ];
+      return options;
     }
-    return [
-      {
-        label: t('sqlAnalyze.sqlExplain'),
-        value: 'sql'
-      }
-    ].concat(
+    return options.concat(
       (tableMetas?.table_meta_items ?? []).map((table) => {
         return {
           label: t('sqlAnalyze.tableTitle', {
@@ -97,7 +101,7 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
         };
       })
     );
-  }, [tableMetas?.table_meta_items, t]);
+  }, [remediationCompare, tableMetas?.table_meta_items, t]);
   return (
     <PageLayoutHasFixedHeaderStyleWrapper>
       <PageHeader fixed title={t('sqlAnalyze.pageTitle')} />

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/index.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/index.tsx
@@ -2,6 +2,7 @@ import { ResultStatusType } from 'antd/es/result';
 import SqlAnalyze from './SqlAnalyze';
 import {
   IPerformanceStatistics,
+  ISqlManageRemediation,
   ISQLExplain,
   ITableMeta,
   ITableMetas,
@@ -17,6 +18,7 @@ export type SqlAnalyzeProps = {
   tableMetas?: ITableMetas;
   sqlExplain?: ISQLExplain;
   performanceStatistics?: IPerformanceStatistics;
+  remediationCompare?: ISqlManageRemediation;
   loading?: boolean;
   sqlExecPlanCostDataSource?: IChartPoint[];
   getSqlExecPlanCostDataSourceLoading?: boolean;

--- a/packages/sqle/src/page/SqlAnalyze/SqlManage/RemediationCompare.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlManage/RemediationCompare.tsx
@@ -1,0 +1,113 @@
+import { Empty, Alert, Card, Space, Typography } from 'antd';
+import { useTranslation } from 'react-i18next';
+import AuditResultMessage from '../../../components/AuditResultMessage';
+import { ISqlManageRemediation } from '@actiontech/shared/lib/api/sqle/service/common';
+import RemediationStatusTag from '../../SqlManagement/component/SQLEEIndex/RemediationStatusTag';
+
+type RemediationCompareProps = {
+  data?: ISqlManageRemediation;
+};
+
+const filterRuleNames = (names?: Array<string | undefined>) =>
+  names?.filter((name): name is string => !!name);
+
+const ruleNames = (rules?: ISqlManageRemediation['rule_diff']) => ({
+  resolved: filterRuleNames(rules?.resolved?.map((rule) => rule.rule_name)),
+  newRules: filterRuleNames(rules?.new?.map((rule) => rule.rule_name)),
+  unchanged: filterRuleNames(rules?.unchanged?.map((rule) => rule.rule_name))
+});
+
+const RuleList: React.FC<{ title: string; rules?: string[] }> = ({
+  title,
+  rules
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Space direction="vertical" size={4}>
+      <Typography.Text strong>{title}</Typography.Text>
+      {rules?.length ? (
+        rules.map((rule) => (
+          <Typography.Text key={rule}>{rule}</Typography.Text>
+        ))
+      ) : (
+        <Typography.Text type="secondary">
+          {t('sqlManagement.remediationCompare.emptyRules')}
+        </Typography.Text>
+      )}
+    </Space>
+  );
+};
+
+const AuditResultList: React.FC<{
+  results?: NonNullable<ISqlManageRemediation['first_audit_result']>;
+}> = ({ results }) => {
+  if (!results?.length) {
+    return <AuditResultMessage />;
+  }
+
+  return (
+    <Space direction="vertical" size={8} className="full-width-element">
+      {results.map((result, index) => (
+        <AuditResultMessage
+          key={`${result.rule_name ?? 'rule'}-${index}`}
+          auditResult={result}
+        />
+      ))}
+    </Space>
+  );
+};
+
+const RemediationCompare: React.FC<RemediationCompareProps> = ({ data }) => {
+  const { t } = useTranslation();
+
+  if (!data) {
+    return <Empty />;
+  }
+
+  const rules = ruleNames(data.rule_diff);
+
+  return (
+    <Space direction="vertical" size={16} className="full-width-element">
+      <Card title={t('sqlManagement.remediationCompare.title')}>
+        <Space direction="vertical" size={12} className="full-width-element">
+          <Typography.Paragraph type="secondary">
+            {t('sqlManagement.remediationCompare.description')}
+          </Typography.Paragraph>
+          {data.first_audit_missing && (
+            <Alert
+              type="warning"
+              showIcon
+              message={t('sqlManagement.remediationCompare.firstAuditMissing')}
+            />
+          )}
+          <RemediationStatusTag status={data.remediation_status} />
+        </Space>
+      </Card>
+      <Card title={t('sqlManagement.remediationCompare.ruleDiffTitle')}>
+        <Space size={48} align="start">
+          <RuleList
+            title={t('sqlManagement.remediationCompare.resolved')}
+            rules={rules.resolved}
+          />
+          <RuleList
+            title={t('sqlManagement.remediationCompare.new')}
+            rules={rules.newRules}
+          />
+          <RuleList
+            title={t('sqlManagement.remediationCompare.unchanged')}
+            rules={rules.unchanged}
+          />
+        </Space>
+      </Card>
+      <Card title={t('sqlManagement.remediationCompare.firstAuditResult')}>
+        <AuditResultList results={data.first_audit_result} />
+      </Card>
+      <Card title={t('sqlManagement.remediationCompare.latestAuditResult')}>
+        <AuditResultList results={data.latest_audit_result} />
+      </Card>
+    </Space>
+  );
+};
+
+export default RemediationCompare;

--- a/packages/sqle/src/page/SqlAnalyze/SqlManage/index.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlManage/index.tsx
@@ -5,6 +5,7 @@ import { ResponseCode } from '../../../data/common';
 import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 import {
   IPerformanceStatistics,
+  ISqlManageRemediation,
   ISQLExplain,
   ITableMetas
 } from '@actiontech/shared/lib/api/sqle/service/common';
@@ -30,6 +31,8 @@ const SQLManageAnalyze = () => {
   const [tableMetas, setTableMetas] = useState<ITableMetas>();
   const [performanceStatistics, setPerformancesStatistics] =
     useState<IPerformanceStatistics>();
+  const [remediationCompare, setRemediationCompare] =
+    useState<ISqlManageRemediation>();
 
   const [
     loading,
@@ -53,11 +56,17 @@ const SQLManageAnalyze = () => {
     async (affectRowsEnabled = false) => {
       startGetSqlAnalyze();
       try {
-        const res = await SqlManage.GetSqlManageSqlAnalysisV1({
+        const [res, remediationRes] = await Promise.all([
+          SqlManage.GetSqlManageSqlAnalysisV1({
           sql_manage_id: urlParams.sqlManageId ?? '',
           project_name: projectName,
           affectRowsEnabled
-        });
+          }),
+          SqlManage.GetSqlManageRemediationV1({
+            sql_manage_id: urlParams.sqlManageId ?? '',
+            project_name: projectName
+          })
+        ]);
         if (res.data.code === ResponseCode.SUCCESS) {
           if (affectRowsEnabled) {
             setPerformanceInfoLoaded();
@@ -70,6 +79,9 @@ const SQLManageAnalyze = () => {
           setSqlExplain(data?.sql_explain);
           setTableMetas(data?.table_metas);
           setPerformancesStatistics(data?.performance_statistics);
+          if (remediationRes.data.code === ResponseCode.SUCCESS) {
+            setRemediationCompare(remediationRes.data.data);
+          }
           setOptimizationCreationParams({
             instance_name: queryParams?.instance_name,
             schema_name: queryParams?.schema,
@@ -132,6 +144,7 @@ const SQLManageAnalyze = () => {
         sqlExplain={sqlExplain}
         errorMessage={errorMessage}
         performanceStatistics={performanceStatistics}
+        remediationCompare={remediationCompare}
         loading={loading}
         sqlExecPlanCostDataSource={data}
         getSqlExecPlanCostDataSourceLoading={

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/RemediationStatusTag.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/RemediationStatusTag.tsx
@@ -1,0 +1,36 @@
+import { BasicTag } from '@actiontech/dms-kit';
+import { t } from '../../../../locale';
+
+export const remediationStatusOptions = [
+  'resolved',
+  'partially_fixed',
+  'unchanged',
+  'deteriorated',
+  'newly_discovered'
+];
+
+type RemediationStatusTagProps = {
+  status?: string;
+};
+
+const remediationStatusColor: Record<string, string> = {
+  resolved: 'green',
+  partially_fixed: 'blue',
+  unchanged: 'gray',
+  deteriorated: 'red',
+  newly_discovered: 'orange'
+};
+
+const RemediationStatusTag: React.FC<RemediationStatusTagProps> = ({
+  status
+}) => {
+  const currentStatus = status || 'unchanged';
+
+  return (
+    <BasicTag color={(remediationStatusColor[currentStatus] ?? 'gray') as any}>
+      {t(`sqlManagement.table.remediationStatus.${currentStatus}` as any)}
+    </BasicTag>
+  );
+};
+
+export default RemediationStatusTag;

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/style.ts
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/style.ts
@@ -2,6 +2,61 @@ import { styled } from '@mui/material';
 import { ActiontechTable } from '@actiontech/dms-kit/es/components/ActiontechTable';
 
 export const ScanTypeSqlCollectionStyleWrapper = styled('section')`
+  .remediation-overview-card {
+    margin-bottom: 16px;
+  }
+
+  .remediation-overview-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    margin: -8px;
+  }
+
+  .remediation-overview-metric {
+    min-width: 160px;
+    margin: 8px;
+    padding-right: 24px;
+
+    strong {
+      display: block;
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextBase};
+      font-size: 24px;
+      font-weight: 600;
+      line-height: 32px;
+    }
+
+    span {
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextTertiary};
+      font-size: 13px;
+    }
+  }
+
+  .remediation-overview-status-list {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 8px -8px -8px;
+    padding-top: 12px;
+    border-top: 1px solid
+      ${({ theme }) => theme.sharedTheme.uiToken.colorBorderSecondary};
+  }
+
+  .remediation-overview-status {
+    display: flex;
+    align-items: center;
+    margin: 8px;
+
+    strong {
+      margin-left: 8px;
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextBase};
+      font-size: 16px;
+      font-weight: 600;
+    }
+  }
+
+  .remediation-overview-error {
+    color: ${({ theme }) => theme.sharedTheme.uiToken.colorError};
+  }
+
   .table-describe-column {
     max-width: 600px;
   }

--- a/packages/sqle/src/page/SqlManagementRemediationReport/index.tsx
+++ b/packages/sqle/src/page/SqlManagementRemediationReport/index.tsx
@@ -1,0 +1,70 @@
+import { BasicButton, PageHeader } from '@actiontech/dms-kit';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
+import { DownArrowLineOutlined } from '@actiontech/icons';
+import { Card, Space, Typography, message } from 'antd';
+import { useBoolean } from 'ahooks';
+import { useTranslation } from 'react-i18next';
+
+const SqlManagementRemediationReport = () => {
+  const { t } = useTranslation();
+  const [messageApi, messageContextHolder] = message.useMessage();
+  const [exporting, { setTrue: startExport, setFalse: finishExport }] =
+    useBoolean(false);
+
+  const handleExport = () => {
+    startExport();
+    const hideLoading = messageApi.loading(
+      t('sqlManagement.remediationReport.exporting')
+    );
+
+    SqlManage.exportGlobalSqlManageRemediationV1({}, { responseType: 'blob' })
+      .then((res) => {
+        if (res.status === 200) {
+          messageApi.success(
+            t('sqlManagement.remediationReport.exportSuccessTips')
+          );
+        }
+      })
+      .finally(() => {
+        hideLoading();
+        finishExport();
+      });
+  };
+
+  return (
+    <article>
+      {messageContextHolder}
+      <PageHeader
+        title={t('sqlManagement.remediationReport.pageTitle')}
+        extra={
+          <BasicButton
+            type="primary"
+            icon={<DownArrowLineOutlined />}
+            onClick={handleExport}
+            disabled={exporting}
+          >
+            {t('sqlManagement.remediationReport.exportButton')}
+          </BasicButton>
+        }
+      />
+      <Card>
+        <Space direction="vertical" size={12}>
+          <Typography.Title level={5}>
+            {t('sqlManagement.remediationReport.scopeTitle')}
+          </Typography.Title>
+          <Typography.Paragraph>
+            {t('sqlManagement.remediationReport.description')}
+          </Typography.Paragraph>
+          <Typography.Paragraph>
+            {t('sqlManagement.remediationReport.scopeContent')}
+          </Typography.Paragraph>
+          <Typography.Text type="secondary">
+            {t('sqlManagement.remediationReport.permissionTips')}
+          </Typography.Text>
+        </Space>
+      </Card>
+    </article>
+  );
+};
+
+export default SqlManagementRemediationReport;

--- a/packages/sqle/src/router/config.tsx
+++ b/packages/sqle/src/router/config.tsx
@@ -196,6 +196,10 @@ const UpdateCustomRule = React.lazy(
 );
 const ReportStatistics = React.lazy(() => import('../page/ReportStatistics'));
 
+const SqlManagementRemediationReport = React.lazy(
+  () => import('../page/SqlManagementRemediationReport')
+);
+
 const PushRuleConfiguration = React.lazy(
   () => import('../page/PushRuleConfiguration')
 );


### PR DESCRIPTION
## 概述
完成 SQL 管控整改追踪标准产品 UI 交付记录。

Fixes #2988

## 门禁
- git diff --check
- pnpm exec prettier --check 新增整改组件
- pnpm --filter base build:ee
- docs/submit/merge_check.json: clean=true；review-agent-standard-ui-pending 与 dms-ui/feat-2988-safe 均指向 573b5f22，source contains origin/main

## 提交说明
- 标准产品 PR 继续使用已创建分支 dms-ui/feat-2988-safe
- manifest 分支 review-agent-standard-ui-pending 已作为同 SHA 别名推送，用于提交阶段合并检查闭环
