### PR TITLE
optimize sql audit task on listing sqls' status

### DIFF
--- a/packages/sqle/src/components/AuditResultMessage/ResultIconRender.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/ResultIconRender.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-
 import { Space } from 'antd';
 import {
   CheckCircleFilled,
@@ -7,36 +6,70 @@ import {
   InfoHexagonFilled,
   CloseCircleFilled
 } from '@actiontech/icons';
+import { useTranslation } from 'react-i18next';
+import { ResultIconRenderProps } from './index.type';
 
+const IconLevelDictionary = {
+  normal: <CheckCircleFilled width={20} height={20} />,
+  notice: <InfoHexagonFilled width={20} height={20} />,
+  warn: <WarningFilled width={20} height={20} />,
+  error: <CloseCircleFilled width={20} height={20} />
+};
+
+/** @deprecated use ResultIconRenderProps instead */
 export type IResultIconRender = {
   iconLevels: string[];
 };
 
-const ResultIconRender = (props: IResultIconRender) => {
-  const { iconLevels } = props;
+const ResultIconRender = (props: ResultIconRenderProps) => {
+  const { auditResultInfo, iconLevels } = props;
+  const { t } = useTranslation();
 
-  const iconData = useMemo(() => {
-    return Array.from(new Set(iconLevels.filter((icon: string) => icon)));
+  const legacyIconData = useMemo(() => {
+    return Array.from(
+      new Set((iconLevels ?? []).filter((icon: string) => icon))
+    );
   }, [iconLevels]);
 
-  const renderIcon = useMemo(() => {
-    return {
-      normal: <CheckCircleFilled width={20} height={20} />,
-      notice: <InfoHexagonFilled width={20} height={20} />,
-      warn: <WarningFilled width={20} height={20} />,
-      error: <CloseCircleFilled width={20} height={20} />
-    };
-  }, []);
+  const auditResultIconData = useMemo(() => {
+    return Array.from(
+      new Set(auditResultInfo?.map((v) => v.level)?.filter(Boolean))
+    );
+  }, [auditResultInfo]);
+
+  if (auditResultInfo) {
+    if (auditResultInfo.some((item) => item.executionFailed)) {
+      return (
+        <Space>
+          <WarningFilled width={20} height={20} />
+          <span>{t('components.auditResultMessage.hasException')}</span>
+        </Space>
+      );
+    }
+
+    return (
+      <Space size={8}>
+        {auditResultIconData.length
+          ? auditResultIconData.map((icon) => (
+              <React.Fragment key={icon}>
+                {IconLevelDictionary[
+                  icon as keyof typeof IconLevelDictionary
+                ] ?? null}
+              </React.Fragment>
+            ))
+          : IconLevelDictionary.normal}
+      </Space>
+    );
+  }
 
   return (
     <Space size={8}>
-      {iconData.map((icon) => {
-        return (
-          <React.Fragment key={icon}>
-            {renderIcon[icon as keyof typeof renderIcon] ?? null}
-          </React.Fragment>
-        );
-      })}
+      {legacyIconData.map((icon) => (
+        <React.Fragment key={icon}>
+          {IconLevelDictionary[icon as keyof typeof IconLevelDictionary] ??
+            null}
+        </React.Fragment>
+      ))}
     </Space>
   );
 };

--- a/packages/sqle/src/components/AuditResultMessage/index.type.ts
+++ b/packages/sqle/src/components/AuditResultMessage/index.type.ts
@@ -8,3 +8,13 @@ export type AuditResultMessageProps = {
   isRuleDeleted?: boolean;
   auditStatus?: string;
 };
+
+export type AuditResultInfoItem = {
+  level: string;
+  executionFailed: boolean;
+};
+
+export type ResultIconRenderProps = {
+  iconLevels?: string[];
+  auditResultInfo?: AuditResultInfoItem[];
+};

--- a/packages/sqle/src/components/AuditResultMessage/style.ts
+++ b/packages/sqle/src/components/AuditResultMessage/style.ts
@@ -1,6 +1,11 @@
 import { styled } from '@mui/material/styles';
 
+import { BasicTag } from '@actiontech/shared';
 import { AuditResultMessageProps } from './index.type';
+
+export const ResultIconTagStyleWrapper = styled(BasicTag)`
+  width: fit-content;
+`;
 
 export const AuditResultMessageStyleWrapper = styled('div')`
   display: flex;

--- a/packages/sqle/src/locale/en-US/components.ts
+++ b/packages/sqle/src/locale/en-US/components.ts
@@ -2,6 +2,8 @@
 export default {
   auditResultMessage: {
     auditPassed: 'Audit passed',
-    ruleDeleted: 'The rule has been deleted'
+    ruleDeleted: 'The rule has been deleted',
+    auditing: 'Auditing',
+    hasException: 'Audit exception occurred'
   }
 };

--- a/packages/sqle/src/locale/en-US/managementConf.ts
+++ b/packages/sqle/src/locale/en-US/managementConf.ts
@@ -155,6 +155,10 @@ export default {
         firstAppearanceTime: 'First appearance time',
         occurrenceCount: 'Occurrence count',
         status: 'Status',
+        auditStatus: 'Audit status',
+        auditResult: 'Audit result',
+        auditResultTooltip: 'Shows the latest audit result',
+        audited: 'Audited',
         explanation: {
           text: 'Explanation',
           operator: 'Add explanation'

--- a/packages/sqle/src/locale/zh-CN/components.ts
+++ b/packages/sqle/src/locale/zh-CN/components.ts
@@ -2,6 +2,8 @@
 export default {
   auditResultMessage: {
     auditPassed: '审核通过',
-    ruleDeleted: '该规则已删除'
+    ruleDeleted: '该规则已删除',
+    auditing: '审核中',
+    hasException: '审核存在异常'
   }
 };

--- a/packages/sqle/src/locale/zh-CN/managementConf.ts
+++ b/packages/sqle/src/locale/zh-CN/managementConf.ts
@@ -151,6 +151,10 @@ export default {
         firstAppearanceTime: '最早一次出现时间',
         occurrenceCount: '出现次数',
         status: '状态',
+        auditStatus: '审核状态',
+        auditResult: '审核结果',
+        auditResultTooltip: '展示最新的审核结果',
+        audited: '已审核',
         explanation: {
           text: '说明',
           operator: '添加说明'

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/AuditStatusTag.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/AuditStatusTag.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'react-i18next';
+import { ResultIconTagStyleWrapper } from '../../../../components/AuditResultMessage/style';
+import { AUDITED, BEING_AUDITED } from './utils';
+
+type AuditStatusTagProps = {
+  status?: string;
+};
+
+const AuditStatusTag: React.FC<AuditStatusTagProps> = ({ status }) => {
+  const { t } = useTranslation();
+
+  if (status === BEING_AUDITED) {
+    return (
+      <ResultIconTagStyleWrapper size="small" color="geekblue">
+        {t('components.auditResultMessage.auditing')}
+      </ResultIconTagStyleWrapper>
+    );
+  }
+
+  if (status === AUDITED) {
+    return (
+      <ResultIconTagStyleWrapper size="small" color="green">
+        {t('managementConf.detail.scanTypeSqlCollection.column.audited')}
+      </ResultIconTagStyleWrapper>
+    );
+  }
+
+  return <>{status || '-'}</>;
+};
+
+export default AuditStatusTag;

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
@@ -645,6 +645,12 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                         class="ant-table-cell"
                         scope="col"
                       >
+                        审核状态
+                      </th>
+                      <th
+                        class="ant-table-cell"
+                        scope="col"
+                      >
                         审核结果
                       </th>
                       <th
@@ -1074,6 +1080,15 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                            
                         </div>
                       </td>
+                      <td
+                        style="padding: 0px; border: 0px; height: 0px;"
+                      >
+                        <div
+                          style="height: 0px; overflow: hidden;"
+                        >
+                           
+                        </div>
+                      </td>
                     </tr>
                     <tr
                       class="ant-table-row ant-table-row-level-0"
@@ -1198,14 +1213,19 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
+                        -
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
                         <div
                           data-testid="trigger-open-report-drawer"
                         >
                           <div
-                            class=" css-1avyf41"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <div
+                              class="ant-space-item"
                             >
                               <svg
                                 height="20"
@@ -1218,12 +1238,7 @@ LIMIT
                                   fill="#41BF9A"
                                 />
                               </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
+                            </div>
                           </div>
                         </div>
                       </td>
@@ -1410,14 +1425,19 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
+                        -
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
                         <div
                           data-testid="trigger-open-report-drawer"
                         >
                           <div
-                            class=" css-1avyf41"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <div
+                              class="ant-space-item"
                             >
                               <svg
                                 height="20"
@@ -1430,12 +1450,7 @@ LIMIT
                                   fill="#41BF9A"
                                 />
                               </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
+                            </div>
                           </div>
                         </div>
                       </td>
@@ -1592,14 +1607,19 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
+                        -
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
                         <div
                           data-testid="trigger-open-report-drawer"
                         >
                           <div
-                            class=" css-1avyf41"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <div
+                              class="ant-space-item"
                             >
                               <svg
                                 height="20"
@@ -1612,12 +1632,7 @@ LIMIT
                                   fill="#41BF9A"
                                 />
                               </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
+                            </div>
                           </div>
                         </div>
                       </td>
@@ -1748,36 +1763,32 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
+                        -
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
                         <div
                           data-testid="trigger-open-report-drawer"
                         >
                           <div
-                            class=" css-1v03opz"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                           >
                             <div
-                              class="css-1avyf41"
+                              class="ant-space-item"
                             >
-                              <span
-                                class="icon-wrapper"
+                              <svg
+                                fill="none"
+                                height="20"
+                                viewBox="0 0 16 16"
+                                width="20"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  fill="none"
-                                  height="20"
-                                  viewBox="0 0 16 16"
-                                  width="20"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
-                                    fill="#EBAD1C"
-                                  />
-                                </svg>
-                              </span>
-                              <span
-                                class="text-wrapper"
-                              >
-                                语法错误或者解析器不支持，请人工确认SQL正确性
-                              </span>
+                                <path
+                                  d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
+                                  fill="#EBAD1C"
+                                />
+                              </svg>
                             </div>
                           </div>
                         </div>
@@ -1909,14 +1920,19 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
+                        -
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
                         <div
                           data-testid="trigger-open-report-drawer"
                         >
                           <div
-                            class=" css-1avyf41"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <div
+                              class="ant-space-item"
                             >
                               <svg
                                 height="20"
@@ -1929,12 +1945,7 @@ LIMIT
                                   fill="#41BF9A"
                                 />
                               </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
+                            </div>
                           </div>
                         </div>
                       </td>
@@ -2108,14 +2119,19 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
+                        -
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
                         <div
                           data-testid="trigger-open-report-drawer"
                         >
                           <div
-                            class=" css-1avyf41"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <div
+                              class="ant-space-item"
                             >
                               <svg
                                 height="20"
@@ -2128,12 +2144,7 @@ LIMIT
                                   fill="#41BF9A"
                                 />
                               </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
+                            </div>
                           </div>
                         </div>
                       </td>
@@ -2795,6 +2806,12 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                           class="ant-table-cell"
                           scope="col"
                         >
+                          审核状态
+                        </th>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
                           审核结果
                         </th>
                         <th
@@ -3224,6 +3241,15 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                              
                           </div>
                         </td>
+                        <td
+                          style="padding: 0px; border: 0px; height: 0px;"
+                        >
+                          <div
+                            style="height: 0px; overflow: hidden;"
+                          >
+                             
+                          </div>
+                        </td>
                       </tr>
                       <tr
                         class="ant-table-row ant-table-row-level-0"
@@ -3348,14 +3374,19 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
+                          -
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
                           <div
                             data-testid="trigger-open-report-drawer"
                           >
                             <div
-                              class=" css-1avyf41"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                             >
-                              <span
-                                class="icon-wrapper"
+                              <div
+                                class="ant-space-item"
                               >
                                 <svg
                                   height="20"
@@ -3368,12 +3399,7 @@ LIMIT
                                     fill="#41BF9A"
                                   />
                                 </svg>
-                              </span>
-                              <span
-                                class="text-wrapper"
-                              >
-                                审核通过
-                              </span>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -3560,14 +3586,19 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
+                          -
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
                           <div
                             data-testid="trigger-open-report-drawer"
                           >
                             <div
-                              class=" css-1avyf41"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                             >
-                              <span
-                                class="icon-wrapper"
+                              <div
+                                class="ant-space-item"
                               >
                                 <svg
                                   height="20"
@@ -3580,12 +3611,7 @@ LIMIT
                                     fill="#41BF9A"
                                   />
                                 </svg>
-                              </span>
-                              <span
-                                class="text-wrapper"
-                              >
-                                审核通过
-                              </span>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -3742,14 +3768,19 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
+                          -
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
                           <div
                             data-testid="trigger-open-report-drawer"
                           >
                             <div
-                              class=" css-1avyf41"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                             >
-                              <span
-                                class="icon-wrapper"
+                              <div
+                                class="ant-space-item"
                               >
                                 <svg
                                   height="20"
@@ -3762,12 +3793,7 @@ LIMIT
                                     fill="#41BF9A"
                                   />
                                 </svg>
-                              </span>
-                              <span
-                                class="text-wrapper"
-                              >
-                                审核通过
-                              </span>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -3898,36 +3924,32 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
+                          -
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
                           <div
                             data-testid="trigger-open-report-drawer"
                           >
                             <div
-                              class=" css-1v03opz"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                             >
                               <div
-                                class="css-1avyf41"
+                                class="ant-space-item"
                               >
-                                <span
-                                  class="icon-wrapper"
+                                <svg
+                                  fill="none"
+                                  height="20"
+                                  viewBox="0 0 16 16"
+                                  width="20"
+                                  xmlns="http://www.w3.org/2000/svg"
                                 >
-                                  <svg
-                                    fill="none"
-                                    height="20"
-                                    viewBox="0 0 16 16"
-                                    width="20"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
-                                      fill="#EBAD1C"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="text-wrapper"
-                                >
-                                  语法错误或者解析器不支持，请人工确认SQL正确性
-                                </span>
+                                  <path
+                                    d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
+                                    fill="#EBAD1C"
+                                  />
+                                </svg>
                               </div>
                             </div>
                           </div>
@@ -4059,14 +4081,19 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
+                          -
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
                           <div
                             data-testid="trigger-open-report-drawer"
                           >
                             <div
-                              class=" css-1avyf41"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                             >
-                              <span
-                                class="icon-wrapper"
+                              <div
+                                class="ant-space-item"
                               >
                                 <svg
                                   height="20"
@@ -4079,12 +4106,7 @@ LIMIT
                                     fill="#41BF9A"
                                   />
                                 </svg>
-                              </span>
-                              <span
-                                class="text-wrapper"
-                              >
-                                审核通过
-                              </span>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -4258,14 +4280,19 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
+                          -
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
                           <div
                             data-testid="trigger-open-report-drawer"
                           >
                             <div
-                              class=" css-1avyf41"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                             >
-                              <span
-                                class="icon-wrapper"
+                              <div
+                                class="ant-space-item"
                               >
                                 <svg
                                   height="20"
@@ -4278,12 +4305,7 @@ LIMIT
                                     fill="#41BF9A"
                                   />
                                 </svg>
-                              </span>
-                              <span
-                                class="text-wrapper"
-                              >
-                                审核通过
-                              </span>
+                              </div>
                             </div>
                           </div>
                         </td>

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
@@ -651,7 +651,9 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                         class="ant-table-cell"
                         scope="col"
                       >
-                        审核结果
+                        <span>
+                          审核结果
+                        </span>
                       </th>
                       <th
                         aria-label="出现次数"
@@ -2812,7 +2814,9 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                           class="ant-table-cell"
                           scope="col"
                         >
-                          审核结果
+                          <span>
+                            审核结果
+                          </span>
                         </th>
                         <th
                           aria-label="出现次数"

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/index.test.tsx
@@ -7,6 +7,8 @@ import { mockProjectInfo } from '@actiontech/shared/lib/testUtil/mockHook/data';
 import { mockUseCurrentUser } from '@actiontech/shared/lib/testUtil/mockHook/mockUseCurrentUser';
 import { getAllBySelector } from '@actiontech/shared/lib/testUtil/customQuery';
 import rule_template from '../../../../../testUtils/mockApi/rule_template';
+import { createSpySuccessResponse } from '@actiontech/shared/lib/testUtil/mockApi';
+import { mockAuditPlanSQLData } from '../../../../../testUtils/mockApi/instanceAuditPlan/data';
 
 describe('test ScanTypeSqlCollection', () => {
   let getInstanceAuditPlanSQLMetaSpy: jest.SpyInstance;
@@ -129,5 +131,57 @@ describe('test ScanTypeSqlCollection', () => {
     fireEvent.click(getAllByTestId('trigger-open-report-drawer')[0]);
     await act(async () => jest.advanceTimersByTime(3000));
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should polling request when sql audit status is being_audited', async () => {
+    getInstanceAuditPlanSQLDataSpy
+      .mockImplementationOnce(() => {
+        return createSpySuccessResponse({
+          data: {
+            rows: [
+              {
+                ...mockAuditPlanSQLData?.rows?.[0],
+                audit_results: '[]',
+                audit_status: 'being_audited'
+              }
+            ]
+          }
+        });
+      })
+      .mockImplementationOnce(() => {
+        return createSpySuccessResponse({
+          data: {
+            rows: [
+              {
+                ...mockAuditPlanSQLData?.rows?.[0]
+              }
+            ]
+          }
+        });
+      });
+
+    customRender();
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(getInstanceAuditPlanSQLDataSpy).toHaveBeenCalledTimes(1);
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(getInstanceAuditPlanSQLDataSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should stop polling request when sql audit status is not being_audited', async () => {
+    getInstanceAuditPlanSQLDataSpy.mockImplementation(() => {
+      return createSpySuccessResponse({
+        data: {
+          rows: [
+            {
+              ...mockAuditPlanSQLData?.rows?.[0]
+            }
+          ]
+        }
+      });
+    });
+
+    customRender();
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(getInstanceAuditPlanSQLDataSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/indx.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/indx.tsx
@@ -46,8 +46,7 @@ import {
 } from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan/index.d';
 import { mergeFilterButtonMeta } from '@actiontech/shared/lib/components/ActiontechTable/hooks/useTableFilterContainer';
 import { ResponseCode } from '@actiontech/shared/lib/enum';
-import { message, Tooltip, Space } from 'antd';
-import { InfoCircleOutlined } from '@actiontech/icons';
+import { message, Tooltip } from 'antd';
 import { Link } from 'react-router-dom';
 
 const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
@@ -363,16 +362,13 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
         return {
           ...column,
           title: (
-            <Space size={4}>
-              {column.title as ReactNode}
-              <Tooltip
-                title={t(
-                  'managementConf.detail.scanTypeSqlCollection.column.auditResultTooltip'
-                )}
-              >
-                <InfoCircleOutlined />
-              </Tooltip>
-            </Space>
+            <Tooltip
+              title={t(
+                'managementConf.detail.scanTypeSqlCollection.column.auditResultTooltip'
+              )}
+            >
+              <span>{column.title as ReactNode}</span>
+            </Tooltip>
           )
         };
       }

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/indx.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/indx.tsx
@@ -8,7 +8,7 @@ import {
 } from '@actiontech/shared/lib/components/ActiontechTable';
 import { useTranslation } from 'react-i18next';
 import ReportDrawer from '../../../../components/ReportDrawer';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, ReactNode } from 'react';
 import { useBoolean, useRequest } from 'ahooks';
 import { ScanTypeSqlCollectionStyleWrapper } from './style';
 import instance_audit_plan from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan';
@@ -34,14 +34,20 @@ import {
   getErrorMessage
 } from '@actiontech/shared/lib/utils/Common';
 import ResultIconRender from '../../../../components/AuditResultMessage/ResultIconRender';
-import AuditResultMessage from '../../../../components/AuditResultMessage';
+import AuditStatusTag from './AuditStatusTag';
+import {
+  BEING_AUDITED,
+  buildTableHeadWithAuditStatus,
+  parseAuditResult
+} from './utils';
 import {
   IGetInstanceAuditPlanSQLDataV1Params,
   IGetInstanceAuditPlanSQLExportV1Params
 } from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan/index.d';
 import { mergeFilterButtonMeta } from '@actiontech/shared/lib/components/ActiontechTable/hooks/useTableFilterContainer';
 import { ResponseCode } from '@actiontech/shared/lib/enum';
-import { message } from 'antd';
+import { message, Tooltip, Space } from 'antd';
+import { InfoCircleOutlined } from '@actiontech/icons';
 import { Link } from 'react-router-dom';
 
 const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
@@ -64,6 +70,8 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
   const [currentAuditResultRecord, setCurrentAuditResultRecord] =
     useState<ScanTypeSqlTableDataSourceItem>();
   const [messageApi, messageContextHolder] = message.useMessage();
+  const [polling, { setFalse: finishPollRequest, setTrue: startPollRequest }] =
+    useBoolean();
 
   const {
     tableChange,
@@ -86,10 +94,13 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     { setTrue: openReportDrawer, setFalse: closeReportDrawer }
   ] = useBoolean(false);
 
-  const onClickAuditResult = (record: ScanTypeSqlTableDataSourceItem) => {
-    openReportDrawer();
-    setCurrentAuditResultRecord(record);
-  };
+  const onClickAuditResult = useCallback(
+    (record: ScanTypeSqlTableDataSourceItem) => {
+      openReportDrawer();
+      setCurrentAuditResultRecord(record);
+    },
+    [openReportDrawer]
+  );
 
   const {
     data: tableMetas,
@@ -165,7 +176,8 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     data: tableRows,
     loading: getTableRowLoading,
     refresh: refreshTableRows,
-    error: getTableRowError
+    error: getTableRowError,
+    cancel
   } = useRequest(
     () => {
       const params: IGetInstanceAuditPlanSQLDataV1Params = {
@@ -186,7 +198,21 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     },
     {
       refreshDeps: [pagination, tableFilterInfo, sortInfo],
-      ready: activeTabKey === auditPlanId
+      ready: activeTabKey === auditPlanId,
+      pollingInterval: 1000,
+      pollingErrorRetryCount: 3,
+      onSuccess: (res) => {
+        if (res.data?.some((i) => i?.audit_status === BEING_AUDITED)) {
+          startPollRequest();
+        } else {
+          cancel();
+          finishPollRequest();
+        }
+      },
+      onError: () => {
+        cancel();
+        finishPollRequest();
+      }
     }
   );
 
@@ -267,6 +293,93 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     };
   }, [username, auditPlanType]);
 
+  const loading = getFilterMetaListLoading || (getTableRowLoading && !polling);
+
+  const tableHead = useMemo(
+    () =>
+      buildTableHeadWithAuditStatus(tableMetas?.head, {
+        auditStatus: t(
+          'managementConf.detail.scanTypeSqlCollection.column.auditStatus'
+        ),
+        auditResult: t(
+          'managementConf.detail.scanTypeSqlCollection.column.auditResult'
+        )
+      }),
+    [tableMetas?.head, t]
+  );
+
+  const columns = useMemo(() => {
+    if (!tableHead.length) {
+      return [];
+    }
+
+    const builtColumns = sortableTableColumnFactory(tableHead, {
+      columnClassName: (type) =>
+        type === 'sql' ? 'ellipsis-column-large-width' : undefined,
+      customRender: (text, record, fieldName, type) => {
+        if (fieldName === 'audit_status') {
+          return <AuditStatusTag status={text} />;
+        }
+
+        if (fieldName === 'audit_results') {
+          return (
+            <div
+              data-testid="trigger-open-report-drawer"
+              onClick={() => onClickAuditResult(record)}
+            >
+              <ResultIconRender auditResultInfo={parseAuditResult(text)} />
+            </div>
+          );
+        }
+
+        if (!text) {
+          return '-';
+        }
+
+        if (type === 'time') {
+          return formatTime(text, '-');
+        }
+
+        if (type === 'sql') {
+          return (
+            <SQLRenderer.Snippet
+              tooltip={false}
+              className="pointer"
+              onClick={() => onClickAuditResult(record)}
+              sql={text}
+              rows={1}
+              showCopyIcon
+              cuttingLength={200}
+            />
+          );
+        }
+
+        return text;
+      }
+    });
+
+    return builtColumns.map((column) => {
+      if (column.dataIndex === 'audit_results') {
+        return {
+          ...column,
+          title: (
+            <Space size={4}>
+              {column.title as ReactNode}
+              <Tooltip
+                title={t(
+                  'managementConf.detail.scanTypeSqlCollection.column.auditResultTooltip'
+                )}
+              >
+                <InfoCircleOutlined />
+              </Tooltip>
+            </Space>
+          )
+        };
+      }
+      return column;
+    });
+  }, [onClickAuditResult, sortableTableColumnFactory, t, tableHead]);
+
   return (
     <ScanTypeSqlCollectionStyleWrapper>
       <TableToolbar setting={tableSetting}>
@@ -284,67 +397,8 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
         rowKey="id"
         setting={tableSetting}
         errorMessage={getTableRowError && getErrorMessage(getTableRowError)}
-        loading={getFilterMetaListLoading || getTableRowLoading}
-        columns={sortableTableColumnFactory(tableMetas?.head ?? [], {
-          columnClassName: (type) =>
-            type === 'sql' ? 'ellipsis-column-large-width' : undefined,
-          customRender: (text, record, fieldName, type) => {
-            if (fieldName === 'audit_results') {
-              let results: IAuditResult[] = [];
-              try {
-                results = JSON.parse(text ?? '[]') as IAuditResult[];
-              } catch (error) {
-                results = [];
-              }
-              return (
-                <div
-                  data-testid="trigger-open-report-drawer"
-                  onClick={() => onClickAuditResult(record)}
-                >
-                  {results?.length > 1 ? (
-                    <ResultIconRender
-                      iconLevels={results.map((item) => {
-                        return item.level ?? '';
-                      })}
-                    />
-                  ) : (
-                    <AuditResultMessage
-                      auditResult={
-                        Array.isArray(results) && results.length
-                          ? results[0]
-                          : {}
-                      }
-                    />
-                  )}
-                </div>
-              );
-            }
-
-            if (!text) {
-              return '-';
-            }
-
-            if (type === 'time') {
-              return formatTime(text, '-');
-            }
-
-            if (type === 'sql') {
-              return (
-                <SQLRenderer.Snippet
-                  tooltip={false}
-                  className="pointer"
-                  onClick={() => onClickAuditResult(record)}
-                  sql={text}
-                  rows={1}
-                  showCopyIcon
-                  cuttingLength={200}
-                />
-              );
-            }
-
-            return text;
-          }
-        })}
+        loading={loading}
+        columns={columns}
         dataSource={tableRows?.data}
         onChange={tableChange}
         pagination={{

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/utils.ts
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/utils.ts
@@ -1,0 +1,91 @@
+import {
+  IAuditResult,
+  IAuditPlanSQLHeadV1
+} from '@actiontech/shared/lib/api/sqle/service/common';
+import { AuditResultInfoItem } from '../../../../components/AuditResultMessage/index.type';
+
+export const BEING_AUDITED = 'being_audited';
+export const AUDITED = 'audited';
+
+const AUDIT_STATUS_FIELD = 'audit_status';
+const AUDIT_RESULTS_FIELD = 'audit_results';
+const PRIORITY_FIELD = 'priority';
+
+type AuditResultJsonItem = IAuditResult & {
+  execution_failed?: boolean;
+};
+
+export const parseAuditResult = (
+  resultString: string
+): AuditResultInfoItem[] => {
+  let results: AuditResultJsonItem[] = [];
+  try {
+    const parsed = JSON.parse(resultString ?? '[]') as
+      | AuditResultJsonItem[]
+      | null;
+    results = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    results = [];
+  }
+  return results.map((item) => ({
+    level: item.level ?? '',
+    executionFailed: !!item.execution_failed
+  }));
+};
+
+export type AuditColumnLabels = {
+  auditStatus: string;
+  auditResult: string;
+};
+
+/**
+ * 在后端返回的 head 中注入 `audit_status` 列，并按以下顺序排列：
+ *   ... → audit_status → priority → audit_results → ...
+ * 即：保证 `audit_status` 出现在 `priority` 之前；若 `priority` 不存在，则
+ * 退化为出现在 `audit_results` 之前。
+ *
+ * 同时统一覆盖 `audit_results` 列标题为「审核结果」，避免后端返回的旧文案。
+ */
+export const buildTableHeadWithAuditStatus = (
+  head: IAuditPlanSQLHeadV1[] | undefined,
+  labels: AuditColumnLabels
+): IAuditPlanSQLHeadV1[] => {
+  if (!head?.length) {
+    return [];
+  }
+
+  const withoutAuditStatus = head
+    .filter((item) => item.field_name !== AUDIT_STATUS_FIELD)
+    .map<IAuditPlanSQLHeadV1>((item) => {
+      if (item.field_name === AUDIT_RESULTS_FIELD) {
+        return { ...item, desc: labels.auditResult };
+      }
+      return item;
+    });
+
+  const auditStatusColumn: IAuditPlanSQLHeadV1 = {
+    field_name: AUDIT_STATUS_FIELD,
+    desc: labels.auditStatus,
+    sortable: false
+  };
+
+  const priorityIndex = withoutAuditStatus.findIndex(
+    (item) => item.field_name === PRIORITY_FIELD
+  );
+  const insertIndex =
+    priorityIndex !== -1
+      ? priorityIndex
+      : withoutAuditStatus.findIndex(
+          (item) => item.field_name === AUDIT_RESULTS_FIELD
+        );
+
+  if (insertIndex === -1) {
+    return withoutAuditStatus;
+  }
+
+  return [
+    ...withoutAuditStatus.slice(0, insertIndex),
+    auditStatusColumn,
+    ...withoutAuditStatus.slice(insertIndex)
+  ];
+};


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/sqle-ee/issues/2997

## 描述你的变更

扫描任务详情页（`SqlManagementConf/Detail/ScanTypeSqlCollection`）新增审核状态展示，并对相关组件做了配套重构。

**功能变更**
- SQL 列表新增「审核状态」列，展示 `审核中` / `已审核` 两种状态 tag（位于 `priority` 之前，`audit_results` 之前）。
- 表格在存在 `being_audited` 行时开启 1s 轮询，所有行结束审核后自动停止；接口连续失败时也会终止轮询，避免 loading 卡死。
- 审核结果列表头统一展示「审核结果」，hover 文字提示「展示最新的审核结果」。
- 审核结果中若存在 `execution_failed` 项，展示「审核存在异常」提示。

**组件 / 架构调整**
- 新增 `AuditStatusTag` 组件，统一渲染审核状态 tag，消除页面与 `ResultIconRender` 之间的重复实现。
- `ResultIconRender` 收敛为单一职责：仅渲染图标列表 + 异常态；新增 `auditResultInfo` 入参，旧 `iconLevels` 路径保留并标记 `@deprecated`。
- 新增 `AuditResultMessage/index.type.ts` 中的 `AuditResultInfoItem` 类型，解耦 utils 与组件 props。
- 新增 `ScanTypeSqlCollection/utils.ts`：
  - `parseAuditResult`：统一解析后端返回的 `audit_results` JSON 字符串。
  - `buildTableHeadWithAuditStatus`：在后端 head 中注入「审核状态」列并维护列顺序（`audit_status → priority → audit_results`），同时覆盖 `audit_results` 列标题。
- 简化 `loading` 表达式，避免轮询期间反复显示 loading。
- 补充对应 i18n 文案（zh-CN / en-US）。

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------