### PR TITLE
feat: SQL 管控引入 SQL 治理能力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 docs-dist
 docs-dist.tar.gz
 es
+
+## local config
+.cursor/

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
@@ -10,6 +10,7 @@ import {
   exportSqlManageV1FilterStatusEnum,
   exportSqlManageV1SortFieldEnum,
   exportSqlManageV1SortOrderEnum,
+  exportSqlManageRemediationV1ExportScopeEnum,
   GetSqlManageListV2FilterSourceEnum,
   GetSqlManageListV2FilterAuditLevelEnum,
   GetSqlManageListV2FilterStatusEnum,
@@ -20,10 +21,12 @@ import {
 
 import {
   IGetSqlManageListResp,
+  IGetSqlManageListV1Resp,
   IBatchUpdateSqlManageReq,
   IBaseRes,
   IGetSqlManageRuleTipsResp,
-  IGetSqlManageSqlAnalysisResp
+  IGetSqlManageSqlAnalysisResp,
+  IGetSqlManageRemediationResp
 } from '../common.d';
 
 export interface IGetSqlManageListParams {
@@ -62,7 +65,7 @@ export interface IGetSqlManageListParams {
   page_size: number;
 }
 
-export interface IGetSqlManageListReturn extends IGetSqlManageListResp {}
+export interface IGetSqlManageListReturn extends IGetSqlManageListV1Resp {}
 
 export interface IBatchUpdateSqlManageParams extends IBatchUpdateSqlManageReq {
   project_name: string;
@@ -104,6 +107,20 @@ export interface IExportSqlManageV1Params {
   sort_field?: exportSqlManageV1SortFieldEnum;
 
   sort_order?: exportSqlManageV1SortOrderEnum;
+}
+
+export interface IExportGlobalSqlManageRemediationV1Params {}
+
+export interface IExportSqlManageRemediationV1Params {
+  project_name: string;
+
+  export_scope: exportSqlManageRemediationV1ExportScopeEnum;
+
+  filter_instance_id?: string;
+
+  instance_audit_plan_id?: string;
+
+  audit_plan_type?: string;
 }
 
 export interface IGetSqlManageRuleTipsParams {
@@ -163,3 +180,12 @@ export interface IGetSqlManageListV2Params {
 }
 
 export interface IGetSqlManageListV2Return extends IGetSqlManageListResp {}
+
+export interface IGetSqlManageRemediationV1Params {
+  project_name: string;
+
+  sql_manage_id: string;
+}
+
+export interface IGetSqlManageRemediationV1Return
+  extends IGetSqlManageRemediationResp {}

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.enum.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.enum.ts
@@ -86,6 +86,14 @@ export enum exportSqlManageV1SortOrderEnum {
   'desc' = 'desc'
 }
 
+export enum exportSqlManageRemediationV1ExportScopeEnum {
+  'project' = 'project',
+
+  'data_source' = 'data_source',
+
+  'scan_task' = 'scan_task'
+}
+
 export enum GetSqlManageListV2FilterSourceEnum {
   'audit_plan' = 'audit_plan',
 

--- a/packages/shared/lib/api/sqle/service/SqlManage/index.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.ts
@@ -12,12 +12,16 @@ import {
   IBatchUpdateSqlManageParams,
   IBatchUpdateSqlManageReturn,
   IExportSqlManageV1Params,
+  IExportGlobalSqlManageRemediationV1Params,
+  IExportSqlManageRemediationV1Params,
   IGetSqlManageRuleTipsParams,
   IGetSqlManageRuleTipsReturn,
   IGetSqlManageSqlAnalysisV1Params,
   IGetSqlManageSqlAnalysisV1Return,
   IGetSqlManageListV2Params,
-  IGetSqlManageListV2Return
+  IGetSqlManageListV2Return,
+  IGetSqlManageRemediationV1Params,
+  IGetSqlManageRemediationV1Return
 } from './index.d';
 
 class SqlManageService extends ServiceBase {
@@ -59,8 +63,36 @@ class SqlManageService extends ServiceBase {
     const project_name = paramsData.project_name;
     delete paramsData.project_name;
 
-    return this.get<any>(
+    return this.get<Blob>(
       `/v1/projects/${project_name}/sql_manages/exports`,
+      paramsData,
+      options
+    );
+  }
+
+  public exportGlobalSqlManageRemediationV1(
+    params: IExportGlobalSqlManageRemediationV1Params = {},
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+
+    return this.get<Blob>(
+      `/v1/sql_manages/remediation_exports`,
+      paramsData,
+      options
+    );
+  }
+
+  public exportSqlManageRemediationV1(
+    params: IExportSqlManageRemediationV1Params,
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+    const project_name = paramsData.project_name;
+    delete paramsData.project_name;
+
+    return this.get<Blob>(
+      `/v1/projects/${project_name}/sql_manages/remediation_exports`,
       paramsData,
       options
     );
@@ -109,6 +141,24 @@ class SqlManageService extends ServiceBase {
 
     return this.get<IGetSqlManageListV2Return>(
       `/v2/projects/${project_name}/sql_manages`,
+      paramsData,
+      options
+    );
+  }
+
+  public GetSqlManageRemediationV1(
+    params: IGetSqlManageRemediationV1Params,
+    options?: AxiosRequestConfig
+  ) {
+    const paramsData = this.cloneDeep(params);
+    const project_name = paramsData.project_name;
+    delete paramsData.project_name;
+
+    const sql_manage_id = paramsData.sql_manage_id;
+    delete paramsData.sql_manage_id;
+
+    return this.get<IGetSqlManageRemediationV1Return>(
+      `/v1/projects/${project_name}/sql_manages/${sql_manage_id}/remediation`,
       paramsData,
       options
     );

--- a/packages/shared/lib/api/sqle/service/common.d.ts
+++ b/packages/shared/lib/api/sqle/service/common.d.ts
@@ -2360,6 +2360,15 @@ export interface ISqlManage {
 
   remark?: string;
 
+  // TODO: 后端已移除/变更，待 codegen 重新生成
+  first_audit_missing?: boolean;
+
+  first_audit_result?: IAuditResult[];
+
+  first_audit_time?: string;
+
+  rule_diff?: IRuleDiff;
+
   schema_name?: string;
 
   source?: ISource;
@@ -2369,6 +2378,57 @@ export interface ISqlManage {
   sql_fingerprint?: string;
 
   status?: SqlManageStatusEnum;
+}
+
+// TODO: 后端 v1.SqlManage 与 v2.SqlManage 字段不同，单独建模 v1（v1 接口已 deprecated）
+export interface ISqlManageV1 {
+  appear_num?: number;
+
+  assignees?: string[];
+
+  audit_result?: IAuditResult[];
+
+  endpoint?: string;
+
+  first_appear_time?: string;
+
+  first_audit_result?: IAuditResult[];
+
+  first_audit_time?: string;
+
+  id?: number;
+
+  instance_name?: string;
+
+  last_appear_time?: string;
+
+  remark?: string;
+
+  rule_diff?: IRuleDiff;
+
+  schema_name?: string;
+
+  source?: ISource;
+
+  sql?: string;
+
+  sql_fingerprint?: string;
+
+  status?: SqlManageStatusEnum;
+}
+
+export interface IGetSqlManageListV1Resp {
+  code?: number;
+
+  data?: ISqlManageV1[];
+
+  message?: string;
+
+  sql_manage_bad_num?: number;
+
+  sql_manage_optimized_num?: number;
+
+  sql_manage_total_num?: number;
 }
 
 export interface IStatisticAuditPlanResV1 {
@@ -3457,4 +3517,41 @@ export interface IWorkflowStepResV2 {
   type?: WorkflowStepResV2TypeEnum;
 
   workflow_step_id?: number;
+}
+
+export interface IRuleDiff {
+  new?: IAuditResult[];
+
+  resolved?: IAuditResult[];
+
+  unchanged?: IAuditResult[];
+}
+
+export interface ISqlManageRemediation {
+  // TODO: 后端已移除/变更，待 codegen 重新生成
+  first_audit_missing?: boolean;
+
+  first_audit_result?: IAuditResult[];
+
+  first_audit_time?: string;
+
+  id?: number;
+
+  latest_audit_result?: IAuditResult[];
+
+  latest_audit_time?: string;
+
+  rule_diff?: IRuleDiff;
+
+  sql?: string;
+
+  sql_fingerprint?: string;
+}
+
+export interface IGetSqlManageRemediationResp {
+  code?: number;
+
+  data?: ISqlManageRemediation;
+
+  message?: string;
 }

--- a/packages/sqle/src/components/AuditResultMessage/AuditLevelSummary.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/AuditLevelSummary.tsx
@@ -1,0 +1,64 @@
+import { useMemo, type FC } from 'react';
+import { Space } from 'antd';
+import {
+  WarningFilled,
+  InfoHexagonFilled,
+  CloseCircleFilled
+} from '@actiontech/icons';
+import { IAuditResult } from '@actiontech/shared/lib/api/sqle/service/common';
+import AuditResultMessage from './index';
+import {
+  AUDIT_LEVEL_DISPLAY_ORDER,
+  AuditLevelSummaryKey,
+  countAuditResultsByLevel,
+  hasAuditViolations
+} from './auditLevelUtils';
+import { AuditLevelSummaryStyleWrapper } from './style';
+
+const LEVEL_ICON_MAP: Record<
+  AuditLevelSummaryKey,
+  FC<{ width?: number; height?: number }>
+> = {
+  error: CloseCircleFilled,
+  warn: WarningFilled,
+  notice: InfoHexagonFilled
+};
+
+export type AuditLevelSummaryProps = {
+  auditResults?: IAuditResult[];
+};
+
+const AuditLevelSummary = ({ auditResults }: AuditLevelSummaryProps) => {
+  const levelCounts = useMemo(
+    () => countAuditResultsByLevel(auditResults),
+    [auditResults]
+  );
+
+  if (!hasAuditViolations(auditResults)) {
+    return <AuditResultMessage auditResult={{}} />;
+  }
+
+  return (
+    <AuditLevelSummaryStyleWrapper>
+      <Space size={12}>
+        {AUDIT_LEVEL_DISPLAY_ORDER.map((level) => {
+          const count = levelCounts[level];
+          if (!count) {
+            return null;
+          }
+
+          const Icon = LEVEL_ICON_MAP[level];
+
+          return (
+            <span key={level} className="audit-level-summary-item">
+              <Icon width={20} height={20} />
+              <span className="audit-level-summary-count">× {count}</span>
+            </span>
+          );
+        })}
+      </Space>
+    </AuditLevelSummaryStyleWrapper>
+  );
+};
+
+export default AuditLevelSummary;

--- a/packages/sqle/src/components/AuditResultMessage/auditLevelUtils.ts
+++ b/packages/sqle/src/components/AuditResultMessage/auditLevelUtils.ts
@@ -1,0 +1,44 @@
+import { IAuditResult } from '@actiontech/shared/lib/api/sqle/service/common';
+
+export const PASS_AUDIT_LEVELS = ['normal', 'UNKNOWN'] as const;
+
+export const AUDIT_LEVEL_DISPLAY_ORDER = ['error', 'warn', 'notice'] as const;
+
+export type AuditLevelSummaryKey = (typeof AUDIT_LEVEL_DISPLAY_ORDER)[number];
+
+export const getAuditResultLevel = (
+  auditResult: IAuditResult & { audit_level?: string }
+) => auditResult.level ?? auditResult.audit_level ?? '';
+
+export const countAuditResultsByLevel = (
+  auditResults?: IAuditResult[]
+): Partial<Record<AuditLevelSummaryKey, number>> => {
+  const counts: Partial<Record<AuditLevelSummaryKey, number>> = {};
+
+  if (!Array.isArray(auditResults)) {
+    return counts;
+  }
+
+  auditResults.forEach((auditResult) => {
+    const level = getAuditResultLevel(auditResult);
+
+    if (
+      !level ||
+      PASS_AUDIT_LEVELS.includes(level as (typeof PASS_AUDIT_LEVELS)[number])
+    ) {
+      return;
+    }
+
+    if (!AUDIT_LEVEL_DISPLAY_ORDER.includes(level as AuditLevelSummaryKey)) {
+      return;
+    }
+
+    const summaryLevel = level as AuditLevelSummaryKey;
+    counts[summaryLevel] = (counts[summaryLevel] ?? 0) + 1;
+  });
+
+  return counts;
+};
+
+export const hasAuditViolations = (auditResults?: IAuditResult[]) =>
+  Object.keys(countAuditResultsByLevel(auditResults)).length > 0;

--- a/packages/sqle/src/components/AuditResultMessage/getAuditResultDisplayText.ts
+++ b/packages/sqle/src/components/AuditResultMessage/getAuditResultDisplayText.ts
@@ -1,0 +1,116 @@
+import i18n, { TFunction } from 'i18next';
+import type { IAuditResultWithExtra } from './index.type';
+
+type I18nInstance = typeof i18n;
+
+export type AuditResultDisplaySource = Pick<
+  IAuditResultWithExtra,
+  'rule_name' | 'message' | 'desc' | 'i18n_audit_result_info'
+>;
+
+export type AuditResultDisplayMode = 'ruleDesc' | 'ruleKey';
+
+const RULE_I18N_KEY_CANDIDATES = (ruleName: string) => [
+  `sqleRule.${ruleName}.desc`,
+  `rule.${ruleName}.desc`
+];
+
+const resolveRuleI18nDesc = (
+  ruleName: string,
+  t: TFunction,
+  i18nInstance: I18nInstance = i18n
+) => {
+  for (const key of RULE_I18N_KEY_CANDIDATES(ruleName)) {
+    if (i18nInstance.exists(key)) {
+      return t(key);
+    }
+  }
+  return '';
+};
+
+const resolveI18nAuditResultMessage = (
+  i18nAuditResultInfo?: AuditResultDisplaySource['i18n_audit_result_info'],
+  language?: string
+) => {
+  if (!i18nAuditResultInfo) {
+    return '';
+  }
+
+  const normalizedLanguage = (language ?? i18n.language ?? '').replace(
+    '-',
+    '_'
+  );
+  const languageCandidates = [
+    language,
+    normalizedLanguage,
+    normalizedLanguage.split('_')[0],
+    'zh',
+    'zh_CN',
+    'zh-CN'
+  ].filter(Boolean) as string[];
+
+  for (const lang of languageCandidates) {
+    const message = i18nAuditResultInfo[lang]?.message;
+    if (message) {
+      return message;
+    }
+  }
+
+  const firstMessage = Object.values(i18nAuditResultInfo).find(
+    (item) => !!item?.message
+  )?.message;
+
+  return firstMessage ?? '';
+};
+
+export const getAuditResultDisplayText = (
+  auditResult: AuditResultDisplaySource | undefined,
+  t: TFunction,
+  options?: {
+    displayMode?: AuditResultDisplayMode;
+    i18nInstance?: I18nInstance;
+  }
+) => {
+  if (!auditResult) {
+    return '';
+  }
+
+  const { rule_name, message, desc, i18n_audit_result_info } = auditResult;
+  const displayMode = options?.displayMode ?? 'ruleDesc';
+  const i18nInstance = options?.i18nInstance ?? i18n;
+
+  if (displayMode === 'ruleKey') {
+    if (rule_name) {
+      return rule_name;
+    }
+    if (message) {
+      return message;
+    }
+    return '';
+  }
+
+  if (rule_name) {
+    const ruleI18nDesc = resolveRuleI18nDesc(rule_name, t, i18nInstance);
+    if (ruleI18nDesc) {
+      return ruleI18nDesc;
+    }
+  }
+
+  if (desc) {
+    return desc;
+  }
+
+  const i18nMessage = resolveI18nAuditResultMessage(
+    i18n_audit_result_info,
+    i18nInstance.language
+  );
+  if (i18nMessage) {
+    return i18nMessage;
+  }
+
+  if (message) {
+    return message;
+  }
+
+  return '';
+};

--- a/packages/sqle/src/components/AuditResultMessage/index.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/index.tsx
@@ -17,6 +17,7 @@ import {
   PartialHexagonFilled
 } from '@actiontech/icons';
 import { getAuditTaskSQLsV2FilterAuditStatusEnum } from '@actiontech/shared/lib/api/sqle/service/task/index.enum';
+import { getAuditResultDisplayText } from './getAuditResultDisplayText';
 
 const passStatusLevelData = ['normal', 'UNKNOWN'];
 
@@ -52,9 +53,10 @@ const AuditResultMessage = ({
   showAnnotation,
   moreBtnLink,
   isRuleDeleted,
-  auditStatus
+  auditStatus,
+  displayMode = 'ruleDesc'
 }: AuditResultMessageProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [visible, { set }] = useBoolean(true);
 
   const renderIcon = useMemo(() => {
@@ -74,12 +76,22 @@ const AuditResultMessage = ({
   }, [auditResult]);
 
   const renderMessage = useMemo(() => {
-    const { level, message } = auditResult || {};
-    if (message) return message;
-    if (passStatusLevelData.includes(level ?? ''))
+    const { level } = auditResult || {};
+    const displayText = getAuditResultDisplayText(auditResult, t, {
+      displayMode,
+      i18nInstance: i18n
+    });
+
+    if (displayText) {
+      return displayText;
+    }
+
+    if (passStatusLevelData.includes(level ?? '')) {
       return t('components.auditResultMessage.auditPassed');
+    }
+
     return '';
-  }, [auditResult, t]);
+  }, [auditResult, displayMode, i18n, t]);
 
   const auditPendingCopy = useMemo(() => {
     if (auditStatus === getAuditTaskSQLsV2FilterAuditStatusEnum.initialized) {

--- a/packages/sqle/src/components/AuditResultMessage/index.type.ts
+++ b/packages/sqle/src/components/AuditResultMessage/index.type.ts
@@ -1,12 +1,32 @@
 import { IAuditResult } from '@actiontech/shared/lib/api/sqle/service/common';
+import { AuditResultDisplayMode } from './getAuditResultDisplayText';
+
+/**
+ * Swagger 类型 `IAuditResult` 之外、业务侧常用的补丁字段。
+ * 统一定义在此处避免在多个组件里重复手工拼接。
+ */
+export type AuditResultExtra = {
+  annotation?: string;
+  desc?: string;
+  i18n_audit_result_info?: Record<
+    string,
+    {
+      message?: string;
+      error_info?: string;
+    }
+  >;
+};
+
+export type IAuditResultWithExtra = IAuditResult & AuditResultExtra;
 
 export type AuditResultMessageProps = {
-  auditResult?: IAuditResult & { annotation?: string };
+  auditResult?: IAuditResultWithExtra;
   styleClass?: string;
   showAnnotation?: boolean;
   moreBtnLink?: string;
   isRuleDeleted?: boolean;
   auditStatus?: string;
+  displayMode?: AuditResultDisplayMode;
 };
 
 export type AuditResultInfoItem = {

--- a/packages/sqle/src/components/AuditResultMessage/style.ts
+++ b/packages/sqle/src/components/AuditResultMessage/style.ts
@@ -60,3 +60,18 @@ export const AuditResultMessageWithAnnotationStyleWrapper = styled('div')<{
     }
   }
 `;
+
+export const AuditLevelSummaryStyleWrapper = styled('div')`
+  .audit-level-summary-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .audit-level-summary-count {
+    color: ${({ theme }) => theme.sharedTheme.uiToken.colorText};
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 20px;
+  }
+`;

--- a/packages/sqle/src/components/AuditResultMessage/test/AuditLevelSummary.test.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/test/AuditLevelSummary.test.tsx
@@ -1,0 +1,47 @@
+import AuditLevelSummary, {
+  AuditLevelSummaryProps
+} from '../AuditLevelSummary';
+
+import { renderWithTheme } from '../../../testUtils/customRender';
+
+describe('sqle/components/AuditResultMessage/AuditLevelSummary', () => {
+  const customRender = (params: AuditLevelSummaryProps = {}) => {
+    return renderWithTheme(<AuditLevelSummary {...params} />);
+  };
+
+  it('render audit passed when audit results is empty', () => {
+    const { baseElement } = customRender();
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('render audit passed when audit results only has pass level', () => {
+    const { baseElement } = customRender({
+      auditResults: [{ level: 'normal', rule_name: 'whitelist' }]
+    });
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('render level icon with count summary', () => {
+    const { baseElement } = customRender({
+      auditResults: [
+        { level: 'error', rule_name: 'ddl_check_char_length' },
+        { level: 'error', rule_name: 'ddl_check_pk_without_auto_increment' },
+        { level: 'warn', rule_name: 'ddl_check_index' },
+        { level: 'notice', rule_name: 'ddl_check_comment' }
+      ]
+    });
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('support audit_level field from backend', () => {
+    const { baseElement } = customRender({
+      auditResults: [
+        {
+          audit_level: 'error',
+          rule_name: 'ddl_check_char_length'
+        } as AuditLevelSummaryProps['auditResults'][number]
+      ]
+    });
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/sqle/src/components/AuditResultMessage/test/AuditLevelSummary.test.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/test/AuditLevelSummary.test.tsx
@@ -39,7 +39,7 @@ describe('sqle/components/AuditResultMessage/AuditLevelSummary', () => {
         {
           audit_level: 'error',
           rule_name: 'ddl_check_char_length'
-        } as AuditLevelSummaryProps['auditResults'][number]
+        } as NonNullable<AuditLevelSummaryProps['auditResults']>[number]
       ]
     });
     expect(baseElement).toMatchSnapshot();

--- a/packages/sqle/src/components/AuditResultMessage/test/__snapshots__/AuditLevelSummary.test.tsx.snap
+++ b/packages/sqle/src/components/AuditResultMessage/test/__snapshots__/AuditLevelSummary.test.tsx.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sqle/components/AuditResultMessage/AuditLevelSummary render audit passed when audit results is empty 1`] = `
+<body>
+  <div>
+    <div
+      class=" css-1avyf41"
+    >
+      <span
+        class="icon-wrapper"
+      >
+        <svg
+          height="20"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+            fill="#41BF9A"
+          />
+        </svg>
+      </span>
+      <span
+        class="text-wrapper"
+      >
+        审核通过
+      </span>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`sqle/components/AuditResultMessage/AuditLevelSummary render audit passed when audit results only has pass level 1`] = `
+<body>
+  <div>
+    <div
+      class=" css-1avyf41"
+    >
+      <span
+        class="icon-wrapper"
+      >
+        <svg
+          height="20"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+            fill="#41BF9A"
+          />
+        </svg>
+      </span>
+      <span
+        class="text-wrapper"
+      >
+        审核通过
+      </span>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`sqle/components/AuditResultMessage/AuditLevelSummary render level icon with count summary 1`] = `
+<body>
+  <div>
+    <div
+      class="css-yzky0k"
+    >
+      <div
+        class="ant-space css-dev-only-do-not-override-txh9fw ant-space-horizontal ant-space-align-center"
+      >
+        <div
+          class="ant-space-item"
+          style="margin-right: 12px;"
+        >
+          <span
+            class="audit-level-summary-item"
+          >
+            <svg
+              height="20"
+              viewBox="0 0 16 16"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                fill="#F66074"
+              />
+            </svg>
+            <span
+              class="audit-level-summary-count"
+            >
+              × 
+              2
+            </span>
+          </span>
+        </div>
+        <div
+          class="ant-space-item"
+          style="margin-right: 12px;"
+        >
+          <span
+            class="audit-level-summary-item"
+          >
+            <svg
+              fill="none"
+              height="20"
+              viewBox="0 0 16 16"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
+                fill="#EBAD1C"
+              />
+            </svg>
+            <span
+              class="audit-level-summary-count"
+            >
+              × 
+              1
+            </span>
+          </span>
+        </div>
+        <div
+          class="ant-space-item"
+        >
+          <span
+            class="audit-level-summary-item"
+          >
+            <svg
+              height="20"
+              viewBox="0 0 20 20"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m13.28 2.084 4.637 4.638v6.558l-4.638 4.638H6.721L2.083 13.28V6.722l4.638-4.638zM9.165 12.5v1.667h1.667V12.5zm0-6.666v5h1.667v-5z"
+                fill="#6094FC"
+              />
+            </svg>
+            <span
+              class="audit-level-summary-count"
+            >
+              × 
+              1
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`sqle/components/AuditResultMessage/AuditLevelSummary support audit_level field from backend 1`] = `
+<body>
+  <div>
+    <div
+      class="css-yzky0k"
+    >
+      <div
+        class="ant-space css-dev-only-do-not-override-txh9fw ant-space-horizontal ant-space-align-center"
+      >
+        <div
+          class="ant-space-item"
+        >
+          <span
+            class="audit-level-summary-item"
+          >
+            <svg
+              height="20"
+              viewBox="0 0 16 16"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                fill="#F66074"
+              />
+            </svg>
+            <span
+              class="audit-level-summary-count"
+            >
+              × 
+              1
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/sqle/src/components/AuditResultMessage/test/auditLevelUtils.test.ts
+++ b/packages/sqle/src/components/AuditResultMessage/test/auditLevelUtils.test.ts
@@ -1,0 +1,43 @@
+import {
+  AUDIT_LEVEL_DISPLAY_ORDER,
+  countAuditResultsByLevel,
+  getAuditResultLevel,
+  hasAuditViolations
+} from '../auditLevelUtils';
+
+describe('sqle/components/AuditResultMessage/auditLevelUtils', () => {
+  it('should read level from level or audit_level', () => {
+    expect(getAuditResultLevel({ level: 'error' })).toBe('error');
+    expect(getAuditResultLevel({ audit_level: 'warn' })).toBe('warn');
+    expect(getAuditResultLevel({ level: 'notice', audit_level: 'error' })).toBe(
+      'notice'
+    );
+  });
+
+  it('should count audit results by level and ignore pass levels', () => {
+    expect(
+      countAuditResultsByLevel([
+        { level: 'error' },
+        { level: 'error' },
+        { level: 'warn' },
+        { level: 'notice' },
+        { level: 'normal' },
+        { level: 'UNKNOWN' }
+      ])
+    ).toEqual({
+      error: 2,
+      warn: 1,
+      notice: 1
+    });
+  });
+
+  it('should keep display order keys only', () => {
+    expect(AUDIT_LEVEL_DISPLAY_ORDER).toEqual(['error', 'warn', 'notice']);
+  });
+
+  it('should detect whether audit results contain violations', () => {
+    expect(hasAuditViolations([])).toBe(false);
+    expect(hasAuditViolations([{ level: 'normal' }])).toBe(false);
+    expect(hasAuditViolations([{ level: 'error' }])).toBe(true);
+  });
+});

--- a/packages/sqle/src/components/AuditResultMessage/test/getAuditResultDisplayText.test.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/test/getAuditResultDisplayText.test.tsx
@@ -1,0 +1,81 @@
+import { getAuditResultDisplayText } from '../getAuditResultDisplayText';
+
+const mockT = (key: string) => key;
+
+describe('sqle/components/AuditResultMessage/getAuditResultDisplayText', () => {
+  it('prefers rule i18n desc over desc and message', () => {
+    const i18nInstance = {
+      language: 'zh-CN',
+      exists: (key: string) => key === 'sqleRule.ddl_check_char_length.desc'
+    };
+
+    expect(
+      getAuditResultDisplayText(
+        {
+          rule_name: 'ddl_check_char_length',
+          desc: '字段长度检查',
+          message: '最末次命中：字段长度超限'
+        },
+        mockT,
+        { i18nInstance: i18nInstance as never }
+      )
+    ).toBe('sqleRule.ddl_check_char_length.desc');
+  });
+
+  it('prefers rule template desc over message and rule_name', () => {
+    expect(
+      getAuditResultDisplayText(
+        {
+          rule_name: 'ddl_check_char_length',
+          desc: '字段长度检查',
+          message: '最末次命中：字段长度超限'
+        },
+        mockT
+      )
+    ).toBe('字段长度检查');
+  });
+
+  it('prefers i18n audit result message over raw message', () => {
+    expect(
+      getAuditResultDisplayText(
+        {
+          rule_name: 'ddl_check_char_length',
+          message: 'raw message',
+          i18n_audit_result_info: {
+            'zh-CN': {
+              message: '字段长度不建议超过阈值'
+            }
+          }
+        },
+        mockT,
+        { i18nInstance: { language: 'zh-CN', exists: () => false } as never }
+      )
+    ).toBe('字段长度不建议超过阈值');
+  });
+
+  it('falls back to message instead of rule_name', () => {
+    expect(
+      getAuditResultDisplayText(
+        {
+          rule_name: 'ddl_check_char_length',
+          message: '字段长度不建议超过阈值'
+        },
+        mockT
+      )
+    ).toBe('字段长度不建议超过阈值');
+  });
+
+  it('supports legacy ruleKey display mode', () => {
+    expect(
+      getAuditResultDisplayText(
+        {
+          rule_name: 'ddl_check_char_length',
+          desc: '字段长度检查',
+          message: '字段长度不建议超过阈值'
+        },
+        mockT,
+        { displayMode: 'ruleKey' }
+      )
+    ).toBe('ddl_check_char_length');
+  });
+});

--- a/packages/sqle/src/components/AuditResultMessage/test/index.ce.test.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/test/index.ce.test.tsx
@@ -5,6 +5,7 @@
 import AuditResultMessage from '..';
 import { AuditResultMessageProps } from '../index.type';
 import { getAuditTaskSQLsV2FilterAuditStatusEnum } from '@actiontech/shared/lib/api/sqle/service/task/index.enum';
+import { screen } from '@testing-library/react';
 
 import { renderWithTheme } from '../../../testUtils/customRender';
 
@@ -27,6 +28,44 @@ describe('sqle/components/AuditResultMessage', () => {
       auditStatus: getAuditTaskSQLsV2FilterAuditStatusEnum.doing
     });
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it('render rule desc before audit message and rule key', () => {
+    customRender({
+      auditResult: {
+        level: 'error',
+        rule_name: 'ddl_check_table_without_if_not_exists',
+        desc: '新建表建议加入 IF NOT EXISTS',
+        message: '最末次命中：新建表建议加入 IF NOT EXISTS'
+      }
+    });
+
+    expect(
+      screen.getByText('新建表建议加入 IF NOT EXISTS')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('ddl_check_table_without_if_not_exists')
+    ).toBeNull();
+    expect(
+      screen.queryByText('最末次命中：新建表建议加入 IF NOT EXISTS')
+    ).toBeNull();
+  });
+
+  it('render message instead of rule key when desc is absent', () => {
+    customRender({
+      auditResult: {
+        level: 'error',
+        rule_name: 'ddl_check_table_without_if_not_exists',
+        message: '最末次命中：新建表建议加入 IF NOT EXISTS'
+      }
+    });
+
+    expect(
+      screen.getByText('最末次命中：新建表建议加入 IF NOT EXISTS')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('ddl_check_table_without_if_not_exists')
+    ).toBeNull();
   });
 
   describe('render snap when has diff level', () => {

--- a/packages/sqle/src/components/AuditResultMessage/test/index.test.tsx
+++ b/packages/sqle/src/components/AuditResultMessage/test/index.test.tsx
@@ -1,6 +1,7 @@
 import AuditResultMessage from '..';
 import { AuditResultMessageProps } from '../index.type';
 import { getAuditTaskSQLsV2FilterAuditStatusEnum } from '@actiontech/shared/lib/api/sqle/service/task/index.enum';
+import { screen } from '@testing-library/react';
 
 import { renderWithTheme } from '../../../testUtils/customRender';
 
@@ -23,6 +24,44 @@ describe('sqle/components/AuditResultMessage', () => {
       auditStatus: getAuditTaskSQLsV2FilterAuditStatusEnum.doing
     });
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it('render rule desc before audit message and rule key', () => {
+    customRender({
+      auditResult: {
+        level: 'error',
+        rule_name: 'ddl_check_table_without_if_not_exists',
+        desc: '新建表建议加入 IF NOT EXISTS',
+        message: '最末次命中：新建表建议加入 IF NOT EXISTS'
+      }
+    });
+
+    expect(
+      screen.getByText('新建表建议加入 IF NOT EXISTS')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('ddl_check_table_without_if_not_exists')
+    ).toBeNull();
+    expect(
+      screen.queryByText('最末次命中：新建表建议加入 IF NOT EXISTS')
+    ).toBeNull();
+  });
+
+  it('render message instead of rule key when desc is absent', () => {
+    customRender({
+      auditResult: {
+        level: 'error',
+        rule_name: 'ddl_check_table_without_if_not_exists',
+        message: '最末次命中：新建表建议加入 IF NOT EXISTS'
+      }
+    });
+
+    expect(
+      screen.getByText('最末次命中：新建表建议加入 IF NOT EXISTS')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('ddl_check_table_without_if_not_exists')
+    ).toBeNull();
   });
 
   describe('render snap when has diff level', () => {

--- a/packages/sqle/src/components/RemediationDetailDrawer/RemediationDiffCompare.test.tsx
+++ b/packages/sqle/src/components/RemediationDetailDrawer/RemediationDiffCompare.test.tsx
@@ -1,0 +1,78 @@
+import { screen, within } from '@testing-library/react';
+import { renderWithTheme } from '../../testUtils/customRender';
+import RemediationDiffCompare from './RemediationDiffCompare';
+
+describe('sqle/components/RemediationDetailDrawer/RemediationDiffCompare', () => {
+  it('renders side-by-side audit results grouped into diff sections', () => {
+    renderWithTheme(
+      <RemediationDiffCompare
+        data={{
+          first_audit_result: [
+            {
+              level: 'warn',
+              rule_name: 'first_rule_without_primary_key',
+              message: '首次命中：建表建议设置主键'
+            },
+            {
+              level: 'error',
+              rule_name: 'first_rule_without_comment',
+              message: '首次命中：字段建议添加注释'
+            }
+          ],
+          latest_audit_result: [
+            {
+              level: 'warn',
+              rule_name: 'latest_rule_without_index',
+              message: '最末次命中：查询条件建议添加索引'
+            },
+            {
+              level: 'error',
+              rule_name: 'latest_rule_without_limit',
+              message: '最末次命中：查询建议添加 LIMIT'
+            }
+          ],
+          rule_diff: {
+            resolved: [{ rule_name: 'first_rule_without_primary_key' }],
+            new: [{ rule_name: 'latest_rule_without_limit' }],
+            unchanged: [{ rule_name: 'latest_rule_without_index' }]
+          }
+        }}
+      />
+    );
+
+    const leftColumn = screen
+      .getByText('最初审核结果')
+      .closest('.diff-column') as HTMLElement;
+
+    expect(
+      within(leftColumn).getByText('首次命中：建表建议设置主键')
+    ).toBeInTheDocument();
+    expect(
+      within(leftColumn).getByText('首次命中：字段建议添加注释')
+    ).toBeInTheDocument();
+    expect(
+      within(leftColumn)
+        .getByText('首次命中：建表建议设置主键')
+        .closest('.diff-item-optimized')
+    ).toBeInTheDocument();
+    expect(
+      within(leftColumn)
+        .getByText('首次命中：字段建议添加注释')
+        .closest('.diff-item-optimized')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('最末次命中：查询条件建议添加索引')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('最末次命中：查询建议添加 LIMIT')
+    ).toBeInTheDocument();
+    expect(screen.getByText('已优化')).toBeInTheDocument();
+    expect(screen.getByText('新增')).toBeInTheDocument();
+    expect(screen.getAllByText('未变动')).toHaveLength(1);
+    expect(
+      screen.queryByText('对比最初审核与当前审核结果，展示规则整改变化')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('规则差异')).not.toBeInTheDocument();
+    expect(screen.queryByText('新发现')).not.toBeInTheDocument();
+  });
+});

--- a/packages/sqle/src/components/RemediationDetailDrawer/RemediationDiffCompare.tsx
+++ b/packages/sqle/src/components/RemediationDetailDrawer/RemediationDiffCompare.tsx
@@ -1,0 +1,290 @@
+import { useMemo, useState } from 'react';
+import { Alert, Empty, Space, Typography } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { DownOutlined, RightOutlined } from '@actiontech/icons';
+import { formatTime } from '@actiontech/shared/lib/utils/Common';
+import AuditResultMessage from '../AuditResultMessage';
+import {
+  IAuditResult,
+  ISqlManageRemediation
+} from '@actiontech/shared/lib/api/sqle/service/common';
+import { RemediationDiffCompareStyleWrapper } from './style';
+
+type RemediationDiffCompareProps = {
+  data?: ISqlManageRemediation;
+};
+
+type DiffSectionVariant = 'optimized' | 'new' | 'unchanged';
+
+type DiffAuditResultListProps = {
+  auditResult: IAuditResult[];
+  optimizedRuleNames?: Set<string>;
+};
+
+type DiffSectionProps = {
+  title: string;
+  variant: DiffSectionVariant;
+  auditResult: IAuditResult[];
+};
+
+const ruleNameSet = (rules?: IAuditResult[]) =>
+  new Set(
+    (rules ?? [])
+      .map((rule) => rule.rule_name ?? '')
+      .filter((ruleName) => !!ruleName)
+  );
+
+const filterAuditResultsByRuleNames = (
+  auditResult: IAuditResult[] | undefined,
+  ruleNames: Set<string>
+) => {
+  return (auditResult ?? []).filter((item) => {
+    const ruleName = item.rule_name ?? '';
+    return ruleName && ruleNames.has(ruleName);
+  });
+};
+
+const groupAuditResults = (
+  auditResult: IAuditResult[] | undefined,
+  highlightedRuleNames: Set<string>
+) => {
+  const highlighted: IAuditResult[] = [];
+  const unchanged: IAuditResult[] = [];
+
+  for (const item of auditResult ?? []) {
+    const ruleName = item.rule_name ?? '';
+    if (ruleName && highlightedRuleNames.has(ruleName)) {
+      highlighted.push(item);
+    } else {
+      unchanged.push(item);
+    }
+  }
+
+  return { highlighted, unchanged };
+};
+
+const DiffAuditResultList: React.FC<DiffAuditResultListProps> = ({
+  auditResult,
+  optimizedRuleNames
+}) => {
+  return (
+    <Space direction="vertical" size={8} className="full-width-element">
+      {auditResult.map((item, index) => {
+        const ruleName = item.rule_name ?? '';
+        const isOptimized = ruleName && optimizedRuleNames?.has(ruleName);
+
+        return (
+          <div
+            key={`${ruleName}${item.message ?? ''}-${index}`}
+            className={
+              isOptimized ? 'diff-item diff-item-optimized' : 'diff-item'
+            }
+          >
+            <AuditResultMessage auditResult={item} />
+          </div>
+        );
+      })}
+    </Space>
+  );
+};
+
+const DiffFirstAuditPanel: React.FC<{
+  auditResult: IAuditResult[];
+  optimizedRuleNames: Set<string>;
+}> = ({ auditResult, optimizedRuleNames }) => {
+  if (!auditResult.length) {
+    return <AuditResultMessage />;
+  }
+
+  return (
+    <div className="diff-section diff-section-unchanged">
+      <div className="diff-section-body diff-section-body-standalone">
+        <DiffAuditResultList
+          auditResult={auditResult}
+          optimizedRuleNames={optimizedRuleNames}
+        />
+      </div>
+    </div>
+  );
+};
+
+const DiffSection: React.FC<DiffSectionProps> = ({
+  title,
+  variant,
+  auditResult
+}) => {
+  const [expanded, setExpanded] = useState(true);
+
+  if (!auditResult.length) {
+    return null;
+  }
+
+  const toggleExpanded = () => {
+    setExpanded((prev) => !prev);
+  };
+
+  return (
+    <div
+      className={`diff-section diff-section-${variant}${
+        !expanded ? ' diff-section-collapsed' : ''
+      }`}
+    >
+      <div
+        className="diff-section-header diff-section-header-collapsible"
+        onClick={toggleExpanded}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleExpanded();
+          }
+        }}
+      >
+        <div className="diff-section-header-main">
+          {expanded ? (
+            <DownOutlined className="diff-section-chevron" />
+          ) : (
+            <RightOutlined className="diff-section-chevron" />
+          )}
+          <Typography.Text className="diff-section-title">
+            {title}
+          </Typography.Text>
+        </div>
+        <Typography.Text type="secondary" className="diff-section-count">
+          {auditResult.length}
+        </Typography.Text>
+      </div>
+      {expanded && (
+        <div className="diff-section-body">
+          <DiffAuditResultList auditResult={auditResult} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RemediationDiffCompare: React.FC<RemediationDiffCompareProps> = ({
+  data
+}) => {
+  const { t } = useTranslation();
+
+  const { removedRuleNames, addedRuleNames } = useMemo(
+    () => ({
+      removedRuleNames: ruleNameSet(data?.rule_diff?.resolved),
+      addedRuleNames: ruleNameSet(data?.rule_diff?.new)
+    }),
+    [data?.rule_diff?.new, data?.rule_diff?.resolved]
+  );
+
+  const { optimizedResults, latestNew, latestUnchanged } = useMemo(() => {
+    const latestGrouped = groupAuditResults(
+      data?.latest_audit_result,
+      addedRuleNames
+    );
+
+    return {
+      optimizedResults: filterAuditResultsByRuleNames(
+        data?.first_audit_result,
+        removedRuleNames
+      ),
+      latestNew: latestGrouped.highlighted,
+      latestUnchanged: latestGrouped.unchanged
+    };
+  }, [
+    addedRuleNames,
+    data?.first_audit_result,
+    data?.latest_audit_result,
+    removedRuleNames
+  ]);
+
+  const firstAuditResults = data?.first_audit_result ?? [];
+
+  if (!data) {
+    return <Empty />;
+  }
+
+  const hasLatestSections =
+    optimizedResults.length > 0 ||
+    latestNew.length > 0 ||
+    latestUnchanged.length > 0;
+
+  return (
+    <RemediationDiffCompareStyleWrapper>
+      {data.first_audit_missing && (
+        <Alert
+          type="warning"
+          showIcon
+          message={t('sqlManagement.remediationCompare.firstAuditMissing')}
+        />
+      )}
+      <div className="diff-columns">
+        <section className="diff-column">
+          <div className="diff-column-header">
+            <Typography.Title level={5} className="diff-column-title">
+              {t('sqlManagement.remediationCompare.firstAuditResult')}
+            </Typography.Title>
+            <Typography.Text
+              type="secondary"
+              className="diff-column-audit-time"
+            >
+              {t('sqlManagement.remediationCompare.auditTime', {
+                time: formatTime(data.first_audit_time, '-')
+              })}
+            </Typography.Text>
+          </div>
+          <DiffFirstAuditPanel
+            auditResult={firstAuditResults}
+            optimizedRuleNames={removedRuleNames}
+          />
+        </section>
+        <section className="diff-column">
+          <div className="diff-column-header">
+            <Typography.Title level={5} className="diff-column-title">
+              {t('sqlManagement.remediationCompare.latestAuditResult')}
+            </Typography.Title>
+            <Typography.Text
+              type="secondary"
+              className="diff-column-audit-time"
+            >
+              {t('sqlManagement.remediationCompare.auditTime', {
+                time: formatTime(data.latest_audit_time, '-')
+              })}
+            </Typography.Text>
+          </div>
+          {hasLatestSections ? (
+            <Space
+              direction="vertical"
+              size={12}
+              className="full-width-element"
+            >
+              <DiffSection
+                title={t('sqlManagement.remediationCompare.diffSectionNew')}
+                variant="new"
+                auditResult={latestNew}
+              />
+              <DiffSection
+                title={t(
+                  'sqlManagement.remediationCompare.diffSectionOptimized'
+                )}
+                variant="optimized"
+                auditResult={optimizedResults}
+              />
+              <DiffSection
+                title={t(
+                  'sqlManagement.remediationCompare.diffSectionUnchanged'
+                )}
+                variant="unchanged"
+                auditResult={latestUnchanged}
+              />
+            </Space>
+          ) : (
+            <AuditResultMessage />
+          )}
+        </section>
+      </div>
+    </RemediationDiffCompareStyleWrapper>
+  );
+};
+
+export default RemediationDiffCompare;

--- a/packages/sqle/src/components/RemediationDetailDrawer/index.tsx
+++ b/packages/sqle/src/components/RemediationDetailDrawer/index.tsx
@@ -1,0 +1,91 @@
+import { ReactNode, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Alert, Empty, Spin } from 'antd';
+import { BasicDrawer } from '@actiontech/shared';
+import { useCurrentProject } from '@actiontech/shared/lib/global';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
+import { ResponseCode } from '@actiontech/shared/lib/enum';
+import { useRequest } from 'ahooks';
+import RemediationDiffCompare from './RemediationDiffCompare';
+
+export const REMEDIATION_DETAIL_DRAWER_WIDTH = 960;
+
+export type RemediationDetailDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  sqlManageId?: string | number;
+  title?: ReactNode;
+  width?: number;
+};
+
+const RemediationDetailDrawer = ({
+  open,
+  onClose,
+  sqlManageId,
+  title = null,
+  width = REMEDIATION_DETAIL_DRAWER_WIDTH
+}: RemediationDetailDrawerProps) => {
+  const { t } = useTranslation();
+  const { projectName } = useCurrentProject();
+
+  const {
+    data: remediationDetail,
+    loading,
+    error,
+    run,
+    mutate
+  } = useRequest(
+    (id: string) =>
+      SqlManage.GetSqlManageRemediationV1({
+        project_name: projectName,
+        sql_manage_id: id
+      }).then((res) => {
+        if (res.data.code === ResponseCode.SUCCESS) {
+          return res.data.data;
+        }
+        throw new Error(
+          res.data?.message ?? t('sqlManagement.remediationCompare.loadFailed')
+        );
+      }),
+    {
+      manual: true
+    }
+  );
+
+  useEffect(() => {
+    if (open && sqlManageId) {
+      run(sqlManageId.toString());
+    }
+    if (!open) {
+      mutate(undefined);
+    }
+  }, [mutate, open, run, sqlManageId]);
+
+  return (
+    <BasicDrawer
+      open={open}
+      title={title}
+      showClosedIcon
+      onClose={onClose}
+      width={width}
+      maskClosable
+      destroyOnClose
+    >
+      <Spin spinning={loading}>
+        {error ? (
+          <Alert
+            type="error"
+            showIcon
+            message={t('sqlManagement.remediationCompare.loadFailed')}
+          />
+        ) : remediationDetail ? (
+          <RemediationDiffCompare data={remediationDetail} />
+        ) : (
+          <Empty />
+        )}
+      </Spin>
+    </BasicDrawer>
+  );
+};
+
+export default RemediationDetailDrawer;

--- a/packages/sqle/src/components/RemediationDetailDrawer/style.ts
+++ b/packages/sqle/src/components/RemediationDetailDrawer/style.ts
@@ -1,0 +1,129 @@
+import { styled } from '@mui/material/styles';
+
+export const RemediationDiffCompareStyleWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  .diff-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+  }
+
+  .diff-column {
+    min-width: 0;
+  }
+
+  .diff-column-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .diff-column-title {
+    margin: 0 !important;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .diff-column-audit-time {
+    flex-shrink: 0;
+    font-size: 12px;
+    line-height: 18px;
+    text-align: right;
+  }
+
+  .diff-section {
+    border-radius: 4px;
+    border: 1px solid transparent;
+    overflow: hidden;
+  }
+
+  .diff-section-optimized {
+    background-color: ${({ theme }) =>
+      theme.sharedTheme.components.basicTag.green.backgroundColor};
+    border-color: ${({ theme }) =>
+      `${theme.sharedTheme.uiToken.colorSuccess}33`};
+  }
+
+  .diff-section-new {
+    background-color: ${({ theme }) =>
+      theme.sharedTheme.uiToken.colorWarningBgHover};
+    border-color: ${({ theme }) =>
+      `${theme.sharedTheme.uiToken.colorWarning}40`};
+  }
+
+  .diff-section-unchanged {
+    background-color: ${({ theme }) =>
+      theme.sharedTheme.uiToken.colorFillTertiary};
+    border-color: transparent;
+  }
+
+  .diff-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .diff-section-header-collapsible {
+    cursor: pointer;
+    user-select: none;
+
+    &:hover {
+      opacity: 0.88;
+    }
+  }
+
+  .diff-section-header-main {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .diff-section-chevron {
+    flex-shrink: 0;
+    font-size: 12px;
+    color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextSecondary};
+  }
+
+  .diff-section-collapsed .diff-section-header {
+    padding-bottom: 8px;
+  }
+
+  .diff-section-title {
+    font-size: 13px;
+    line-height: 20px;
+    font-weight: 500;
+  }
+
+  .diff-section-count {
+    font-size: 12px;
+    line-height: 18px;
+  }
+
+  .diff-section-body {
+    padding: 0 12px 12px;
+  }
+
+  .diff-section-body-standalone {
+    padding: 12px;
+  }
+
+  .diff-item {
+    border-radius: 4px;
+    padding: 4px 0;
+    min-width: 0;
+  }
+
+  .diff-item-optimized {
+    padding: 4px 8px;
+    background-color: ${({ theme }) =>
+      theme.sharedTheme.components.basicTag.green.backgroundColor};
+  }
+`;

--- a/packages/sqle/src/components/ReportDrawer/index.tsx
+++ b/packages/sqle/src/components/ReportDrawer/index.tsx
@@ -77,8 +77,13 @@ const ReportDrawer = ({
                             }-${index}`}
                             auditResult={{
                               level: item?.level ?? '',
-                              message: item?.message ?? ''
+                              message: item?.message ?? '',
+                              rule_name: item?.rule_name ?? '',
+                              desc: item?.desc ?? '',
+                              i18n_audit_result_info:
+                                item?.i18n_audit_result_info
                             }}
+                            displayMode="ruleDesc"
                             isRuleDeleted={item.isRuleDeleted}
                           />
                         );
@@ -92,8 +97,12 @@ const ReportDrawer = ({
                           auditResult={{
                             level: item?.level ?? '',
                             message: item?.message ?? '',
-                            annotation: item.annotation ?? ''
+                            rule_name: item?.rule_name ?? '',
+                            desc: item?.desc ?? '',
+                            annotation: item.annotation ?? '',
+                            i18n_audit_result_info: item?.i18n_audit_result_info
                           }}
+                          displayMode="ruleDesc"
                           showAnnotation
                           moreBtnLink={
                             item?.rule_name && item?.db_type

--- a/packages/sqle/src/components/ReportDrawer/index.type.ts
+++ b/packages/sqle/src/components/ReportDrawer/index.type.ts
@@ -1,9 +1,8 @@
-import { IAuditResult } from '@actiontech/shared/lib/api/sqle/service/common';
 import { ReactNode } from 'react';
+import { IAuditResultWithExtra } from '../AuditResultMessage/index.type';
 
-export type IAuditResultItem = IAuditResult & {
+export type IAuditResultItem = IAuditResultWithExtra & {
   isRuleDeleted?: boolean;
-  annotation?: string;
 };
 
 export type TypeData = {

--- a/packages/sqle/src/data/EmitterKey.ts
+++ b/packages/sqle/src/data/EmitterKey.ts
@@ -30,6 +30,7 @@ enum EmitterKey {
   Refresh_Sql_Management_Conf_Overview_List = 'Refresh_Sql_Management_Conf_Overview_List',
   Refresh_Sql_Management_Conf_Detail_Sql_List = 'Refresh_Sql_Management_Conf_Detail_Sql_List',
   Export_Sql_Management_Conf_Detail_Sql_List = 'Export_Sql_Management_Conf_Detail_Sql_List',
+  Export_Sql_Management_Conf_Detail_Remediation = 'Export_Sql_Management_Conf_Detail_Remediation',
 
   Refresh_Sql_management_Exception_List = 'Refresh_Sql_management_Exception_List',
 

--- a/packages/sqle/src/data/ModalName.ts
+++ b/packages/sqle/src/data/ModalName.ts
@@ -15,6 +15,7 @@ export enum ModalName {
   Assignment_Member_Batch = 'Assignment_Member_Batch',
   Change_Status_Single = 'Change_Status_Single',
   View_Audit_Result_Drawer = 'View_Audit_Result_Drawer',
+  View_Remediation_Detail_Drawer = 'View_Remediation_Detail_Drawer',
   Change_SQL_Priority = 'Change_SQL_Priority',
 
   // IDE plugin audit

--- a/packages/sqle/src/locale/en-US/managementConf.ts
+++ b/packages/sqle/src/locale/en-US/managementConf.ts
@@ -108,9 +108,17 @@ export default {
     title: '{{instanceName}} intelligent scan details',
     staticScanTypes: 'Static scan',
     export: 'Export',
+    exportReport: 'Export report',
+    exportScanTaskReport: 'Export scan task report',
+    exportRemediationReport: 'Export SQL remediation report',
+    exportDataSourceRemediationReport: 'Export data source remediation report',
     auditImmediately: 'Audit immediately',
     auditImmediatelySuccessTips: 'Audit successfully',
     exportTips: 'Exporting scan task details',
+    remediationExport: 'SQL remediation',
+    remediationExportTips: 'Exporting SQL management remediation report',
+    remediationExportSuccessTips:
+      'Export SQL management remediation report successfully',
     overview: {
       title: 'Overview',
       column: {
@@ -156,8 +164,8 @@ export default {
         occurrenceCount: 'Occurrence count',
         status: 'Status',
         auditStatus: 'Audit status',
-        auditResult: 'Audit result',
-        auditResultTooltip: 'Shows the latest audit result',
+        firstAuditResult: 'Initial audit result',
+        currentAuditResult: 'Current audit result',
         audited: 'Audited',
         explanation: {
           text: 'Explanation',

--- a/packages/sqle/src/locale/en-US/sqlManagement.ts
+++ b/packages/sqle/src/locale/en-US/sqlManagement.ts
@@ -3,9 +3,18 @@ export default {
   pageTitle: 'SQL management',
   pageHeader: {
     action: {
-      export: 'Export',
+      exportReport: 'Export Report',
+      export: 'Export SQL Management Report',
       exporting: 'Exporting file',
-      exportSuccessTips: 'Export file successfully'
+      exportSuccessTips: 'Export file successfully',
+      exportFailedTips: 'Export file failed',
+      remediationExportCurrentProject:
+        'Export Current Project SQL Remediation Report',
+      remediationExportAllProjects:
+        'Export All Projects SQL Remediation Report',
+      remediationExporting: 'Exporting SQL management remediation report',
+      remediationExportSuccessTips:
+        'Export SQL management remediation report successfully'
     }
   },
   statistics: {
@@ -52,13 +61,33 @@ export default {
       highPriority: 'High priority',
       lowPriority: 'Low priority',
       auditResult: 'Audit result',
+      firstAuditResult: 'Initial audit result',
+      currentAuditResult: 'Current audit result',
+      viewAuditResultCompare: 'View audit result comparison',
+      viewFirstAuditResultDetail: 'View audit result comparison',
+      viewCurrentAuditResultDetail: 'View audit result comparison',
       firstOccurrence: 'First occurrence time',
       lastOccurrence: 'Last occurrence time',
       occurrenceCount: 'Occurrence count',
       personInCharge: 'Person in charge',
       status: 'Status',
+      remediationStatus: 'Remediation status',
       comment: 'Comment',
       endpoints: 'Endpoint info'
+    },
+    remediationStatus: {
+      resolved: 'Resolved',
+      partially_fixed: 'Partially fixed',
+      unchanged: 'Unchanged',
+      deteriorated: 'Deteriorated',
+      newly_discovered: 'Newly discovered',
+      no_remediation_needed: 'No remediation needed'
+    },
+    remediationStatusDisplay: {
+      fully_resolved: 'Fully remediated',
+      partially_fixed: 'Partially remediated',
+      pending_remediation: 'Not yet remediated',
+      no_remediation_needed: 'No remediation needed'
     },
     filter: {
       time: 'Time range',
@@ -90,5 +119,18 @@ export default {
     statusReport: {
       title: 'SQL audit result'
     }
+  },
+  remediationCompare: {
+    tab: 'Remediation compare',
+    drawerTitle: 'Remediation status details',
+    loadFailed: 'Failed to load remediation details. Please try again later.',
+    firstAuditMissing:
+      'No first audit snapshot is available. The latest result is shown as newly discovered issues.',
+    firstAuditResult: 'First audit result',
+    latestAuditResult: 'Latest audit result',
+    auditTime: 'Audit time: {{time}}',
+    diffSectionOptimized: 'Optimized',
+    diffSectionUnchanged: 'Unchanged',
+    diffSectionNew: 'New'
   }
 };

--- a/packages/sqle/src/locale/zh-CN/managementConf.ts
+++ b/packages/sqle/src/locale/zh-CN/managementConf.ts
@@ -104,9 +104,16 @@ export default {
     title: '{{instanceName}} 智能扫描详情',
     staticScanTypes: '静态扫描',
     export: '导出',
+    exportReport: '导出报表',
+    exportScanTaskReport: '导出扫描任务报表',
+    exportRemediationReport: '导出SQL管控整改报表',
+    exportDataSourceRemediationReport: '导出该数据源整改报表',
     auditImmediately: '立即审核',
     auditImmediatelySuccessTips: '审核成功',
     exportTips: '正在导出扫描任务详情',
+    remediationExport: 'SQL 管控整改',
+    remediationExportTips: '正在导出 SQL 管控整改报表',
+    remediationExportSuccessTips: 'SQL 管控整改报表导出成功',
     overview: {
       title: '概览',
       column: {
@@ -152,8 +159,8 @@ export default {
         occurrenceCount: '出现次数',
         status: '状态',
         auditStatus: '审核状态',
-        auditResult: '审核结果',
-        auditResultTooltip: '展示最新的审核结果',
+        firstAuditResult: '最初审核结果',
+        currentAuditResult: '当前审核结果',
         audited: '已审核',
         explanation: {
           text: '说明',

--- a/packages/sqle/src/locale/zh-CN/sqlManagement.ts
+++ b/packages/sqle/src/locale/zh-CN/sqlManagement.ts
@@ -3,9 +3,15 @@ export default {
   pageTitle: 'SQL管控',
   pageHeader: {
     action: {
-      export: '导出',
+      exportReport: '导出报表',
+      export: '导出 SQL管控报表',
       exporting: '正在导出文件',
-      exportSuccessTips: '导出文件成功'
+      exportSuccessTips: '导出文件成功',
+      exportFailedTips: '导出文件失败',
+      remediationExportCurrentProject: '导出当前项目SQL整改报表',
+      remediationExportAllProjects: '导出所有项目SQL整改报表',
+      remediationExporting: '正在导出 SQL 管控整改报表',
+      remediationExportSuccessTips: 'SQL 管控整改报表导出成功'
     }
   },
   statistics: {
@@ -58,13 +64,33 @@ export default {
       highPriority: '高优先',
       lowPriority: '低优先',
       auditResult: '审核结果',
+      firstAuditResult: '最初审核结果',
+      currentAuditResult: '当前审核结果',
+      viewAuditResultCompare: '查看审核结果对比',
+      viewFirstAuditResultDetail: '查看审核结果对比',
+      viewCurrentAuditResultDetail: '查看审核结果对比',
       firstOccurrence: '初次出现时间',
       lastOccurrence: '最后一次出现时间',
       occurrenceCount: '出现数量',
       personInCharge: '负责人',
       status: '状态',
+      remediationStatus: '整改状态',
       comment: '备注',
       endpoints: '端点信息'
+    },
+    remediationStatus: {
+      resolved: '已整改',
+      partially_fixed: '部分整改',
+      unchanged: '未变化',
+      deteriorated: '恶化',
+      newly_discovered: '新发现',
+      no_remediation_needed: '无需整改'
+    },
+    remediationStatusDisplay: {
+      fully_resolved: '完全整改',
+      partially_fixed: '部分整改',
+      pending_remediation: '尚未整改',
+      no_remediation_needed: '无需整改'
     },
     filter: {
       time: '时间范围',
@@ -96,5 +122,17 @@ export default {
     statusReport: {
       title: 'SQL审核结果'
     }
+  },
+  remediationCompare: {
+    tab: '整改对比',
+    drawerTitle: '整改状态详情',
+    loadFailed: '整改详情加载失败，请稍后重试。',
+    firstAuditMissing: '无最初审核快照，当前按最末次结果展示新发现问题。',
+    firstAuditResult: '最初审核结果',
+    latestAuditResult: '当前审核结果',
+    auditTime: '审核时间：{{time}}',
+    diffSectionOptimized: '已优化',
+    diffSectionUnchanged: '未变动',
+    diffSectionNew: '新增'
   }
 };

--- a/packages/sqle/src/page/SqlAnalyze/ManagementConf/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAnalyze/ManagementConf/__snapshots__/index.test.tsx.snap
@@ -50,6 +50,20 @@ exports[`SqlAnalyze/ManagementConfAnalyze should get analyze data from origin 1`
                     SQL解析
                   </div>
                 </label>
+                <label
+                  class="ant-segmented-item"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
               </div>
             </div>
           </section>
@@ -57,7 +71,7 @@ exports[`SqlAnalyze/ManagementConfAnalyze should get analyze data from origin 1`
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
@@ -316,13 +330,27 @@ exports[`SqlAnalyze/ManagementConfAnalyze should get analyze data from origin 2`
                   />
                   <div
                     class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item ant-segmented-item-selected"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
                     title="global_configuration_ldap表"
                   >
                     global_configuration_ldap表
                   </div>
                 </label>
                 <label
-                  class="ant-segmented-item ant-segmented-item-selected"
+                  class="ant-segmented-item"
                 >
                   <input
                     class="ant-segmented-item-input"
@@ -342,11 +370,10 @@ exports[`SqlAnalyze/ManagementConfAnalyze should get analyze data from origin 2`
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
-                hidden=""
               >
                 <div
                   class="ant-space-item"
@@ -2669,6 +2696,7 @@ exports[`SqlAnalyze/ManagementConfAnalyze should get analyze data from origin 2`
               </div>
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
+                hidden=""
               >
                 <div
                   class="ant-space-item"

--- a/packages/sqle/src/page/SqlAnalyze/ManagementConf/index.test.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/ManagementConf/index.test.tsx
@@ -14,9 +14,9 @@ import {
 } from '@actiontech/shared/lib/testUtil/common';
 import instance_audit_plan from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan';
 
-jest.mock('react-router', () => {
+jest.mock('react-router-dom', () => {
   return {
-    ...jest.requireActual('react-router'),
+    ...jest.requireActual('react-router-dom'),
     useParams: jest.fn()
   };
 });

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/SqlAnalyze.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/SqlAnalyze.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import React, { useMemo, useState } from 'react';
-import { Spin } from 'antd';
+import { Alert, Card, Spin } from 'antd';
 import { PageLayoutHasFixedHeaderStyleWrapper } from '@actiontech/shared/lib/styleWrapper/element';
 import {
   EmptyBox,
@@ -13,6 +13,7 @@ import { SqlAnalyzeContStyleWrapper, SqlContStyleWrapper } from './style';
 import useTableSchema from './useTableSchema';
 import useSQLExecPlan from './useSQLExecPlan';
 import { SqlAnalyzeProps } from '.';
+import RemediationDiffCompare from '../../../components/RemediationDetailDrawer/RemediationDiffCompare';
 
 const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
   const { t } = useTranslation();
@@ -22,6 +23,8 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
     errorMessage,
     loading = false,
     performanceStatistics,
+    remediationCompare,
+    remediationLoadFailed = false,
     errorType = 'error'
   } = props;
 
@@ -50,9 +53,21 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
         tableMetas?.table_meta_items.length
       )
     ) {
-      return [{ label: t('sqlAnalyze.sqlExplain'), value: 'sql' }];
+      return [
+        { label: t('sqlAnalyze.sqlExplain'), value: 'sql' },
+        {
+          label: t('sqlManagement.remediationCompare.tab'),
+          value: 'remediation'
+        }
+      ];
     }
-    return [{ label: t('sqlAnalyze.sqlExplain'), value: 'sql' }].concat(
+    return [
+      { label: t('sqlAnalyze.sqlExplain'), value: 'sql' },
+      {
+        label: t('sqlManagement.remediationCompare.tab'),
+        value: 'remediation'
+      }
+    ].concat(
       (tableMetas?.table_meta_items ?? []).map((table) => {
         return {
           label: t('sqlAnalyze.tableTitle', {
@@ -86,6 +101,21 @@ const SqlAnalyze: React.FC<SqlAnalyzeProps> = (props) => {
                     ...sqlExplain,
                     ...performanceStatistics
                   })}
+                {tabStatus === 'remediation' && (
+                  <Card title={t('sqlManagement.remediationCompare.tab')}>
+                    {remediationLoadFailed ? (
+                      <Alert
+                        type="error"
+                        showIcon
+                        message={t(
+                          'sqlManagement.remediationCompare.loadFailed'
+                        )}
+                      />
+                    ) : (
+                      <RemediationDiffCompare data={remediationCompare} />
+                    )}
+                  </Card>
+                )}
                 {tableMetas?.table_meta_items?.map((table) => {
                   return (
                     <React.Fragment key={table.name}>

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/index.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/index.tsx
@@ -2,6 +2,7 @@ import { ResultStatusType } from 'antd/es/result';
 import SqlAnalyze from './SqlAnalyze';
 import {
   IPerformanceStatistics,
+  ISqlManageRemediation,
   ISQLExplain,
   ITableMeta,
   ITableMetas
@@ -13,6 +14,8 @@ export type SqlAnalyzeProps = {
   tableMetas?: ITableMetas;
   sqlExplain?: ISQLExplain;
   performanceStatistics?: IPerformanceStatistics;
+  remediationCompare?: ISqlManageRemediation;
+  remediationLoadFailed?: boolean;
   loading?: boolean;
 };
 

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/style.ts
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/style.ts
@@ -84,4 +84,40 @@ export const SqlContStyleWrapper = styled('section')`
       line-height: 28px;
     }
   }
+
+  .remediation-compare-wrapper {
+    padding: 24px 40px;
+
+    .remediation-section-space {
+      width: 100%;
+    }
+
+    .remediation-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .remediation-title {
+      margin-bottom: 0;
+    }
+
+    .remediation-columns,
+    .remediation-diff-columns {
+      display: grid;
+      grid-column-gap: 16px;
+    }
+
+    .remediation-columns {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .remediation-diff-columns {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .ant-list-item {
+      align-items: flex-start;
+    }
+  }
 `;

--- a/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/test/__snapshots__/SqlAnalyze.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAnalyze/SqlAnalyze/test/__snapshots__/SqlAnalyze.test.tsx.snap
@@ -51,6 +51,20 @@ exports[`SqlAnalyze/Global-SqlAnalyze render snap when data is empty 1`] = `
                       SQL解析
                     </div>
                   </label>
+                  <label
+                    class="ant-segmented-item"
+                  >
+                    <input
+                      class="ant-segmented-item-input"
+                      type="radio"
+                    />
+                    <div
+                      class="ant-segmented-item-label"
+                      title="整改对比"
+                    >
+                      整改对比
+                    </div>
+                  </label>
                 </div>
               </div>
             </section>
@@ -58,7 +72,7 @@ exports[`SqlAnalyze/Global-SqlAnalyze render snap when data is empty 1`] = `
               class="tab-cont-wrapper"
             >
               <section
-                class="css-nzcwff"
+                class="css-15cja80"
               >
                 <div
                   class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
@@ -334,6 +348,20 @@ exports[`SqlAnalyze/Global-SqlAnalyze render snap when data is loading 1`] = `
                       SQL解析
                     </div>
                   </label>
+                  <label
+                    class="ant-segmented-item"
+                  >
+                    <input
+                      class="ant-segmented-item-input"
+                      type="radio"
+                    />
+                    <div
+                      class="ant-segmented-item-label"
+                      title="整改对比"
+                    >
+                      整改对比
+                    </div>
+                  </label>
                 </div>
               </div>
             </section>
@@ -341,7 +369,7 @@ exports[`SqlAnalyze/Global-SqlAnalyze render snap when data is loading 1`] = `
               class="tab-cont-wrapper"
             >
               <section
-                class="css-nzcwff"
+                class="css-15cja80"
               >
                 <div
                   class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
@@ -1148,6 +1176,20 @@ exports[`SqlAnalyze/Global-SqlAnalyze render snap when have data 1`] = `
                     />
                     <div
                       class="ant-segmented-item-label"
+                      title="整改对比"
+                    >
+                      整改对比
+                    </div>
+                  </label>
+                  <label
+                    class="ant-segmented-item"
+                  >
+                    <input
+                      class="ant-segmented-item-input"
+                      type="radio"
+                    />
+                    <div
+                      class="ant-segmented-item-label"
                       title="global_configuration_ldap表"
                     >
                       global_configuration_ldap表
@@ -1174,7 +1216,7 @@ exports[`SqlAnalyze/Global-SqlAnalyze render snap when have data 1`] = `
               class="tab-cont-wrapper"
             >
               <section
-                class="css-nzcwff"
+                class="css-15cja80"
               >
                 <div
                   class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"

--- a/packages/sqle/src/page/SqlAnalyze/SqlManage/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAnalyze/SqlManage/__snapshots__/index.test.tsx.snap
@@ -74,6 +74,20 @@ exports[`SqlAnalyze/SQLManage should get analyze data from origin 1`] = `
                     SQL解析
                   </div>
                 </label>
+                <label
+                  class="ant-segmented-item"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
               </div>
             </div>
           </section>
@@ -81,7 +95,7 @@ exports[`SqlAnalyze/SQLManage should get analyze data from origin 1`] = `
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
@@ -340,6 +354,20 @@ exports[`SqlAnalyze/SQLManage should get analyze data from origin 2`] = `
                   />
                   <div
                     class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
                     title="global_configuration_ldap表"
                   >
                     global_configuration_ldap表
@@ -366,7 +394,7 @@ exports[`SqlAnalyze/SQLManage should get analyze data from origin 2`] = `
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
@@ -6490,13 +6518,27 @@ exports[`SqlAnalyze/SQLManage should get analyze data from origin 3`] = `
                   />
                   <div
                     class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item ant-segmented-item-selected"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
                     title="global_configuration_ldap表"
                   >
                     global_configuration_ldap表
                   </div>
                 </label>
                 <label
-                  class="ant-segmented-item ant-segmented-item-selected"
+                  class="ant-segmented-item"
                 >
                   <input
                     class="ant-segmented-item-input"
@@ -6516,11 +6558,10 @@ exports[`SqlAnalyze/SQLManage should get analyze data from origin 3`] = `
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
-                hidden=""
               >
                 <div
                   class="ant-space-item"
@@ -8843,6 +8884,7 @@ exports[`SqlAnalyze/SQLManage should get analyze data from origin 3`] = `
               </div>
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
+                hidden=""
               >
                 <div
                   class="ant-space-item"

--- a/packages/sqle/src/page/SqlAnalyze/SqlManage/index.test.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlManage/index.test.tsx
@@ -16,9 +16,9 @@ import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 import { SQLManageSqlAnalyzeData } from '../__testData__';
 import SQLManageAnalyze from '.';
 
-jest.mock('react-router', () => {
+jest.mock('react-router-dom', () => {
   return {
-    ...jest.requireActual('react-router'),
+    ...jest.requireActual('react-router-dom'),
     useParams: jest.fn()
   };
 });
@@ -48,6 +48,9 @@ describe('SqlAnalyze/SQLManage', () => {
   const mockGetAnalyzeData = () => {
     const spy = jest.spyOn(SqlManage, 'GetSqlManageSqlAnalysisV1');
     spy.mockImplementation(() => resolveThreeSecond(SQLManageSqlAnalyzeData));
+    jest
+      .spyOn(SqlManage, 'GetSqlManageRemediationV1')
+      .mockImplementation(() => resolveThreeSecond({}));
     return spy;
   };
 

--- a/packages/sqle/src/page/SqlAnalyze/SqlManage/index.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/SqlManage/index.tsx
@@ -8,6 +8,7 @@ import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 import { SQLManageAnalyzeUrlParams } from './index.type';
 import {
   IPerformanceStatistics,
+  ISqlManageRemediation,
   ISQLExplain,
   ITableMetas
 } from '@actiontech/shared/lib/api/sqle/service/common';
@@ -24,6 +25,10 @@ const SQLManageAnalyze = () => {
   const [tableMetas, setTableMetas] = useState<ITableMetas>();
   const [performanceStatistics, setPerformancesStatistics] =
     useState<IPerformanceStatistics>();
+  const [remediationCompare, setRemediationCompare] =
+    useState<ISqlManageRemediation>();
+  const [remediationLoadFailed, setRemediationLoadFailed] =
+    useState<boolean>(false);
   const [
     loading,
     { setTrue: startGetSqlAnalyze, setFalse: getSqlAnalyzeFinish }
@@ -33,22 +38,55 @@ const SQLManageAnalyze = () => {
   const getSqlAnalyze = useCallback(async () => {
     startGetSqlAnalyze();
     try {
-      const res = await SqlManage.GetSqlManageSqlAnalysisV1({
-        sql_manage_id: urlParams.sqlManageId ?? '',
-        project_name: projectName
-      });
-      if (res.data.code === ResponseCode.SUCCESS) {
+      const [analysisResult, remediationResult] = await Promise.allSettled([
+        SqlManage.GetSqlManageSqlAnalysisV1({
+          sql_manage_id: urlParams.sqlManageId ?? '',
+          project_name: projectName
+        }),
+        SqlManage.GetSqlManageRemediationV1({
+          sql_manage_id: urlParams.sqlManageId ?? '',
+          project_name: projectName
+        })
+      ]);
+
+      if (
+        analysisResult.status === 'fulfilled' &&
+        analysisResult.value.data.code === ResponseCode.SUCCESS
+      ) {
         setErrorMessage('');
-        setSqlExplain(res.data.data?.sql_explain);
-        setTableMetas(res.data.data?.table_metas);
-        setPerformancesStatistics(res.data.data?.performance_statistics);
+        setSqlExplain(analysisResult.value.data.data?.sql_explain);
+        setTableMetas(analysisResult.value.data.data?.table_metas);
+        setPerformancesStatistics(
+          analysisResult.value.data.data?.performance_statistics
+        );
       } else {
-        if (res.data.code === ResponseCode.NotSupportDML) {
-          setErrorType('info');
+        setSqlExplain(undefined);
+        setTableMetas(undefined);
+        setPerformancesStatistics(undefined);
+        if (analysisResult.status === 'fulfilled') {
+          if (analysisResult.value.data.code === ResponseCode.NotSupportDML) {
+            setErrorType('info');
+          } else {
+            setErrorType('error');
+          }
+          setErrorMessage(analysisResult.value.data.message ?? '');
         } else {
           setErrorType('error');
+          setErrorMessage(
+            (analysisResult.reason as { message?: string })?.message ?? ''
+          );
         }
-        setErrorMessage(res.data.message ?? '');
+      }
+
+      if (
+        remediationResult.status === 'fulfilled' &&
+        remediationResult.value.data.code === ResponseCode.SUCCESS
+      ) {
+        setRemediationCompare(remediationResult.value.data.data);
+        setRemediationLoadFailed(false);
+      } else {
+        setRemediationCompare(undefined);
+        setRemediationLoadFailed(true);
       }
     } finally {
       getSqlAnalyzeFinish();
@@ -71,6 +109,8 @@ const SQLManageAnalyze = () => {
       sqlExplain={sqlExplain}
       errorMessage={errorMessage}
       performanceStatistics={performanceStatistics}
+      remediationCompare={remediationCompare}
+      remediationLoadFailed={remediationLoadFailed}
       loading={loading}
     />
   );

--- a/packages/sqle/src/page/SqlAnalyze/Workflow/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlAnalyze/Workflow/__snapshots__/index.test.tsx.snap
@@ -74,6 +74,20 @@ exports[`SqlAnalyze/Workflow should get analyze data from origin 1`] = `
                     SQL解析
                   </div>
                 </label>
+                <label
+                  class="ant-segmented-item"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
               </div>
             </div>
           </section>
@@ -81,7 +95,7 @@ exports[`SqlAnalyze/Workflow should get analyze data from origin 1`] = `
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
@@ -340,6 +354,20 @@ exports[`SqlAnalyze/Workflow should get analyze data from origin 2`] = `
                   />
                   <div
                     class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
                     title="global_configuration_ldap表"
                   >
                     global_configuration_ldap表
@@ -366,7 +394,7 @@ exports[`SqlAnalyze/Workflow should get analyze data from origin 2`] = `
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
@@ -6490,13 +6518,27 @@ exports[`SqlAnalyze/Workflow should get analyze data from origin 3`] = `
                   />
                   <div
                     class="ant-segmented-item-label"
+                    title="整改对比"
+                  >
+                    整改对比
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item ant-segmented-item-selected"
+                >
+                  <input
+                    class="ant-segmented-item-input"
+                    type="radio"
+                  />
+                  <div
+                    class="ant-segmented-item-label"
                     title="global_configuration_ldap表"
                   >
                     global_configuration_ldap表
                   </div>
                 </label>
                 <label
-                  class="ant-segmented-item ant-segmented-item-selected"
+                  class="ant-segmented-item"
                 >
                   <input
                     class="ant-segmented-item-input"
@@ -6516,11 +6558,10 @@ exports[`SqlAnalyze/Workflow should get analyze data from origin 3`] = `
             class="tab-cont-wrapper"
           >
             <section
-              class="css-nzcwff"
+              class="css-15cja80"
             >
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
-                hidden=""
               >
                 <div
                   class="ant-space-item"
@@ -8843,6 +8884,7 @@ exports[`SqlAnalyze/Workflow should get analyze data from origin 3`] = `
               </div>
               <div
                 class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical full-width-element"
+                hidden=""
               >
                 <div
                   class="ant-space-item"

--- a/packages/sqle/src/page/SqlAnalyze/Workflow/index.test.tsx
+++ b/packages/sqle/src/page/SqlAnalyze/Workflow/index.test.tsx
@@ -17,9 +17,9 @@ import { WorkflowSqlAnalyzeData } from '../__testData__';
 
 import WorkflowSqlAnalyze from '.';
 
-jest.mock('react-router', () => {
+jest.mock('react-router-dom', () => {
   return {
-    ...jest.requireActual('react-router'),
+    ...jest.requireActual('react-router-dom'),
     useParams: jest.fn()
   };
 });

--- a/packages/sqle/src/page/SqlManagement/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`page/SqlManagement render sql management page 1`] = `
               class="extra"
             >
               <button
-                class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
+                class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-dropdown-trigger basic-button-wrapper css-geipcv"
                 type="button"
               >
                 <span
@@ -40,7 +40,7 @@ exports[`page/SqlManagement render sql management page 1`] = `
                   </svg>
                 </span>
                 <span>
-                  导出
+                  导出报表
                 </span>
               </button>
             </div>
@@ -470,6 +470,9 @@ exports[`page/SqlManagement render sql management page 1`] = `
                           <col
                             style="width: 200px;"
                           />
+                          <col
+                            style="width: 200px;"
+                          />
                           <col />
                           <col />
                           <col />
@@ -535,7 +538,13 @@ exports[`page/SqlManagement render sql management page 1`] = `
                               class="ant-table-cell"
                               scope="col"
                             >
-                              审核结果
+                              最初审核结果
+                            </th>
+                            <th
+                              class="ant-table-cell"
+                              scope="col"
+                            >
+                              当前审核结果
                             </th>
                             <th
                               class="ant-table-cell"
@@ -713,13 +722,22 @@ exports[`page/SqlManagement render sql management page 1`] = `
                                  
                               </div>
                             </td>
+                            <td
+                              style="padding: 0px; border: 0px; height: 0px;"
+                            >
+                              <div
+                                style="height: 0px; overflow: hidden;"
+                              >
+                                 
+                              </div>
+                            </td>
                           </tr>
                           <tr
                             class="ant-table-placeholder"
                           >
                             <td
                               class="ant-table-cell"
-                              colspan="13"
+                              colspan="14"
                             >
                               <div
                                 class="ant-table-expanded-row-fixed"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/RemediationDetailDrawer/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/RemediationDetailDrawer/index.tsx
@@ -1,0 +1,27 @@
+import RemediationDetailDrawer from '../../../../../../components/RemediationDetailDrawer';
+import { ModalName } from '../../../../../../data/ModalName';
+import useSqlManagementRedux from '../../hooks/useSqlManagementRedux';
+
+const RemediationDetailDrawerModal = () => {
+  const {
+    open: visible,
+    selectSqlManagement: selectedData,
+    setSelectData,
+    updateModalStatus
+  } = useSqlManagementRedux(ModalName.View_Remediation_Detail_Drawer);
+
+  const closeModal = () => {
+    updateModalStatus(ModalName.View_Remediation_Detail_Drawer, false);
+    setSelectData(null);
+  };
+
+  return (
+    <RemediationDetailDrawer
+      open={visible}
+      onClose={closeModal}
+      sqlManageId={selectedData?.id}
+    />
+  );
+};
+
+export default RemediationDetailDrawerModal;

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/StatusDrawer/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/StatusDrawer/__snapshots__/index.test.tsx.snap
@@ -38,7 +38,28 @@ exports[`page/SqlManagement/StatusDrawer close modal by click close button 1`] =
                 <div
                   class="ant-drawer-title"
                 >
-                  SQL审核结果
+                  <div
+                    class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical"
+                  >
+                    <div
+                      class="ant-space-item"
+                      style="margin-bottom: 0px;"
+                    >
+                      <span>
+                        当前审核结果
+                      </span>
+                    </div>
+                    <div
+                      class="ant-space-item"
+                    >
+                      <span
+                        class="ant-typography ant-typography-secondary css-dev-only-do-not-override-txh9fw"
+                        style="font-size: 12px; font-weight: 400;"
+                      >
+                        2024-01-03 11:28:34
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div
@@ -254,7 +275,28 @@ exports[`page/SqlManagement/StatusDrawer render empty status drawer info 1`] = `
                 <div
                   class="ant-drawer-title"
                 >
-                  SQL审核结果
+                  <div
+                    class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical"
+                  >
+                    <div
+                      class="ant-space-item"
+                      style="margin-bottom: 0px;"
+                    >
+                      <span>
+                        当前审核结果
+                      </span>
+                    </div>
+                    <div
+                      class="ant-space-item"
+                    >
+                      <span
+                        class="ant-typography ant-typography-secondary css-dev-only-do-not-override-txh9fw"
+                        style="font-size: 12px; font-weight: 400;"
+                      >
+                        -
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div
@@ -434,7 +476,28 @@ exports[`page/SqlManagement/StatusDrawer render status drawer info 1`] = `
                 <div
                   class="ant-drawer-title"
                 >
-                  SQL审核结果
+                  <div
+                    class="ant-space css-dev-only-do-not-override-txh9fw ant-space-vertical"
+                  >
+                    <div
+                      class="ant-space-item"
+                      style="margin-bottom: 0px;"
+                    >
+                      <span>
+                        当前审核结果
+                      </span>
+                    </div>
+                    <div
+                      class="ant-space-item"
+                    >
+                      <span
+                        class="ant-typography ant-typography-secondary css-dev-only-do-not-override-txh9fw"
+                        style="font-size: 12px; font-weight: 400;"
+                      >
+                        2024-01-03 11:28:34
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/StatusDrawer/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/StatusDrawer/index.test.tsx
@@ -77,7 +77,7 @@ describe('page/SqlManagement/StatusDrawer', () => {
       filter_rule_names: ruleNames.join(',')
     });
     expect(baseElement).toMatchSnapshot();
-    expect(screen.getByText('SQL审核结果')).toBeInTheDocument();
+    expect(screen.getByText('当前审核结果')).toBeInTheDocument();
     expect(screen.getByText('审核结果')).toBeInTheDocument();
     expect(screen.getByText('SQL语句')).toBeInTheDocument();
   });

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/StatusDrawer/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/StatusDrawer/index.tsx
@@ -1,4 +1,7 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Space, Typography } from 'antd';
+import { formatTime } from '@actiontech/shared/lib/utils/Common';
 import { ModalName } from '../../../../../../data/ModalName';
 import ReportDrawer from '../../../../../../components/ReportDrawer';
 import useSqlManagementRedux from '../../hooks/useSqlManagementRedux';
@@ -19,19 +22,34 @@ const StatusDrawer = () => {
     updateModalStatus
   } = useSqlManagementRedux(ModalName.View_Audit_Result_Drawer);
 
-  const { auditResultRuleInfo, loading } = useAuditResultRuleInfo(
-    selectedData?.audit_result ?? []
+  const auditResults = useMemo(
+    () => selectedData?.audit_result ?? [],
+    [selectedData?.audit_result]
   );
+
+  const { auditResultRuleInfo, loading } = useAuditResultRuleInfo(auditResults);
 
   const closeModal = () => {
     updateModalStatus(ModalName.View_Audit_Result_Drawer, false);
     setSelectData(null);
   };
 
+  const drawerTitle = (
+    <Space direction="vertical" size={0}>
+      <span>{t('sqlManagement.table.column.currentAuditResult')}</span>
+      <Typography.Text
+        type="secondary"
+        style={{ fontSize: 12, fontWeight: 400 }}
+      >
+        {formatTime(selectedData?.last_receive_timestamp, '-')}
+      </Typography.Text>
+    </Space>
+  );
+
   return (
     <ReportDrawer
       open={visible}
-      title={t('sqlManagement.table.statusReport.title')}
+      title={drawerTitle}
       data={{
         auditResult: auditResultRuleInfo,
         sql: selectedData?.sql ?? ''

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/index.test.tsx
@@ -53,6 +53,7 @@ describe('test init sql manage modal', () => {
           [ModalName.Assignment_Member_Batch]: false,
           [ModalName.Change_Status_Single]: false,
           [ModalName.View_Audit_Result_Drawer]: false,
+          [ModalName.View_Remediation_Detail_Drawer]: false,
           [ModalName.Change_SQL_Priority]: false
         }
       },

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/Modal/index.tsx
@@ -10,6 +10,7 @@ import EventEmitter from '../../../../../utils/EventEmitter';
 import EmitterKey from '../../../../../data/EmitterKey';
 import AddWhitelist from '../../../../Whitelist/Drawer/AddWhitelist';
 import ChangePriority from './ChangePriority';
+import RemediationDetailDrawer from './RemediationDetailDrawer';
 
 const SqlManagementModal = () => {
   const { initModalStatus } = useSqlManagementRedux();
@@ -20,6 +21,7 @@ const SqlManagementModal = () => {
       [ModalName.Assignment_Member_Batch]: false,
       [ModalName.Change_Status_Single]: false,
       [ModalName.View_Audit_Result_Drawer]: false,
+      [ModalName.View_Remediation_Detail_Drawer]: false,
       [ModalName.Change_SQL_Priority]: false
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -33,6 +35,7 @@ const SqlManagementModal = () => {
     <>
       <AssignmentSingle />
       <StatusDrawer />
+      <RemediationDetailDrawer />
       <AssignmentBatch />
       <ChangeStatus />
       <CreateSqlManagementException onCreated={onCreated} />

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
             class="extra"
           >
             <button
-              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
+              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-dropdown-trigger basic-button-wrapper css-geipcv"
               type="button"
             >
               <span
@@ -39,7 +39,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                 </svg>
               </span>
               <span>
-                导出
+                导出报表
               </span>
             </button>
           </div>
@@ -828,6 +828,9 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                         <col
                           style="width: 200px;"
                         />
+                        <col
+                          style="width: 200px;"
+                        />
                         <col />
                         <col />
                         <col />
@@ -892,7 +895,13 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                             class="ant-table-cell"
                             scope="col"
                           >
-                            审核结果
+                            最初审核结果
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            当前审核结果
                           </th>
                           <th
                             class="ant-table-cell"
@@ -1070,6 +1079,15 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                                
                             </div>
                           </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0"
@@ -1109,25 +1127,87 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="audit-result-wrapper"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                             >
                               <div
-                                class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                class="ant-space-item"
                               >
                                 <div
-                                  class="ant-space-item"
+                                  class="audit-result-wrapper"
                                 >
-                                  <svg
-                                    height="20"
-                                    viewBox="0 0 16 16"
-                                    width="20"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    <path
-                                      d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
-                                      fill="#F66074"
-                                    />
-                                  </svg>
+                                    <span
+                                      class="icon-wrapper"
+                                    >
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <div
+                                  class="audit-result-wrapper"
+                                >
+                                  <div
+                                    class="css-yzky0k"
+                                  >
+                                    <div
+                                      class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                    >
+                                      <div
+                                        class="ant-space-item"
+                                      >
+                                        <span
+                                          class="audit-level-summary-item"
+                                        >
+                                          <svg
+                                            height="20"
+                                            viewBox="0 0 16 16"
+                                            width="20"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                                              fill="#F66074"
+                                            />
+                                          </svg>
+                                          <span
+                                            class="audit-level-summary-count"
+                                          >
+                                            × 
+                                            2
+                                          </span>
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -1690,7 +1770,7 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
             class="extra"
           >
             <button
-              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
+              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-dropdown-trigger basic-button-wrapper css-geipcv"
               type="button"
             >
               <span
@@ -1708,7 +1788,7 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
                 </svg>
               </span>
               <span>
-                导出
+                导出报表
               </span>
             </button>
           </div>
@@ -2138,6 +2218,9 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
                         <col
                           style="width: 200px;"
                         />
+                        <col
+                          style="width: 200px;"
+                        />
                         <col />
                         <col />
                         <col />
@@ -2203,7 +2286,13 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
                             class="ant-table-cell"
                             scope="col"
                           >
-                            审核结果
+                            最初审核结果
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            当前审核结果
                           </th>
                           <th
                             class="ant-table-cell"
@@ -2381,13 +2470,22 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
                                
                             </div>
                           </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                         </tr>
                         <tr
                           class="ant-table-placeholder"
                         >
                           <td
                             class="ant-table-cell"
-                            colspan="13"
+                            colspan="14"
                           >
                             <div
                               class="ant-table-expanded-row-fixed"
@@ -2430,7 +2528,7 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
             class="extra"
           >
             <button
-              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
+              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-dropdown-trigger basic-button-wrapper css-geipcv"
               type="button"
             >
               <span
@@ -2448,7 +2546,7 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                 </svg>
               </span>
               <span>
-                导出
+                导出报表
               </span>
             </button>
           </div>
@@ -2877,6 +2975,9 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                         <col
                           style="width: 200px;"
                         />
+                        <col
+                          style="width: 200px;"
+                        />
                         <col />
                         <col />
                         <col />
@@ -2941,7 +3042,13 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                             scope="col"
                           >
-                            审核结果
+                            最初审核结果
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            当前审核结果
                           </th>
                           <th
                             class="ant-table-cell"
@@ -3119,6 +3226,15 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                                
                             </div>
                           </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0"
@@ -3158,25 +3274,87 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="audit-result-wrapper"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                             >
                               <div
-                                class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                class="ant-space-item"
                               >
                                 <div
-                                  class="ant-space-item"
+                                  class="audit-result-wrapper"
                                 >
-                                  <svg
-                                    height="20"
-                                    viewBox="0 0 16 16"
-                                    width="20"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    <path
-                                      d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
-                                      fill="#F66074"
-                                    />
-                                  </svg>
+                                    <span
+                                      class="icon-wrapper"
+                                    >
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <div
+                                  class="audit-result-wrapper"
+                                >
+                                  <div
+                                    class="css-yzky0k"
+                                  >
+                                    <div
+                                      class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                    >
+                                      <div
+                                        class="ant-space-item"
+                                      >
+                                        <span
+                                          class="audit-level-summary-item"
+                                        >
+                                          <svg
+                                            height="20"
+                                            viewBox="0 0 16 16"
+                                            width="20"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                                              fill="#F66074"
+                                            />
+                                          </svg>
+                                          <span
+                                            class="audit-level-summary-count"
+                                          >
+                                            × 
+                                            2
+                                          </span>
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -3515,31 +3693,79 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="audit-result-wrapper"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                             >
                               <div
-                                class=" css-1avyf41"
+                                class="ant-space-item"
                               >
-                                <span
-                                  class="icon-wrapper"
+                                <div
+                                  class="audit-result-wrapper"
                                 >
-                                  <svg
-                                    height="20"
-                                    viewBox="0 0 20 20"
-                                    width="20"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    <path
-                                      d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                      fill="#41BF9A"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="text-wrapper"
+                                    <span
+                                      class="icon-wrapper"
+                                    >
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <div
+                                  class="audit-result-wrapper"
                                 >
-                                  审核通过
-                                </span>
+                                  <div
+                                    class=" css-1avyf41"
+                                  >
+                                    <span
+                                      class="icon-wrapper"
+                                    >
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                           </td>
@@ -3907,34 +4133,87 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="audit-result-wrapper"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                             >
                               <div
-                                class=" css-1v03opz"
+                                class="ant-space-item"
                               >
                                 <div
-                                  class="css-1avyf41"
+                                  class="audit-result-wrapper"
                                 >
-                                  <span
-                                    class="icon-wrapper"
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    <svg
-                                      height="20"
-                                      viewBox="0 0 16 16"
-                                      width="20"
-                                      xmlns="http://www.w3.org/2000/svg"
+                                    <span
+                                      class="icon-wrapper"
                                     >
-                                      <path
-                                        d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
-                                        fill="#F66074"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    class="text-wrapper"
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <div
+                                  class="audit-result-wrapper"
+                                >
+                                  <div
+                                    class="css-yzky0k"
                                   >
-                                    建议UNIQUE索引名使用 IDX_UK_表名_字段名
-                                  </span>
+                                    <div
+                                      class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                    >
+                                      <div
+                                        class="ant-space-item"
+                                      >
+                                        <span
+                                          class="audit-level-summary-item"
+                                        >
+                                          <svg
+                                            height="20"
+                                            viewBox="0 0 16 16"
+                                            width="20"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                                              fill="#F66074"
+                                            />
+                                          </svg>
+                                          <span
+                                            class="audit-level-summary-count"
+                                          >
+                                            × 
+                                            1
+                                          </span>
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -4268,34 +4547,87 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="audit-result-wrapper"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                             >
                               <div
-                                class=" css-1v03opz"
+                                class="ant-space-item"
                               >
                                 <div
-                                  class="css-1avyf41"
+                                  class="audit-result-wrapper"
                                 >
-                                  <span
-                                    class="icon-wrapper"
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    <svg
-                                      height="20"
-                                      viewBox="0 0 16 16"
-                                      width="20"
-                                      xmlns="http://www.w3.org/2000/svg"
+                                    <span
+                                      class="icon-wrapper"
                                     >
-                                      <path
-                                        d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
-                                        fill="#F66074"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    class="text-wrapper"
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <div
+                                  class="audit-result-wrapper"
+                                >
+                                  <div
+                                    class="css-yzky0k"
                                   >
-                                    建议UNIQUE索引名使用 IDX_UK_表名_字段名
-                                  </span>
+                                    <div
+                                      class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                    >
+                                      <div
+                                        class="ant-space-item"
+                                      >
+                                        <span
+                                          class="audit-level-summary-item"
+                                        >
+                                          <svg
+                                            height="20"
+                                            viewBox="0 0 16 16"
+                                            width="20"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                                              fill="#F66074"
+                                            />
+                                          </svg>
+                                          <span
+                                            class="audit-level-summary-count"
+                                          >
+                                            × 
+                                            1
+                                          </span>
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -4554,34 +4886,78 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="audit-result-wrapper"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                             >
                               <div
-                                class=" css-1v03opz"
+                                class="ant-space-item"
                               >
                                 <div
-                                  class="css-1avyf41"
+                                  class="audit-result-wrapper"
                                 >
-                                  <span
-                                    class="icon-wrapper"
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    <svg
-                                      height="20"
-                                      viewBox="0 0 20 20"
-                                      width="20"
-                                      xmlns="http://www.w3.org/2000/svg"
+                                    <span
+                                      class="icon-wrapper"
                                     >
-                                      <path
-                                        d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                        fill="#41BF9A"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    class="text-wrapper"
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <div
+                                  class="audit-result-wrapper"
+                                >
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    白名单
-                                  </span>
+                                    <span
+                                      class="icon-wrapper"
+                                    >
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -4946,7 +5322,7 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
             class="extra"
           >
             <button
-              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
+              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-dropdown-trigger basic-button-wrapper css-geipcv"
               type="button"
             >
               <span
@@ -4964,7 +5340,7 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                 </svg>
               </span>
               <span>
-                导出
+                导出报表
               </span>
             </button>
           </div>
@@ -5351,6 +5727,9 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                         <col
                           style="width: 200px;"
                         />
+                        <col
+                          style="width: 200px;"
+                        />
                         <col />
                         <col />
                         <col />
@@ -5415,7 +5794,13 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                             class="ant-table-cell"
                             scope="col"
                           >
-                            审核结果
+                            最初审核结果
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            当前审核结果
                           </th>
                           <th
                             class="ant-table-cell"
@@ -5593,6 +5978,15 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                                
                             </div>
                           </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                         </tr>
                         <tr
                           class="ant-table-row ant-table-row-level-0"
@@ -5632,25 +6026,87 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="audit-result-wrapper"
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                             >
                               <div
-                                class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                class="ant-space-item"
                               >
                                 <div
-                                  class="ant-space-item"
+                                  class="audit-result-wrapper"
                                 >
-                                  <svg
-                                    height="20"
-                                    viewBox="0 0 16 16"
-                                    width="20"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    class=" css-1avyf41"
                                   >
-                                    <path
-                                      d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
-                                      fill="#F66074"
-                                    />
-                                  </svg>
+                                    <span
+                                      class="icon-wrapper"
+                                    >
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 20 20"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                          fill="#41BF9A"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      class="text-wrapper"
+                                    >
+                                      审核通过
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <div
+                                  class="audit-result-wrapper"
+                                >
+                                  <div
+                                    class="css-yzky0k"
+                                  >
+                                    <div
+                                      class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                    >
+                                      <div
+                                        class="ant-space-item"
+                                      >
+                                        <span
+                                          class="audit-level-summary-item"
+                                        >
+                                          <svg
+                                            height="20"
+                                            viewBox="0 0 16 16"
+                                            width="20"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                                              fill="#F66074"
+                                            />
+                                          </svg>
+                                          <span
+                                            class="audit-level-summary-count"
+                                          >
+                                            × 
+                                            2
+                                          </span>
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
                             </div>

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
@@ -1126,42 +1126,7 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -3273,42 +3238,7 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -3692,82 +3622,12 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -4132,42 +3992,7 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -4546,42 +4371,7 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -4885,42 +4675,7 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -5322,7 +5077,7 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
             class="extra"
           >
             <button
-              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-dropdown-trigger basic-button-wrapper css-geipcv"
+              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
               type="button"
             >
               <span
@@ -6025,42 +5780,7 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                           <td
                             class="ant-table-cell"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                            >
-                              <div
-                                class="ant-space-item"
-                              >
-                                <div
-                                  class="audit-result-wrapper"
-                                >
-                                  <div
-                                    class=" css-1avyf41"
-                                  >
-                                    <span
-                                      class="icon-wrapper"
-                                    >
-                                      <svg
-                                        height="20"
-                                        viewBox="0 0 20 20"
-                                        width="20"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      class="text-wrapper"
-                                    >
-                                      审核通过
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
+                            -
                           </td>
                           <td
                             class="ant-table-cell"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/column.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/column.tsx
@@ -9,17 +9,20 @@ import {
 import { ModalName } from '../../../../data/ModalName';
 import { IGetSqlManageListV2Params } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.d';
 import { ISqlManage } from '@actiontech/shared/lib/api/sqle/service/common';
-import ResultIconRender from '../../../../components/AuditResultMessage/ResultIconRender';
-import AuditResultMessage from '../../../../components/AuditResultMessage';
+import AuditLevelSummary from '../../../../components/AuditResultMessage/AuditLevelSummary';
 import { Link } from 'react-router-dom';
-import { AvatarCom, EditText, SQLRenderer } from '@actiontech/shared';
+import {
+  AvatarCom,
+  EditText,
+  SQLRenderer,
+  BasicToolTips
+} from '@actiontech/shared';
 import { tooltipsCommonProps } from '@actiontech/shared/lib/components/BasicToolTips';
 import { Avatar } from 'antd';
 import StatusTag from './StatusTag';
 import { BasicTag, BasicTypographyEllipsis } from '@actiontech/shared';
 import { ACTIONTECH_TABLE_ACTION_BUTTON_WIDTH } from '@actiontech/shared/lib/components/ActiontechTable/hooks/useTableAction';
 import { SQLAuditRecordListUrlParamsKey } from './index.data';
-
 export type SqlManagementTableFilterParamType = PageInfoWithoutIndexAndSize<
   IGetSqlManageListV2Params,
   'fuzzy_search_sql_fingerprint' | 'filter_status' | 'project_name'
@@ -262,31 +265,50 @@ const SqlManagementColumn: (
       }
     },
     {
+      dataIndex: 'first_audit_result',
+      width: 200,
+      title: () => t('sqlManagement.table.column.firstAuditResult'),
+      render: (result = [], record) => {
+        if (!result || result.length === 0) {
+          return '-';
+        }
+        return (
+          <BasicToolTips
+            title={t('sqlManagement.table.column.viewAuditResultCompare')}
+          >
+            <div
+              onClick={() =>
+                openModal(ModalName.View_Remediation_Detail_Drawer, record)
+              }
+              className="audit-result-wrapper"
+            >
+              <AuditLevelSummary auditResults={result} />
+            </div>
+          </BasicToolTips>
+        );
+      }
+    },
+    {
       dataIndex: 'audit_result',
       width: 200,
-      title: () => t('sqlManagement.table.column.auditResult'),
+      title: () => t('sqlManagement.table.column.currentAuditResult'),
       render: (result = [], record) => {
+        if (!result || result.length === 0) {
+          return '-';
+        }
         return (
-          <div
-            onClick={() =>
-              openModal(ModalName.View_Audit_Result_Drawer, record)
-            }
-            className="audit-result-wrapper"
+          <BasicToolTips
+            title={t('sqlManagement.table.column.viewAuditResultCompare')}
           >
-            {result?.length > 1 ? (
-              <ResultIconRender
-                iconLevels={result.map((item) => {
-                  return item.level ?? '';
-                })}
-              />
-            ) : (
-              <AuditResultMessage
-                auditResult={
-                  Array.isArray(result) && result.length ? result[0] : {}
-                }
-              />
-            )}
-          </div>
+            <div
+              onClick={() =>
+                openModal(ModalName.View_Remediation_Detail_Drawer, record)
+              }
+              className="audit-result-wrapper"
+            >
+              <AuditLevelSummary auditResults={result} />
+            </div>
+          </BasicToolTips>
         );
       }
     },

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
@@ -1,10 +1,5 @@
-import {
-  act,
-  cleanup,
-  fireEvent,
-  screen,
-  waitFor
-} from '@testing-library/react';
+import { act, cleanup, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SQLEEIndex from '.';
 import { superRender } from '../../../../testUtils/customRender';
 import sqlManage from '../../../../testUtils/mockApi/sqlManage';
@@ -234,20 +229,14 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     const exportRequest = sqlManage.exportSqlManage();
     superRender(<SQLEEIndex />);
     expect(request).toHaveBeenCalled();
+    await act(async () => jest.advanceTimersByTime(3000));
     fireEvent.click(screen.getByText('与我相关'));
     fireEvent.click(screen.getByText('查看高优先级SQL'));
 
     expect(screen.getByText('导出报表')).toBeInTheDocument();
-    jest.useRealTimers();
-    try {
-      fireEvent.click(screen.getByText('导出报表'));
-      await waitFor(() => {
-        expect(screen.getByText('导出 SQL管控报表')).toBeInTheDocument();
-      });
-      fireEvent.click(screen.getByText('导出 SQL管控报表'));
-    } finally {
-      jest.useFakeTimers();
-    }
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(screen.getByText('导出报表'));
+    await user.click(await screen.findByText('导出 SQL管控报表'));
     expect(exportRequest).toHaveBeenCalledWith(
       {
         ...exportParams,
@@ -267,16 +256,10 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     const exportRequest = sqlManage.exportSqlManageRemediation();
     superRender(<SQLEEIndex />);
     expect(request).toHaveBeenCalled();
-    jest.useRealTimers();
-    try {
-      fireEvent.click(screen.getByText('导出报表'));
-      await waitFor(() => {
-        expect(screen.getByText('导出当前项目SQL整改报表')).toBeInTheDocument();
-      });
-      fireEvent.click(screen.getByText('导出当前项目SQL整改报表'));
-    } finally {
-      jest.useFakeTimers();
-    }
+    await act(async () => jest.advanceTimersByTime(3000));
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(screen.getByText('导出报表'));
+    await user.click(await screen.findByText('导出当前项目SQL整改报表'));
     expect(exportRequest).toHaveBeenCalledWith(
       {
         project_name: mockProjectInfo.projectName,
@@ -295,16 +278,10 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     const exportRequest = sqlManage.exportGlobalSqlManageRemediation();
     superRender(<SQLEEIndex />);
     expect(request).toHaveBeenCalled();
-    jest.useRealTimers();
-    try {
-      fireEvent.click(screen.getByText('导出报表'));
-      await waitFor(() => {
-        expect(screen.getByText('导出所有项目SQL整改报表')).toBeInTheDocument();
-      });
-      fireEvent.click(screen.getByText('导出所有项目SQL整改报表'));
-    } finally {
-      jest.useFakeTimers();
-    }
+    await act(async () => jest.advanceTimersByTime(3000));
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(screen.getByText('导出报表'));
+    await user.click(await screen.findByText('导出所有项目SQL整改报表'));
     expect(exportRequest).toHaveBeenCalledWith(
       {},
       {
@@ -627,12 +604,23 @@ describe('page/SqlManagement/SQLEEIndex', () => {
   });
 
   it('click audit result and open remediation detail drawer', async () => {
+    const rowWithFirstAudit = {
+      ...sqlManageListData.data[0],
+      first_audit_result: sqlManageListData.data[0].audit_result
+    };
     const request = sqlManage.getSqlManageList();
+    request.mockImplementation(() =>
+      createSpySuccessResponse({
+        ...sqlManageListData,
+        data: [rowWithFirstAudit]
+      })
+    );
     superRender(<SQLEEIndex />);
     expect(request).toHaveBeenCalled();
     await act(async () => jest.advanceTimersByTime(3000));
     expect(getAllBySelector('.audit-result-wrapper').length).toBe(2);
-    fireEvent.click(getAllBySelector('.audit-result-wrapper')[1]);
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(getAllBySelector('.audit-result-wrapper')[1]);
     await act(async () => jest.advanceTimersByTime(300));
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'sqlManagement/updateModalStatus',
@@ -643,17 +631,28 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     });
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'sqlManagement/setSqlManagementSelectData',
-      payload: sqlManageListData.data[0]
+      payload: rowWithFirstAudit
     });
   });
 
   it('click first audit result and open remediation detail drawer', async () => {
+    const rowWithFirstAudit = {
+      ...sqlManageListData.data[0],
+      first_audit_result: sqlManageListData.data[0].audit_result
+    };
     const request = sqlManage.getSqlManageList();
+    request.mockImplementation(() =>
+      createSpySuccessResponse({
+        ...sqlManageListData,
+        data: [rowWithFirstAudit]
+      })
+    );
     superRender(<SQLEEIndex />);
     expect(request).toHaveBeenCalled();
     await act(async () => jest.advanceTimersByTime(3000));
     expect(getAllBySelector('.audit-result-wrapper').length).toBe(2);
-    fireEvent.click(getAllBySelector('.audit-result-wrapper')[0]);
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(getAllBySelector('.audit-result-wrapper')[0]);
     await act(async () => jest.advanceTimersByTime(300));
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'sqlManagement/updateModalStatus',
@@ -664,7 +663,7 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     });
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'sqlManagement/setSqlManagementSelectData',
-      payload: sqlManageListData.data[0]
+      payload: rowWithFirstAudit
     });
   });
 });

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
@@ -1,4 +1,10 @@
-import { act, cleanup, fireEvent, screen } from '@testing-library/react';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor
+} from '@testing-library/react';
 import SQLEEIndex from '.';
 import { superRender } from '../../../../testUtils/customRender';
 import sqlManage from '../../../../testUtils/mockApi/sqlManage';
@@ -22,7 +28,8 @@ import { ModalName } from '../../../../data/ModalName';
 import { mockUseAuditPlanTypes } from '../../../../testUtils/mockRequest';
 import {
   GetSqlManageListV2FilterPriorityEnum,
-  exportSqlManageV1FilterPriorityEnum
+  exportSqlManageV1FilterPriorityEnum,
+  exportSqlManageRemediationV1ExportScopeEnum
 } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
 
 jest.mock('react-redux', () => {
@@ -230,8 +237,17 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     fireEvent.click(screen.getByText('与我相关'));
     fireEvent.click(screen.getByText('查看高优先级SQL'));
 
-    expect(screen.getByText('导出')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('导出'));
+    expect(screen.getByText('导出报表')).toBeInTheDocument();
+    jest.useRealTimers();
+    try {
+      fireEvent.click(screen.getByText('导出报表'));
+      await waitFor(() => {
+        expect(screen.getByText('导出 SQL管控报表')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('导出 SQL管控报表'));
+    } finally {
+      jest.useFakeTimers();
+    }
     expect(exportRequest).toHaveBeenCalledWith(
       {
         ...exportParams,
@@ -244,6 +260,59 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     );
     await act(async () => jest.advanceTimersByTime(3000));
     expect(screen.getByText('导出文件成功')).toBeInTheDocument();
+  });
+
+  it('export remediation report for current project', async () => {
+    const request = sqlManage.getSqlManageList();
+    const exportRequest = sqlManage.exportSqlManageRemediation();
+    superRender(<SQLEEIndex />);
+    expect(request).toHaveBeenCalled();
+    jest.useRealTimers();
+    try {
+      fireEvent.click(screen.getByText('导出报表'));
+      await waitFor(() => {
+        expect(screen.getByText('导出当前项目SQL整改报表')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('导出当前项目SQL整改报表'));
+    } finally {
+      jest.useFakeTimers();
+    }
+    expect(exportRequest).toHaveBeenCalledWith(
+      {
+        project_name: mockProjectInfo.projectName,
+        export_scope: exportSqlManageRemediationV1ExportScopeEnum.project
+      },
+      {
+        responseType: 'blob'
+      }
+    );
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(screen.getByText('SQL 管控整改报表导出成功')).toBeInTheDocument();
+  });
+
+  it('export remediation report for all projects', async () => {
+    const request = sqlManage.getSqlManageList();
+    const exportRequest = sqlManage.exportGlobalSqlManageRemediation();
+    superRender(<SQLEEIndex />);
+    expect(request).toHaveBeenCalled();
+    jest.useRealTimers();
+    try {
+      fireEvent.click(screen.getByText('导出报表'));
+      await waitFor(() => {
+        expect(screen.getByText('导出所有项目SQL整改报表')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('导出所有项目SQL整改报表'));
+    } finally {
+      jest.useFakeTimers();
+    }
+    expect(exportRequest).toHaveBeenCalledWith(
+      {},
+      {
+        responseType: 'blob'
+      }
+    );
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(screen.getByText('SQL 管控整改报表导出成功')).toBeInTheDocument();
   });
 
   it('batch assignment operation for sql', async () => {
@@ -557,18 +626,39 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     });
   });
 
-  it('click audit result and open sql audit result', async () => {
+  it('click audit result and open remediation detail drawer', async () => {
     const request = sqlManage.getSqlManageList();
     superRender(<SQLEEIndex />);
     expect(request).toHaveBeenCalled();
     await act(async () => jest.advanceTimersByTime(3000));
-    expect(getAllBySelector('.audit-result-wrapper').length).toBe(1);
+    expect(getAllBySelector('.audit-result-wrapper').length).toBe(2);
+    fireEvent.click(getAllBySelector('.audit-result-wrapper')[1]);
+    await act(async () => jest.advanceTimersByTime(300));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'sqlManagement/updateModalStatus',
+      payload: {
+        modalName: ModalName.View_Remediation_Detail_Drawer,
+        status: true
+      }
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'sqlManagement/setSqlManagementSelectData',
+      payload: sqlManageListData.data[0]
+    });
+  });
+
+  it('click first audit result and open remediation detail drawer', async () => {
+    const request = sqlManage.getSqlManageList();
+    superRender(<SQLEEIndex />);
+    expect(request).toHaveBeenCalled();
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(getAllBySelector('.audit-result-wrapper').length).toBe(2);
     fireEvent.click(getAllBySelector('.audit-result-wrapper')[0]);
     await act(async () => jest.advanceTimersByTime(300));
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'sqlManagement/updateModalStatus',
       payload: {
-        modalName: ModalName.View_Audit_Result_Drawer,
+        modalName: ModalName.View_Remediation_Detail_Drawer,
         status: true
       }
     });

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
@@ -29,7 +29,8 @@ import {
   GetSqlManageListV2SortFieldEnum,
   GetSqlManageListV2SortOrderEnum,
   exportSqlManageV1FilterPriorityEnum,
-  exportSqlManageV1FilterStatusEnum
+  exportSqlManageV1FilterStatusEnum,
+  exportSqlManageRemediationV1ExportScopeEnum
 } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
 import SqlManagementColumn, {
   ExtraFilterMeta,
@@ -39,7 +40,8 @@ import SqlManagementColumn, {
 import { ModalName } from '../../../../data/ModalName';
 import { SorterResult, TableRowSelection } from 'antd/es/table/interface';
 import { ISqlManage } from '@actiontech/shared/lib/api/sqle/service/common';
-import { Spin, message } from 'antd';
+import { Spin, message, Dropdown } from 'antd';
+import type { MenuProps } from 'antd';
 import SqlManagementModal from './Modal';
 import EmitterKey from '../../../../data/EmitterKey';
 import EventEmitter from '../../../../utils/EventEmitter';
@@ -331,16 +333,102 @@ const SQLEEIndex = () => {
     } as IExportSqlManageV1Params;
     SqlManage.exportSqlManageV1(params, { responseType: 'blob' })
       .then((res) => {
-        if (res.data.code === ResponseCode.SUCCESS) {
+        if (
+          (res.data as unknown as { code?: number }).code ===
+          ResponseCode.SUCCESS
+        ) {
           messageApi.success(
             t('sqlManagement.pageHeader.action.exportSuccessTips')
           );
         }
       })
+      .catch((e: Error) => {
+        messageApi.error(
+          e?.message ?? t('sqlManagement.pageHeader.action.exportFailedTips')
+        );
+      })
       .finally(() => {
         hideLoading();
         finishExport();
       });
+  };
+
+  const handleRemediationExport = (scope: 'project' | 'global') => {
+    if (!actionPermission || projectArchive) {
+      return;
+    }
+    startExport();
+    const hideLoading = messageApi.loading(
+      t('sqlManagement.pageHeader.action.remediationExporting')
+    );
+
+    const exportPromise =
+      scope === 'project'
+        ? SqlManage.exportSqlManageRemediationV1(
+            {
+              project_name: projectName,
+              export_scope: exportSqlManageRemediationV1ExportScopeEnum.project
+            },
+            { responseType: 'blob' }
+          )
+        : SqlManage.exportGlobalSqlManageRemediationV1(
+            {},
+            { responseType: 'blob' }
+          );
+
+    exportPromise
+      .then((res) => {
+        if (res.status === 200) {
+          messageApi.success(
+            t('sqlManagement.pageHeader.action.remediationExportSuccessTips')
+          );
+        }
+      })
+      .catch((e: Error) => {
+        messageApi.error(
+          e?.message ?? t('sqlManagement.pageHeader.action.exportFailedTips')
+        );
+      })
+      .finally(() => {
+        hideLoading();
+        finishExport();
+      });
+  };
+
+  const exportMenuItems: MenuProps['items'] = useMemo(() => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'sqlManage',
+        label: t('sqlManagement.pageHeader.action.export')
+      }
+    ];
+
+    if (actionPermission && !projectArchive) {
+      items.push(
+        {
+          key: 'project',
+          label: t(
+            'sqlManagement.pageHeader.action.remediationExportCurrentProject'
+          )
+        },
+        {
+          key: 'global',
+          label: t(
+            'sqlManagement.pageHeader.action.remediationExportAllProjects'
+          )
+        }
+      );
+    }
+
+    return items;
+  }, [t, actionPermission, projectArchive]);
+
+  const onExportMenuClick: MenuProps['onClick'] = ({ key }) => {
+    if (key === 'sqlManage') {
+      handleExport();
+      return;
+    }
+    handleRemediationExport(key as 'project' | 'global');
   };
 
   useEffect(() => {
@@ -383,13 +471,30 @@ const SQLEEIndex = () => {
       <PageHeader
         title={t('sqlManagement.pageTitle')}
         extra={
-          <BasicButton
-            onClick={handleExport}
-            icon={<DownArrowLineOutlined />}
-            disabled={exportButtonDisabled}
-          >
-            {t('sqlManagement.pageHeader.action.export')}
-          </BasicButton>
+          exportMenuItems.length <= 1 ? (
+            <BasicButton
+              icon={<DownArrowLineOutlined />}
+              disabled={exportButtonDisabled}
+              onClick={handleExport}
+            >
+              {t('sqlManagement.pageHeader.action.exportReport')}
+            </BasicButton>
+          ) : (
+            <Dropdown
+              menu={{
+                items: exportMenuItems,
+                onClick: onExportMenuClick
+              }}
+              disabled={exportButtonDisabled}
+            >
+              <BasicButton
+                icon={<DownArrowLineOutlined />}
+                disabled={exportButtonDisabled}
+              >
+                {t('sqlManagement.pageHeader.action.exportReport')}
+              </BasicButton>
+            </Dropdown>
+          )
         }
       />
       {/* page */}

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`test ScanTypeSqlCollection should match snapshot 1`] = `
 <div>
   <section
-    class="css-1kw0l6j"
+    class="css-16x4zhu"
   >
     <div
       class="ant-spin-nested-loading css-dev-only-do-not-override-1kh50jg"
@@ -189,7 +189,7 @@ exports[`test ScanTypeSqlCollection should match snapshot 1`] = `
 exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
 <div>
   <section
-    class="css-1kw0l6j"
+    class="css-16x4zhu"
   >
     <div
       class="ant-spin-nested-loading css-dev-only-do-not-override-1kh50jg"
@@ -1913,32 +1913,49 @@ LIMIT
                         class="ant-table-cell"
                       >
                         <div
-                          class="audit-result-wrapper"
-                          data-testid="trigger-open-remediation-drawer"
+                          class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                         >
                           <div
-                            class=" css-1avyf41"
+                            class="ant-space-item"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <div
+                              class="audit-result-wrapper"
+                              data-testid="trigger-open-remediation-drawer"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <div
+                                class="css-yzky0k"
                               >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
+                                <div
+                                  class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                >
+                                  <div
+                                    class="ant-space-item"
+                                  >
+                                    <span
+                                      class="audit-level-summary-item"
+                                    >
+                                      <svg
+                                        height="20"
+                                        viewBox="0 0 16 16"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                                          fill="#F66074"
+                                        />
+                                      </svg>
+                                      <span
+                                        class="audit-level-summary-count"
+                                      >
+                                        × 
+                                        1
+                                      </span>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </td>
@@ -1946,40 +1963,48 @@ LIMIT
                         class="ant-table-cell"
                       >
                         <div
-                          class="audit-result-wrapper"
-                          data-testid="trigger-open-remediation-drawer"
+                          class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                         >
                           <div
-                            class="css-yzky0k"
+                            class="ant-space-item"
                           >
                             <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                              class="audit-result-wrapper"
+                              data-testid="trigger-open-remediation-drawer"
                             >
                               <div
-                                class="ant-space-item"
+                                class="css-yzky0k"
                               >
-                                <span
-                                  class="audit-level-summary-item"
+                                <div
+                                  class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                                 >
-                                  <svg
-                                    fill="none"
-                                    height="20"
-                                    viewBox="0 0 16 16"
-                                    width="20"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    class="ant-space-item"
                                   >
-                                    <path
-                                      d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
-                                      fill="#EBAD1C"
-                                    />
-                                  </svg>
-                                  <span
-                                    class="audit-level-summary-count"
-                                  >
-                                    × 
-                                    1
-                                  </span>
-                                </span>
+                                    <span
+                                      class="audit-level-summary-item"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        height="20"
+                                        viewBox="0 0 16 16"
+                                        width="20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
+                                          fill="#EBAD1C"
+                                        />
+                                      </svg>
+                                      <span
+                                        class="audit-level-summary-count"
+                                      >
+                                        × 
+                                        1
+                                      </span>
+                                    </span>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -2628,7 +2653,7 @@ exports[`test ScanTypeSqlCollection should open remediation drawer on audit resu
 <body>
   <div>
     <section
-      class="css-1kw0l6j"
+      class="css-16x4zhu"
     >
       <div
         class="ant-spin-nested-loading css-dev-only-do-not-override-1kh50jg"
@@ -4352,32 +4377,49 @@ LIMIT
                           class="ant-table-cell"
                         >
                           <div
-                            class="audit-result-wrapper"
-                            data-testid="trigger-open-remediation-drawer"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                           >
                             <div
-                              class=" css-1avyf41"
+                              class="ant-space-item"
                             >
-                              <span
-                                class="icon-wrapper"
+                              <div
+                                class="audit-result-wrapper"
+                                data-testid="trigger-open-remediation-drawer"
                               >
-                                <svg
-                                  height="20"
-                                  viewBox="0 0 20 20"
-                                  width="20"
-                                  xmlns="http://www.w3.org/2000/svg"
+                                <div
+                                  class="css-yzky0k"
                                 >
-                                  <path
-                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                    fill="#41BF9A"
-                                  />
-                                </svg>
-                              </span>
-                              <span
-                                class="text-wrapper"
-                              >
-                                审核通过
-                              </span>
+                                  <div
+                                    class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                  >
+                                    <div
+                                      class="ant-space-item"
+                                    >
+                                      <span
+                                        class="audit-level-summary-item"
+                                      >
+                                        <svg
+                                          height="20"
+                                          viewBox="0 0 16 16"
+                                          width="20"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M8 14.666A6.666 6.666 0 1 1 8 1.333a6.666 6.666 0 0 1 0 13.333m0-7.609L6.115 5.171l-.944.943L7.057 8 5.171 9.885l.944.943L8 8.942l1.885 1.886.944-.943L8.943 8l1.886-1.886-.944-.943z"
+                                            fill="#F66074"
+                                          />
+                                        </svg>
+                                        <span
+                                          class="audit-level-summary-count"
+                                        >
+                                          × 
+                                          1
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -4385,40 +4427,48 @@ LIMIT
                           class="ant-table-cell"
                         >
                           <div
-                            class="audit-result-wrapper"
-                            data-testid="trigger-open-remediation-drawer"
+                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
                           >
                             <div
-                              class="css-yzky0k"
+                              class="ant-space-item"
                             >
                               <div
-                                class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                                class="audit-result-wrapper"
+                                data-testid="trigger-open-remediation-drawer"
                               >
                                 <div
-                                  class="ant-space-item"
+                                  class="css-yzky0k"
                                 >
-                                  <span
-                                    class="audit-level-summary-item"
+                                  <div
+                                    class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
                                   >
-                                    <svg
-                                      fill="none"
-                                      height="20"
-                                      viewBox="0 0 16 16"
-                                      width="20"
-                                      xmlns="http://www.w3.org/2000/svg"
+                                    <div
+                                      class="ant-space-item"
                                     >
-                                      <path
-                                        d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
-                                        fill="#EBAD1C"
-                                      />
-                                    </svg>
-                                    <span
-                                      class="audit-level-summary-count"
-                                    >
-                                      × 
-                                      1
-                                    </span>
-                                  </span>
+                                      <span
+                                        class="audit-level-summary-item"
+                                      >
+                                        <svg
+                                          fill="none"
+                                          height="20"
+                                          viewBox="0 0 16 16"
+                                          width="20"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
+                                            fill="#EBAD1C"
+                                          />
+                                        </svg>
+                                        <span
+                                          class="audit-level-summary-count"
+                                        >
+                                          × 
+                                          1
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -5120,7 +5170,7 @@ LIMIT
                   class="ant-spin-container"
                 >
                   <div
-                    class="css-89hxei"
+                    class="css-ay3j81"
                   >
                     <div
                       class="diff-columns"
@@ -5143,32 +5193,28 @@ LIMIT
                           </span>
                         </div>
                         <div
-                          class="diff-rules-container"
+                          class=" css-1avyf41"
                         >
-                          <div
-                            class=" css-1avyf41"
+                          <span
+                            class="icon-wrapper"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <svg
+                              height="20"
+                              viewBox="0 0 20 20"
+                              width="20"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
-                          </div>
+                              <path
+                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                fill="#41BF9A"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            审核通过
+                          </span>
                         </div>
                       </section>
                       <section
@@ -5189,32 +5235,28 @@ LIMIT
                           </span>
                         </div>
                         <div
-                          class="diff-rules-container"
+                          class=" css-1avyf41"
                         >
-                          <div
-                            class=" css-1avyf41"
+                          <span
+                            class="icon-wrapper"
                           >
-                            <span
-                              class="icon-wrapper"
+                            <svg
+                              height="20"
+                              viewBox="0 0 20 20"
+                              width="20"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="text-wrapper"
-                            >
-                              审核通过
-                            </span>
-                          </div>
+                              <path
+                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                fill="#41BF9A"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            审核通过
+                          </span>
                         </div>
                       </section>
                     </div>

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/__snapshots__/index.test.tsx.snap
@@ -651,9 +651,13 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                         class="ant-table-cell"
                         scope="col"
                       >
-                        <span>
-                          审核结果
-                        </span>
+                        最初审核结果
+                      </th>
+                      <th
+                        class="ant-table-cell"
+                        scope="col"
+                      >
+                        当前审核结果
                       </th>
                       <th
                         aria-label="出现次数"
@@ -1091,6 +1095,15 @@ exports[`test ScanTypeSqlCollection should match snapshot 2`] = `
                            
                         </div>
                       </td>
+                      <td
+                        style="padding: 0px; border: 0px; height: 0px;"
+                      >
+                        <div
+                          style="height: 0px; overflow: hidden;"
+                        >
+                           
+                        </div>
+                      </td>
                     </tr>
                     <tr
                       class="ant-table-row ant-table-row-level-0"
@@ -1215,33 +1228,76 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
-                        -
+                        <span
+                          class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                        >
+                          审核中
+                        </span>
                       </td>
                       <td
                         class="ant-table-cell"
                       >
                         <div
-                          data-testid="trigger-open-report-drawer"
+                          class=" css-1avyf41"
                         >
-                          <div
-                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                          <span
+                            class="icon-wrapper"
                           >
-                            <div
-                              class="ant-space-item"
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
+                        </div>
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        <div
+                          class=" css-1avyf41"
+                        >
+                          <span
+                            class="icon-wrapper"
+                          >
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
                         </div>
                       </td>
                       <td
@@ -1427,33 +1483,76 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
-                        -
+                        <span
+                          class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                        >
+                          审核中
+                        </span>
                       </td>
                       <td
                         class="ant-table-cell"
                       >
                         <div
-                          data-testid="trigger-open-report-drawer"
+                          class=" css-1avyf41"
                         >
-                          <div
-                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                          <span
+                            class="icon-wrapper"
                           >
-                            <div
-                              class="ant-space-item"
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
+                        </div>
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        <div
+                          class=" css-1avyf41"
+                        >
+                          <span
+                            class="icon-wrapper"
+                          >
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
                         </div>
                       </td>
                       <td
@@ -1609,33 +1708,76 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
-                        -
+                        <span
+                          class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                        >
+                          审核中
+                        </span>
                       </td>
                       <td
                         class="ant-table-cell"
                       >
                         <div
-                          data-testid="trigger-open-report-drawer"
+                          class=" css-1avyf41"
                         >
-                          <div
-                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                          <span
+                            class="icon-wrapper"
                           >
-                            <div
-                              class="ant-space-item"
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
+                        </div>
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        <div
+                          class=" css-1avyf41"
+                        >
+                          <span
+                            class="icon-wrapper"
+                          >
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
                         </div>
                       </td>
                       <td
@@ -1771,26 +1913,74 @@ LIMIT
                         class="ant-table-cell"
                       >
                         <div
-                          data-testid="trigger-open-report-drawer"
+                          class="audit-result-wrapper"
+                          data-testid="trigger-open-remediation-drawer"
                         >
                           <div
-                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                            class=" css-1avyf41"
                           >
-                            <div
-                              class="ant-space-item"
+                            <span
+                              class="icon-wrapper"
                             >
                               <svg
-                                fill="none"
                                 height="20"
-                                viewBox="0 0 16 16"
+                                viewBox="0 0 20 20"
                                 width="20"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
-                                  fill="#EBAD1C"
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
                                 />
                               </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              审核通过
+                            </span>
+                          </div>
+                        </div>
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        <div
+                          class="audit-result-wrapper"
+                          data-testid="trigger-open-remediation-drawer"
+                        >
+                          <div
+                            class="css-yzky0k"
+                          >
+                            <div
+                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                            >
+                              <div
+                                class="ant-space-item"
+                              >
+                                <span
+                                  class="audit-level-summary-item"
+                                >
+                                  <svg
+                                    fill="none"
+                                    height="20"
+                                    viewBox="0 0 16 16"
+                                    width="20"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
+                                      fill="#EBAD1C"
+                                    />
+                                  </svg>
+                                  <span
+                                    class="audit-level-summary-count"
+                                  >
+                                    × 
+                                    1
+                                  </span>
+                                </span>
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -1922,33 +2112,76 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
-                        -
+                        <span
+                          class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                        >
+                          审核中
+                        </span>
                       </td>
                       <td
                         class="ant-table-cell"
                       >
                         <div
-                          data-testid="trigger-open-report-drawer"
+                          class=" css-1avyf41"
                         >
-                          <div
-                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                          <span
+                            class="icon-wrapper"
                           >
-                            <div
-                              class="ant-space-item"
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
+                        </div>
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        <div
+                          class=" css-1avyf41"
+                        >
+                          <span
+                            class="icon-wrapper"
+                          >
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
                         </div>
                       </td>
                       <td
@@ -2121,33 +2354,76 @@ LIMIT
                       <td
                         class="ant-table-cell"
                       >
-                        -
+                        <span
+                          class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                        >
+                          审核中
+                        </span>
                       </td>
                       <td
                         class="ant-table-cell"
                       >
                         <div
-                          data-testid="trigger-open-report-drawer"
+                          class=" css-1avyf41"
                         >
-                          <div
-                            class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                          <span
+                            class="icon-wrapper"
                           >
-                            <div
-                              class="ant-space-item"
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                height="20"
-                                viewBox="0 0 20 20"
-                                width="20"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                  fill="#41BF9A"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
+                        </div>
+                      </td>
+                      <td
+                        class="ant-table-cell"
+                      >
+                        <div
+                          class=" css-1avyf41"
+                        >
+                          <span
+                            class="icon-wrapper"
+                          >
+                            <svg
+                              fill="none"
+                              height="16"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                stroke="#7470ED"
+                              />
+                              <path
+                                d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                fill="#7470ED"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="text-wrapper"
+                          >
+                            正在审核
+                          </span>
                         </div>
                       </td>
                       <td
@@ -2348,7 +2624,7 @@ LIMIT
 </div>
 `;
 
-exports[`test ScanTypeSqlCollection should open report drawer and set current audit result record on audit result click 1`] = `
+exports[`test ScanTypeSqlCollection should open remediation drawer on audit result click 1`] = `
 <body>
   <div>
     <section
@@ -2814,9 +3090,13 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                           class="ant-table-cell"
                           scope="col"
                         >
-                          <span>
-                            审核结果
-                          </span>
+                          最初审核结果
+                        </th>
+                        <th
+                          class="ant-table-cell"
+                          scope="col"
+                        >
+                          当前审核结果
                         </th>
                         <th
                           aria-label="出现次数"
@@ -3254,6 +3534,15 @@ exports[`test ScanTypeSqlCollection should open report drawer and set current au
                              
                           </div>
                         </td>
+                        <td
+                          style="padding: 0px; border: 0px; height: 0px;"
+                        >
+                          <div
+                            style="height: 0px; overflow: hidden;"
+                          >
+                             
+                          </div>
+                        </td>
                       </tr>
                       <tr
                         class="ant-table-row ant-table-row-level-0"
@@ -3378,33 +3667,76 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
-                          -
+                          <span
+                            class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                          >
+                            审核中
+                          </span>
                         </td>
                         <td
                           class="ant-table-cell"
                         >
                           <div
-                            data-testid="trigger-open-report-drawer"
+                            class=" css-1avyf41"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                            <span
+                              class="icon-wrapper"
                             >
-                              <div
-                                class="ant-space-item"
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  height="20"
-                                  viewBox="0 0 20 20"
-                                  width="20"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                    fill="#41BF9A"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          <div
+                            class=" css-1avyf41"
+                          >
+                            <span
+                              class="icon-wrapper"
+                            >
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
                           </div>
                         </td>
                         <td
@@ -3590,33 +3922,76 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
-                          -
+                          <span
+                            class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                          >
+                            审核中
+                          </span>
                         </td>
                         <td
                           class="ant-table-cell"
                         >
                           <div
-                            data-testid="trigger-open-report-drawer"
+                            class=" css-1avyf41"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                            <span
+                              class="icon-wrapper"
                             >
-                              <div
-                                class="ant-space-item"
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  height="20"
-                                  viewBox="0 0 20 20"
-                                  width="20"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                    fill="#41BF9A"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          <div
+                            class=" css-1avyf41"
+                          >
+                            <span
+                              class="icon-wrapper"
+                            >
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
                           </div>
                         </td>
                         <td
@@ -3772,33 +4147,76 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
-                          -
+                          <span
+                            class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                          >
+                            审核中
+                          </span>
                         </td>
                         <td
                           class="ant-table-cell"
                         >
                           <div
-                            data-testid="trigger-open-report-drawer"
+                            class=" css-1avyf41"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                            <span
+                              class="icon-wrapper"
                             >
-                              <div
-                                class="ant-space-item"
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  height="20"
-                                  viewBox="0 0 20 20"
-                                  width="20"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                    fill="#41BF9A"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          <div
+                            class=" css-1avyf41"
+                          >
+                            <span
+                              class="icon-wrapper"
+                            >
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
                           </div>
                         </td>
                         <td
@@ -3934,26 +4352,74 @@ LIMIT
                           class="ant-table-cell"
                         >
                           <div
-                            data-testid="trigger-open-report-drawer"
+                            class="audit-result-wrapper"
+                            data-testid="trigger-open-remediation-drawer"
                           >
                             <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                              class=" css-1avyf41"
                             >
-                              <div
-                                class="ant-space-item"
+                              <span
+                                class="icon-wrapper"
                               >
                                 <svg
-                                  fill="none"
                                   height="20"
-                                  viewBox="0 0 16 16"
+                                  viewBox="0 0 20 20"
                                   width="20"
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
                                   <path
-                                    d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
-                                    fill="#EBAD1C"
+                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                    fill="#41BF9A"
                                   />
                                 </svg>
+                              </span>
+                              <span
+                                class="text-wrapper"
+                              >
+                                审核通过
+                              </span>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          <div
+                            class="audit-result-wrapper"
+                            data-testid="trigger-open-remediation-drawer"
+                          >
+                            <div
+                              class="css-yzky0k"
+                            >
+                              <div
+                                class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                              >
+                                <div
+                                  class="ant-space-item"
+                                >
+                                  <span
+                                    class="audit-level-summary-item"
+                                  >
+                                    <svg
+                                      fill="none"
+                                      height="20"
+                                      viewBox="0 0 16 16"
+                                      width="20"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m8.577 2 6.35 11a.667.667 0 0 1-.577 1H1.648a.667.667 0 0 1-.577-1l6.35-11a.667.667 0 0 1 1.156 0m-1.244 8.667V12h1.333v-1.333zm0-4.667v3.334h1.333V6z"
+                                        fill="#EBAD1C"
+                                      />
+                                    </svg>
+                                    <span
+                                      class="audit-level-summary-count"
+                                    >
+                                      × 
+                                      1
+                                    </span>
+                                  </span>
+                                </div>
                               </div>
                             </div>
                           </div>
@@ -4085,33 +4551,76 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
-                          -
+                          <span
+                            class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                          >
+                            审核中
+                          </span>
                         </td>
                         <td
                           class="ant-table-cell"
                         >
                           <div
-                            data-testid="trigger-open-report-drawer"
+                            class=" css-1avyf41"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                            <span
+                              class="icon-wrapper"
                             >
-                              <div
-                                class="ant-space-item"
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  height="20"
-                                  viewBox="0 0 20 20"
-                                  width="20"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                    fill="#41BF9A"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          <div
+                            class=" css-1avyf41"
+                          >
+                            <span
+                              class="icon-wrapper"
+                            >
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
                           </div>
                         </td>
                         <td
@@ -4284,33 +4793,76 @@ LIMIT
                         <td
                           class="ant-table-cell"
                         >
-                          -
+                          <span
+                            class="ant-tag ant-tag-geekblue basic-tag-wrapper basic-small-tag-wrapper css-sdwkac css-dev-only-do-not-override-bj9uhl"
+                          >
+                            审核中
+                          </span>
                         </td>
                         <td
                           class="ant-table-cell"
                         >
                           <div
-                            data-testid="trigger-open-report-drawer"
+                            class=" css-1avyf41"
                           >
-                            <div
-                              class="ant-space css-dev-only-do-not-override-bj9uhl ant-space-horizontal ant-space-align-center"
+                            <span
+                              class="icon-wrapper"
                             >
-                              <div
-                                class="ant-space-item"
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  height="20"
-                                  viewBox="0 0 20 20"
-                                  width="20"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                    fill="#41BF9A"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="ant-table-cell"
+                        >
+                          <div
+                            class=" css-1avyf41"
+                          >
+                            <span
+                              class="icon-wrapper"
+                            >
+                              <svg
+                                fill="none"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M6.875 1.516a2.25 2.25 0 0 1 2.25 0l3.928 2.267a2.25 2.25 0 0 1 1.125 1.95v4.535a2.25 2.25 0 0 1-1.125 1.948l-3.928 2.269a2.25 2.25 0 0 1-2.25 0l-3.928-2.268a2.25 2.25 0 0 1-1.125-1.95V5.733a2.25 2.25 0 0 1 1.125-1.949z"
+                                  stroke="#7470ED"
+                                />
+                                <path
+                                  d="M8 3.155V8l4.207 2.404a1 1 0 0 0 .123-.481V6.077a1 1 0 0 0-.5-.866L8.5 3.29a1 1 0 0 0-.5-.134"
+                                  fill="#7470ED"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              正在审核
+                            </span>
                           </div>
                         </td>
                         <td
@@ -4525,46 +5077,16 @@ LIMIT
       />
       <div
         class="ant-drawer-content-wrapper"
-        style="width: 720px;"
+        style="width: 960px;"
       >
         <div
           aria-modal="true"
-          class="ant-drawer-content basic-drawer-wrapper drawer-wrapper-no-padding css-1q29jje"
+          class="ant-drawer-content basic-drawer-wrapper css-1q29jje"
           role="dialog"
         >
           <div
             class="ant-drawer-wrapper-body"
           >
-            <div
-              class="ant-drawer-header"
-            >
-              <div
-                class="ant-drawer-header-title"
-              >
-                <div
-                  class="ant-drawer-title"
-                >
-                  SQL审核结果
-                </div>
-              </div>
-              <div
-                class="ant-drawer-extra"
-              >
-                <a
-                  href="/sqle/project/700300/sql-management-conf/1/analyze/1"
-                  target="blank"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
-                    type="button"
-                  >
-                    <span>
-                      分 析
-                    </span>
-                  </button>
-                </a>
-              </div>
-            </div>
             <div
               class="ant-drawer-body"
             >
@@ -4592,79 +5114,112 @@ LIMIT
                 </span>
               </div>
               <div
-                class="audit-report-wrapper css-126skhi"
+                class="ant-spin-nested-loading css-dev-only-do-not-override-txh9fw"
               >
                 <div
-                  class="ant-spin-nested-loading css-dev-only-do-not-override-txh9fw"
+                  class="ant-spin-container"
                 >
                   <div
-                    class="ant-spin-container"
+                    class="css-89hxei"
                   >
-                    <section
-                      class="wrapper-item"
+                    <div
+                      class="diff-columns"
                     >
-                      <h3
-                        class="ant-typography css-dev-only-do-not-override-txh9fw"
-                      >
-                        审核结果
-                      </h3>
-                      <div
-                        class="wrapper-cont"
+                      <section
+                        class="diff-column"
                       >
                         <div
-                          class="result-item css-1avyf41"
+                          class="diff-column-header"
                         >
-                          <span
-                            class="icon-wrapper"
+                          <h5
+                            class="ant-typography diff-column-title css-dev-only-do-not-override-txh9fw"
                           >
-                            <svg
-                              height="20"
-                              viewBox="0 0 20 20"
-                              width="20"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                fill="#41BF9A"
-                              />
-                            </svg>
-                          </span>
+                            最初审核结果
+                          </h5>
                           <span
-                            class="text-wrapper"
+                            class="ant-typography ant-typography-secondary diff-column-audit-time css-dev-only-do-not-override-txh9fw"
                           >
-                            审核通过
+                            审核时间：-
                           </span>
                         </div>
-                      </div>
-                    </section>
+                        <div
+                          class="diff-rules-container"
+                        >
+                          <div
+                            class=" css-1avyf41"
+                          >
+                            <span
+                              class="icon-wrapper"
+                            >
+                              <svg
+                                height="20"
+                                viewBox="0 0 20 20"
+                                width="20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              审核通过
+                            </span>
+                          </div>
+                        </div>
+                      </section>
+                      <section
+                        class="diff-column"
+                      >
+                        <div
+                          class="diff-column-header"
+                        >
+                          <h5
+                            class="ant-typography diff-column-title css-dev-only-do-not-override-txh9fw"
+                          >
+                            当前审核结果
+                          </h5>
+                          <span
+                            class="ant-typography ant-typography-secondary diff-column-audit-time css-dev-only-do-not-override-txh9fw"
+                          >
+                            审核时间：-
+                          </span>
+                        </div>
+                        <div
+                          class="diff-rules-container"
+                        >
+                          <div
+                            class=" css-1avyf41"
+                          >
+                            <span
+                              class="icon-wrapper"
+                            >
+                              <svg
+                                height="20"
+                                viewBox="0 0 20 20"
+                                width="20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="text-wrapper"
+                            >
+                              审核通过
+                            </span>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
                   </div>
                 </div>
-                <section
-                  class="wrapper-item"
-                >
-                  <div
-                    class="title-wrap"
-                  >
-                    <h3
-                      class="ant-typography css-dev-only-do-not-override-txh9fw"
-                    >
-                      SQL语句
-                    </h3>
-                  </div>
-                  <div
-                    class="wrapper-cont"
-                  >
-                    <input
-                      class="actiontech-sql-view-only-editor-renderer-wrapper custom-monaco-editor css-baixa9"
-                      height="90%"
-                      language="sql"
-                      options="{"readOnly":true,"automaticLayout":true,"minimap":{"enabled":false},"fontFamily":"SF Mono","fontSize":14,"fontWeight":"400","lineNumbersMinChars":2,"suggestFontSize":14}"
-                      value="/* ApplicationName=DBeaver 24.1.2 - SQLEditor <Console> */ select 1,SLEEP(11)
-LIMIT 0, 200"
-                      width="100%"
-                    />
-                  </div>
-                </section>
               </div>
             </div>
           </div>

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import { mockUseCurrentProject } from '@actiontech/shared/lib/testUtil/mockHook/mockUseCurrentProject';
 import instanceAuditPlan from '../../../../../testUtils/mockApi/instanceAuditPlan';
 import { superRender } from '../../../../../testUtils/customRender';
-import ScanTypeSqlCollection from '../indx';
+import ScanTypeSqlCollection from '..';
 import { act, fireEvent } from '@testing-library/react';
 import { mockProjectInfo } from '@actiontech/shared/lib/testUtil/mockHook/data';
 import { mockUseCurrentUser } from '@actiontech/shared/lib/testUtil/mockHook/mockUseCurrentUser';
@@ -9,6 +9,7 @@ import { getAllBySelector } from '@actiontech/shared/lib/testUtil/customQuery';
 import rule_template from '../../../../../testUtils/mockApi/rule_template';
 import { createSpySuccessResponse } from '@actiontech/shared/lib/testUtil/mockApi';
 import { mockAuditPlanSQLData } from '../../../../../testUtils/mockApi/instanceAuditPlan/data';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 
 describe('test ScanTypeSqlCollection', () => {
   let getInstanceAuditPlanSQLMetaSpy: jest.SpyInstance;
@@ -42,6 +43,8 @@ describe('test ScanTypeSqlCollection', () => {
         instanceType={instanceType}
         exportDone={jest.fn()}
         exportPending={jest.fn()}
+        remediationExportDone={jest.fn()}
+        remediationExportPending={jest.fn()}
         auditPlanType="default"
       />
     );
@@ -123,12 +126,15 @@ describe('test ScanTypeSqlCollection', () => {
     });
   });
 
-  it('should open report drawer and set current audit result record on audit result click', async () => {
+  it('should open remediation drawer on audit result click', async () => {
     rule_template.getRuleList();
+    jest.spyOn(SqlManage, 'GetSqlManageRemediationV1').mockResolvedValue({
+      data: { code: 0, data: {} }
+    } as Awaited<ReturnType<typeof SqlManage.GetSqlManageRemediationV1>>);
     const { getAllByTestId, baseElement } = customRender();
     await act(async () => jest.advanceTimersByTime(3000));
 
-    fireEvent.click(getAllByTestId('trigger-open-report-drawer')[0]);
+    fireEvent.click(getAllByTestId('trigger-open-remediation-drawer')[0]);
     await act(async () => jest.advanceTimersByTime(3000));
     expect(baseElement).toMatchSnapshot();
   });

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.tsx
@@ -508,6 +508,7 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
         }}
         open={reportDrawerVisible}
         onClose={closeReportDrawer}
+        showAnnotation
         loading={auditResultInfoLoading}
         extra={
           <Link

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.tsx
@@ -8,10 +8,12 @@ import {
 } from '@actiontech/shared/lib/components/ActiontechTable';
 import { useTranslation } from 'react-i18next';
 import ReportDrawer from '../../../../components/ReportDrawer';
-import { useCallback, useEffect, useMemo, useState, ReactNode } from 'react';
+import RemediationDetailDrawer from '../../../../components/RemediationDetailDrawer';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useBoolean, useRequest } from 'ahooks';
 import { ScanTypeSqlCollectionStyleWrapper } from './style';
 import instance_audit_plan from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 import {
   useCurrentProject,
   useCurrentUser
@@ -21,7 +23,7 @@ import {
   ScanTypeSqlTableDataSourceItem
 } from './index.type';
 import useBackendTable from '../../../../hooks/useBackendTable';
-import { BasicButton, SQLRenderer } from '@actiontech/shared';
+import { BasicButton, SQLRenderer, BasicToolTips } from '@actiontech/shared';
 import eventEmitter from '../../../../utils/EventEmitter';
 import EmitterKey from '../../../../data/EmitterKey';
 import {
@@ -33,7 +35,8 @@ import {
   formatTime,
   getErrorMessage
 } from '@actiontech/shared/lib/utils/Common';
-import ResultIconRender from '../../../../components/AuditResultMessage/ResultIconRender';
+import AuditResultMessage from '../../../../components/AuditResultMessage';
+import AuditLevelSummary from '../../../../components/AuditResultMessage/AuditLevelSummary';
 import AuditStatusTag from './AuditStatusTag';
 import {
   BEING_AUDITED,
@@ -46,8 +49,10 @@ import {
 } from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan/index.d';
 import { mergeFilterButtonMeta } from '@actiontech/shared/lib/components/ActiontechTable/hooks/useTableFilterContainer';
 import { ResponseCode } from '@actiontech/shared/lib/enum';
-import { message, Tooltip } from 'antd';
+import { message } from 'antd';
 import { Link } from 'react-router-dom';
+import { exportSqlManageRemediationV1ExportScopeEnum } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
+import { getAuditTaskSQLsV2FilterAuditStatusEnum } from '@actiontech/shared/lib/api/sqle/service/task/index.enum';
 
 const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
   instanceAuditPlanId,
@@ -56,7 +61,9 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
   activeTabKey,
   instanceType,
   exportDone,
-  exportPending
+  exportPending,
+  remediationExportPending,
+  remediationExportDone
 }) => {
   const { t } = useTranslation();
   const { sortableTableColumnFactory, tableFilterMetaFactory } =
@@ -67,6 +74,8 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
   const { projectName, projectID } = useCurrentProject();
   const { username } = useCurrentUser();
   const [currentAuditResultRecord, setCurrentAuditResultRecord] =
+    useState<ScanTypeSqlTableDataSourceItem>();
+  const [remediationDrawerRecord, setRemediationDrawerRecord] =
     useState<ScanTypeSqlTableDataSourceItem>();
   const [messageApi, messageContextHolder] = message.useMessage();
   const [polling, { setFalse: finishPollRequest, setTrue: startPollRequest }] =
@@ -93,12 +102,25 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     { setTrue: openReportDrawer, setFalse: closeReportDrawer }
   ] = useBoolean(false);
 
-  const onClickAuditResult = useCallback(
+  const [
+    remediationDrawerVisible,
+    { setTrue: openRemediationDrawer, setFalse: closeRemediationDrawer }
+  ] = useBoolean(false);
+
+  const onClickSql = useCallback(
     (record: ScanTypeSqlTableDataSourceItem) => {
       openReportDrawer();
       setCurrentAuditResultRecord(record);
     },
     [openReportDrawer]
+  );
+
+  const onClickAuditResult = useCallback(
+    (record: ScanTypeSqlTableDataSourceItem) => {
+      setRemediationDrawerRecord(record);
+      openRemediationDrawer();
+    },
+    [openRemediationDrawer]
   );
 
   const {
@@ -176,7 +198,7 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     loading: getTableRowLoading,
     refresh: refreshTableRows,
     error: getTableRowError,
-    cancel
+    cancel: cancelTableRowsRequest
   } = useRequest(
     () => {
       const params: IGetInstanceAuditPlanSQLDataV1Params = {
@@ -201,28 +223,22 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
       pollingInterval: 1000,
       pollingErrorRetryCount: 3,
       onSuccess: (res) => {
-        if (res.data?.some((i) => i?.audit_status === BEING_AUDITED)) {
+        if (res.data?.some((row) => row?.audit_status === BEING_AUDITED)) {
           startPollRequest();
         } else {
-          cancel();
+          cancelTableRowsRequest();
           finishPollRequest();
         }
       },
       onError: () => {
-        cancel();
+        cancelTableRowsRequest();
         finishPollRequest();
       }
     }
   );
 
   const recordAuditResult = useMemo<IAuditResult[]>(() => {
-    try {
-      return JSON.parse(
-        currentAuditResultRecord?.['audit_results'] ?? '[]'
-      ) as IAuditResult[];
-    } catch (error) {
-      return [];
-    }
+    return parseAuditResult(currentAuditResultRecord?.['audit_results']);
   }, [currentAuditResultRecord]);
 
   const { auditResultRuleInfo, loading: auditResultInfoLoading } =
@@ -285,6 +301,53 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     t
   ]);
 
+  useEffect(() => {
+    const exportScanTypeRemediation = () => {
+      remediationExportPending();
+      const hideLoading = messageApi.loading(
+        t('managementConf.detail.remediationExportTips'),
+        0
+      );
+
+      SqlManage.exportSqlManageRemediationV1(
+        {
+          project_name: projectName,
+          export_scope: exportSqlManageRemediationV1ExportScopeEnum.scan_task,
+          instance_audit_plan_id: instanceAuditPlanId ?? '',
+          audit_plan_type: auditPlanType
+        },
+        { responseType: 'blob' }
+      )
+        .then((res) => {
+          if (res.status === 200) {
+            messageApi.success(
+              t('managementConf.detail.remediationExportSuccessTips')
+            );
+          }
+        })
+        .finally(() => {
+          remediationExportDone();
+          hideLoading();
+        });
+    };
+    const { unsubscribe } = eventEmitter.subscribe(
+      EmitterKey.Export_Sql_Management_Conf_Detail_Remediation,
+      exportScanTypeRemediation
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [
+    auditPlanType,
+    instanceAuditPlanId,
+    messageApi,
+    projectName,
+    remediationExportDone,
+    remediationExportPending,
+    t
+  ]);
+
   const tableSetting = useMemo<ColumnsSettingProps>(() => {
     return {
       tableName: `sql_management_conf_${auditPlanType}`,
@@ -292,7 +355,13 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
     };
   }, [username, auditPlanType]);
 
-  const loading = getFilterMetaListLoading || (getTableRowLoading && !polling);
+  const loading = useMemo(
+    () =>
+      polling && !getFilterMetaListLoading
+        ? false
+        : getFilterMetaListLoading || getTableRowLoading,
+    [polling, getFilterMetaListLoading, getTableRowLoading]
+  );
 
   const tableHead = useMemo(
     () =>
@@ -300,11 +369,49 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
         auditStatus: t(
           'managementConf.detail.scanTypeSqlCollection.column.auditStatus'
         ),
-        auditResult: t(
-          'managementConf.detail.scanTypeSqlCollection.column.auditResult'
+        firstAuditResult: t(
+          'managementConf.detail.scanTypeSqlCollection.column.firstAuditResult'
+        ),
+        currentAuditResult: t(
+          'managementConf.detail.scanTypeSqlCollection.column.currentAuditResult'
         )
       }),
     [tableMetas?.head, t]
+  );
+
+  const renderAuditResultCell = useCallback(
+    (
+      record: ScanTypeSqlTableDataSourceItem,
+      fieldName: 'first_audit_results' | 'audit_results'
+    ) => {
+      const isBeingAudited = record['audit_status'] === BEING_AUDITED;
+
+      if (isBeingAudited) {
+        return (
+          <AuditResultMessage
+            auditResult={{}}
+            auditStatus={getAuditTaskSQLsV2FilterAuditStatusEnum.doing}
+          />
+        );
+      }
+
+      const results = parseAuditResult(record[fieldName]);
+
+      return (
+        <BasicToolTips
+          title={t('sqlManagement.table.column.viewAuditResultCompare')}
+        >
+          <div
+            data-testid="trigger-open-remediation-drawer"
+            className="audit-result-wrapper"
+            onClick={() => onClickAuditResult(record)}
+          >
+            <AuditLevelSummary auditResults={results} />
+          </div>
+        </BasicToolTips>
+      );
+    },
+    [onClickAuditResult, t]
   );
 
   const columns = useMemo(() => {
@@ -312,23 +419,22 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
       return [];
     }
 
-    const builtColumns = sortableTableColumnFactory(tableHead, {
+    return sortableTableColumnFactory(tableHead, {
       columnClassName: (type) =>
         type === 'sql' ? 'ellipsis-column-large-width' : undefined,
       customRender: (text, record, fieldName, type) => {
+        const isBeingAudited = record['audit_status'] === BEING_AUDITED;
+
         if (fieldName === 'audit_status') {
           return <AuditStatusTag status={text} />;
         }
 
+        if (fieldName === 'first_audit_results') {
+          return renderAuditResultCell(record, 'first_audit_results');
+        }
+
         if (fieldName === 'audit_results') {
-          return (
-            <div
-              data-testid="trigger-open-report-drawer"
-              onClick={() => onClickAuditResult(record)}
-            >
-              <ResultIconRender auditResultInfo={parseAuditResult(text)} />
-            </div>
-          );
+          return renderAuditResultCell(record, 'audit_results');
         }
 
         if (!text) {
@@ -344,7 +450,11 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
             <SQLRenderer.Snippet
               tooltip={false}
               className="pointer"
-              onClick={() => onClickAuditResult(record)}
+              onClick={() => {
+                if (!isBeingAudited) {
+                  onClickSql(record);
+                }
+              }}
               sql={text}
               rows={1}
               showCopyIcon
@@ -356,25 +466,12 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
         return text;
       }
     });
-
-    return builtColumns.map((column) => {
-      if (column.dataIndex === 'audit_results') {
-        return {
-          ...column,
-          title: (
-            <Tooltip
-              title={t(
-                'managementConf.detail.scanTypeSqlCollection.column.auditResultTooltip'
-              )}
-            >
-              <span>{column.title as ReactNode}</span>
-            </Tooltip>
-          )
-        };
-      }
-      return column;
-    });
-  }, [onClickAuditResult, sortableTableColumnFactory, t, tableHead]);
+  }, [
+    onClickSql,
+    renderAuditResultCell,
+    sortableTableColumnFactory,
+    tableHead
+  ]);
 
   return (
     <ScanTypeSqlCollectionStyleWrapper>
@@ -424,6 +521,11 @@ const ScanTypeSqlCollection: React.FC<ScanTypeSqlCollectionProps> = ({
             </BasicButton>
           </Link>
         }
+      />
+      <RemediationDetailDrawer
+        open={remediationDrawerVisible}
+        onClose={closeRemediationDrawer}
+        sqlManageId={remediationDrawerRecord?.id}
       />
     </ScanTypeSqlCollectionStyleWrapper>
   );

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.type.ts
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/index.type.ts
@@ -6,6 +6,8 @@ export type ScanTypeSqlCollectionProps = {
   instanceType: string;
   exportPending: () => void;
   exportDone: () => void;
+  remediationExportPending: () => void;
+  remediationExportDone: () => void;
 };
 
 export type ScanTypeSqlTableDataSourceItem = { [key in string]: string };

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/style.ts
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/style.ts
@@ -1,6 +1,10 @@
-import { styled } from '@mui/material';
+import { styled } from '@mui/material/styles';
 
 export const ScanTypeSqlCollectionStyleWrapper = styled('section')`
+  .audit-result-wrapper {
+    cursor: pointer;
+  }
+
   .table-describe-column {
     max-width: 600px;
   }

--- a/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/utils.ts
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/ScanTypeSqlCollection/utils.ts
@@ -2,49 +2,52 @@ import {
   IAuditResult,
   IAuditPlanSQLHeadV1
 } from '@actiontech/shared/lib/api/sqle/service/common';
-import { AuditResultInfoItem } from '../../../../components/AuditResultMessage/index.type';
 
 export const BEING_AUDITED = 'being_audited';
 export const AUDITED = 'audited';
 
 const AUDIT_STATUS_FIELD = 'audit_status';
 const AUDIT_RESULTS_FIELD = 'audit_results';
+const FIRST_AUDIT_RESULTS_FIELD = 'first_audit_results';
 const PRIORITY_FIELD = 'priority';
 
-type AuditResultJsonItem = IAuditResult & {
-  execution_failed?: boolean;
-};
-
-export const parseAuditResult = (
-  resultString: string
-): AuditResultInfoItem[] => {
-  let results: AuditResultJsonItem[] = [];
-  try {
-    const parsed = JSON.parse(resultString ?? '[]') as
-      | AuditResultJsonItem[]
-      | null;
-    results = Array.isArray(parsed) ? parsed : [];
-  } catch {
-    results = [];
+/**
+ * 通用的审核结果解析函数：兼容字符串(JSON)、双重编码字符串、数组以及空值。
+ */
+export const parseAuditResult = (raw?: unknown): IAuditResult[] => {
+  if (raw === undefined || raw === null || raw === '' || raw === 'null') {
+    return [];
   }
-  return results.map((item) => ({
-    level: item.level ?? '',
-    executionFailed: !!item.execution_failed
-  }));
+  if (Array.isArray(raw)) {
+    return raw as IAuditResult[];
+  }
+  if (typeof raw !== 'string') {
+    return [];
+  }
+  try {
+    let parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'string') {
+      parsed = JSON.parse(parsed);
+    }
+    return Array.isArray(parsed) ? (parsed as IAuditResult[]) : [];
+  } catch {
+    return [];
+  }
 };
 
 export type AuditColumnLabels = {
   auditStatus: string;
-  auditResult: string;
+  firstAuditResult: string;
+  currentAuditResult: string;
 };
 
 /**
  * 在后端返回的 head 中注入 `audit_status` 列，并按以下顺序排列：
- *   ... → audit_status → priority → audit_results → ...
+ *   ... → audit_status → priority → first_audit_results → audit_results → ...
  * 即：保证 `audit_status` 出现在 `priority` 之前；若 `priority` 不存在，则
- * 退化为出现在 `audit_results` 之前。
+ * 退化为出现在 `first_audit_results` / `audit_results` 之前。
  *
- * 同时统一覆盖 `audit_results` 列标题为「审核结果」，避免后端返回的旧文案。
+ * 同时统一覆盖审核结果列标题，避免后端返回的旧文案。
  */
 export const buildTableHeadWithAuditStatus = (
   head: IAuditPlanSQLHeadV1[] | undefined,
@@ -57,8 +60,11 @@ export const buildTableHeadWithAuditStatus = (
   const withoutAuditStatus = head
     .filter((item) => item.field_name !== AUDIT_STATUS_FIELD)
     .map<IAuditPlanSQLHeadV1>((item) => {
+      if (item.field_name === FIRST_AUDIT_RESULTS_FIELD) {
+        return { ...item, desc: labels.firstAuditResult };
+      }
       if (item.field_name === AUDIT_RESULTS_FIELD) {
-        return { ...item, desc: labels.auditResult };
+        return { ...item, desc: labels.currentAuditResult };
       }
       return item;
     });
@@ -72,20 +78,26 @@ export const buildTableHeadWithAuditStatus = (
   const priorityIndex = withoutAuditStatus.findIndex(
     (item) => item.field_name === PRIORITY_FIELD
   );
-  const insertIndex =
+  const firstAuditResultsIndex = withoutAuditStatus.findIndex(
+    (item) => item.field_name === FIRST_AUDIT_RESULTS_FIELD
+  );
+  const auditResultsIndex = withoutAuditStatus.findIndex(
+    (item) => item.field_name === AUDIT_RESULTS_FIELD
+  );
+  const insertBeforeIndex =
     priorityIndex !== -1
       ? priorityIndex
-      : withoutAuditStatus.findIndex(
-          (item) => item.field_name === AUDIT_RESULTS_FIELD
-        );
+      : firstAuditResultsIndex !== -1
+      ? firstAuditResultsIndex
+      : auditResultsIndex;
 
-  if (insertIndex === -1) {
+  if (insertBeforeIndex === -1) {
     return withoutAuditStatus;
   }
 
   return [
-    ...withoutAuditStatus.slice(0, insertIndex),
+    ...withoutAuditStatus.slice(0, insertBeforeIndex),
     auditStatusColumn,
-    ...withoutAuditStatus.slice(insertIndex)
+    ...withoutAuditStatus.slice(insertBeforeIndex)
   ];
 };

--- a/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/__snapshots__/index.test.tsx.snap
@@ -162,6 +162,33 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 1`] = `
         />
         <div
           class="ant-space-item"
+          style="margin-right: 8px;"
+        >
+          <button
+            class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
+            type="button"
+          >
+            <span
+              class="ant-btn-icon"
+            >
+              <svg
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1.75 11.083h10.5v1.167H1.75zm5.833-3.4 3.542-3.541.825.824L7 9.916 2.05 4.968l.825-.825 3.542 3.54V1.167h1.166z"
+                />
+              </svg>
+            </span>
+            <span>
+              导出该数据源整改报表
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-space-item"
         >
           <button
             class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-btn-sm ant-btn-icon-only basic-button-wrapper css-geipcv"
@@ -224,7 +251,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 1`] = `
                           <col />
                           <col />
                           <col />
-                          <col />
                           <col
                             style="width: 246px;"
                           />
@@ -262,12 +288,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 1`] = `
                               scope="col"
                             >
                               采集到的SQL数
-                            </th>
-                            <th
-                              class="ant-table-cell"
-                              scope="col"
-                            >
-                              审核有问题的SQL数
                             </th>
                             <th
                               class="ant-table-cell"
@@ -355,22 +375,13 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 1`] = `
                                  
                               </div>
                             </td>
-                            <td
-                              style="padding: 0px; border: 0px; height: 0px;"
-                            >
-                              <div
-                                style="height: 0px; overflow: hidden;"
-                              >
-                                 
-                              </div>
-                            </td>
                           </tr>
                           <tr
                             class="ant-table-placeholder"
                           >
                             <td
                               class="ant-table-cell"
-                              colspan="8"
+                              colspan="7"
                             >
                               <div
                                 class="ant-table-expanded-row-fixed"
@@ -515,6 +526,33 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
         />
         <div
           class="ant-space-item"
+          style="margin-right: 8px;"
+        >
+          <button
+            class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default basic-button-wrapper css-geipcv"
+            type="button"
+          >
+            <span
+              class="ant-btn-icon"
+            >
+              <svg
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1.75 11.083h10.5v1.167H1.75zm5.833-3.4 3.542-3.541.825.824L7 9.916 2.05 4.968l.825-.825 3.542 3.54V1.167h1.166z"
+                />
+              </svg>
+            </span>
+            <span>
+              导出该数据源整改报表
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-space-item"
         >
           <button
             class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-btn-sm ant-btn-icon-only basic-button-wrapper css-geipcv"
@@ -577,7 +615,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                           <col />
                           <col />
                           <col />
-                          <col />
                           <col
                             style="width: 246px;"
                           />
@@ -620,12 +657,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                               class="ant-table-cell"
                               scope="col"
                             >
-                              审核有问题的SQL数
-                            </th>
-                            <th
-                              class="ant-table-cell"
-                              scope="col"
-                            >
                               最近一次采集时间
                             </th>
                             <th
@@ -645,15 +676,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                             class="ant-table-measure-row"
                             style="height: 0px; font-size: 0px;"
                           >
-                            <td
-                              style="padding: 0px; border: 0px; height: 0px;"
-                            >
-                              <div
-                                style="height: 0px; overflow: hidden;"
-                              >
-                                 
-                              </div>
-                            </td>
                             <td
                               style="padding: 0px; border: 0px; height: 0px;"
                             >
@@ -767,11 +789,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                               class="ant-table-cell"
                             >
                               -
-                            </td>
-                            <td
-                              class="ant-table-cell"
-                            >
-                              0
                             </td>
                             <td
                               class="ant-table-cell"
@@ -949,11 +966,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                             <td
                               class="ant-table-cell"
                             >
-                              0
-                            </td>
-                            <td
-                              class="ant-table-cell"
-                            >
                               -
                             </td>
                             <td
@@ -1057,11 +1069,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                             <td
                               class="ant-table-cell"
                             >
-                              0
-                            </td>
-                            <td
-                              class="ant-table-cell"
-                            >
                               -
                             </td>
                             <td
@@ -1156,11 +1163,6 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                               class="ant-table-cell"
                             >
                               -
-                            </td>
-                            <td
-                              class="ant-table-cell"
-                            >
-                              0
                             </td>
                             <td
                               class="ant-table-cell"

--- a/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/__snapshots__/index.test.tsx.snap
@@ -251,6 +251,7 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 1`] = `
                           <col />
                           <col />
                           <col />
+                          <col />
                           <col
                             style="width: 246px;"
                           />
@@ -288,6 +289,12 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 1`] = `
                               scope="col"
                             >
                               采集到的SQL数
+                            </th>
+                            <th
+                              class="ant-table-cell"
+                              scope="col"
+                            >
+                              审核有问题的SQL数
                             </th>
                             <th
                               class="ant-table-cell"
@@ -375,13 +382,22 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 1`] = `
                                  
                               </div>
                             </td>
+                            <td
+                              style="padding: 0px; border: 0px; height: 0px;"
+                            >
+                              <div
+                                style="height: 0px; overflow: hidden;"
+                              >
+                                 
+                              </div>
+                            </td>
                           </tr>
                           <tr
                             class="ant-table-placeholder"
                           >
                             <td
                               class="ant-table-cell"
-                              colspan="7"
+                              colspan="8"
                             >
                               <div
                                 class="ant-table-expanded-row-fixed"
@@ -615,6 +631,7 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                           <col />
                           <col />
                           <col />
+                          <col />
                           <col
                             style="width: 246px;"
                           />
@@ -657,6 +674,12 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                               class="ant-table-cell"
                               scope="col"
                             >
+                              审核有问题的SQL数
+                            </th>
+                            <th
+                              class="ant-table-cell"
+                              scope="col"
+                            >
                               最近一次采集时间
                             </th>
                             <th
@@ -676,6 +699,15 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                             class="ant-table-measure-row"
                             style="height: 0px; font-size: 0px;"
                           >
+                            <td
+                              style="padding: 0px; border: 0px; height: 0px;"
+                            >
+                              <div
+                                style="height: 0px; overflow: hidden;"
+                              >
+                                 
+                              </div>
+                            </td>
                             <td
                               style="padding: 0px; border: 0px; height: 0px;"
                             >
@@ -789,6 +821,11 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                               class="ant-table-cell"
                             >
                               -
+                            </td>
+                            <td
+                              class="ant-table-cell"
+                            >
+                              0
                             </td>
                             <td
                               class="ant-table-cell"
@@ -966,6 +1003,11 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                             <td
                               class="ant-table-cell"
                             >
+                              0
+                            </td>
+                            <td
+                              class="ant-table-cell"
+                            >
                               -
                             </td>
                             <td
@@ -1069,6 +1111,11 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                             <td
                               class="ant-table-cell"
                             >
+                              0
+                            </td>
+                            <td
+                              class="ant-table-cell"
+                            >
                               -
                             </td>
                             <td
@@ -1163,6 +1210,11 @@ exports[`test SqlManagementConf/Detail/index.tsx should match snapshot 2`] = `
                               class="ant-table-cell"
                             >
                               -
+                            </td>
+                            <td
+                              class="ant-table-cell"
+                            >
+                              0
                             </td>
                             <td
                               class="ant-table-cell"

--- a/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/index.test.tsx
@@ -7,7 +7,8 @@ import {
 import instanceAuditPlan from '../../../../testUtils/mockApi/instanceAuditPlan';
 import { superRender } from '../../../../testUtils/customRender';
 import ConfDetail from '..';
-import { act, fireEvent } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { mockUseCurrentProject } from '@actiontech/shared/lib/testUtil/mockHook/mockUseCurrentProject';
 import { mockUseCurrentUser } from '@actiontech/shared/lib/testUtil/mockHook/mockUseCurrentUser';
 import { mockUseUserOperationPermission } from '@actiontech/shared/lib/testUtil/mockHook/mockUseUserOperationPermission';
@@ -87,13 +88,14 @@ describe('test SqlManagementConf/Detail/index.tsx', () => {
 
     expect(queryByText('导出报表')).not.toBeInTheDocument();
     expect(queryByText('立即审核')).not.toBeInTheDocument();
-    fireEvent.click(getAllByText('自定义')[0]);
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(getAllByText('自定义')[0]);
     await act(async () => jest.advanceTimersByTime(0));
     expect(queryByText('导出报表')).toBeInTheDocument();
     expect(queryByText('立即审核')).toBeInTheDocument();
 
-    fireEvent.click(getByText('导出报表'));
-    fireEvent.click(getByText('导出扫描任务报表'));
+    await user.click(getByText('导出报表'));
+    await user.click(await screen.findByText('导出扫描任务报表'));
     expect(getInstanceAuditPlanSQLExportSpy).toHaveBeenCalledTimes(1);
     expect(getInstanceAuditPlanSQLExportSpy).toHaveBeenNthCalledWith(
       1,

--- a/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/__tests__/index.test.tsx
@@ -85,14 +85,15 @@ describe('test SqlManagementConf/Detail/index.tsx', () => {
     );
     await act(async () => jest.advanceTimersByTime(3000));
 
-    expect(queryByText('导出')).not.toBeInTheDocument();
+    expect(queryByText('导出报表')).not.toBeInTheDocument();
     expect(queryByText('立即审核')).not.toBeInTheDocument();
     fireEvent.click(getAllByText('自定义')[0]);
     await act(async () => jest.advanceTimersByTime(0));
-    expect(queryByText('导 出')).toBeInTheDocument();
+    expect(queryByText('导出报表')).toBeInTheDocument();
     expect(queryByText('立即审核')).toBeInTheDocument();
 
-    fireEvent.click(getByText('导 出'));
+    fireEvent.click(getByText('导出报表'));
+    fireEvent.click(getByText('导出扫描任务报表'));
     expect(getInstanceAuditPlanSQLExportSpy).toHaveBeenCalledTimes(1);
     expect(getInstanceAuditPlanSQLExportSpy).toHaveBeenNthCalledWith(
       1,
@@ -105,10 +106,10 @@ describe('test SqlManagementConf/Detail/index.tsx', () => {
       },
       { responseType: 'blob' }
     );
-    expect(getByText('导 出').closest('button')).toBeDisabled();
+    expect(getByText('导出报表').closest('button')).toBeDisabled();
 
     await act(async () => jest.advanceTimersByTime(3000));
-    expect(getByText('导 出').closest('button')).not.toBeDisabled();
+    expect(getByText('导出报表').closest('button')).not.toBeDisabled();
 
     fireEvent.click(getByText('立即审核'));
     expect(auditPlanTriggerSqlAuditSpy).toHaveBeenCalledTimes(1);

--- a/packages/sqle/src/page/SqlManagementConf/Detail/index.tsx
+++ b/packages/sqle/src/page/SqlManagementConf/Detail/index.tsx
@@ -10,7 +10,7 @@ import { SegmentedTabsProps } from '@actiontech/shared/lib/components/SegmentedT
 import ConfDetailOverview from './Overview';
 import { TableRefreshButton } from '@actiontech/shared/lib/components/ActiontechTable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import ScanTypeSqlCollection from './ScanTypeSqlCollection/indx';
+import ScanTypeSqlCollection from './ScanTypeSqlCollection';
 import { useBoolean, useRequest } from 'ahooks';
 import {
   useLocation,
@@ -19,11 +19,14 @@ import {
   useSearchParams
 } from 'react-router-dom';
 import instance_audit_plan from '@actiontech/shared/lib/api/sqle/service/instance_audit_plan';
+import SqlManage from '@actiontech/shared/lib/api/sqle/service/SqlManage';
 import {
   useCurrentProject,
+  useCurrentUser,
   useUserOperationPermission
 } from '@actiontech/shared/lib/global';
-import { Result, Space } from 'antd';
+import { Result, Space, Dropdown } from 'antd';
+import type { MenuProps } from 'antd';
 import { getErrorMessage } from '@actiontech/shared/lib/utils/Common';
 import { SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY } from './index.data';
 import eventEmitter from '../../../utils/EventEmitter';
@@ -31,6 +34,8 @@ import EmitterKey from '../../../data/EmitterKey';
 import { message } from 'antd';
 import { ResponseCode } from '@actiontech/shared/lib/enum';
 import { OpPermissionItemOpPermissionTypeEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+import { DownArrowLineOutlined } from '@actiontech/icons';
+import { exportSqlManageRemediationV1ExportScopeEnum } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
 
 const ConfDetail: React.FC = () => {
   const { t } = useTranslation();
@@ -38,13 +43,18 @@ const ConfDetail: React.FC = () => {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
-  const { projectName } = useCurrentProject();
+  const { projectName, projectArchive } = useCurrentProject();
+  const { isAdmin, isProjectManager } = useCurrentUser();
 
   const [activeKey, setActiveKey] = useState(
     SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY
   );
   const [exporting, { setTrue: exportPending, setFalse: exportDone }] =
     useBoolean();
+  const [
+    remediationExporting,
+    { setTrue: remediationExportPending, setFalse: remediationExportDone }
+  ] = useBoolean();
 
   const [auditing, { setTrue: auditPending, setFalse: auditDone }] =
     useBoolean();
@@ -100,6 +110,44 @@ const ConfDetail: React.FC = () => {
     );
   }, [data?.instance_id, isHaveServicePermission]);
 
+  const actionPermission = useMemo(() => {
+    return isAdmin || isProjectManager(projectName);
+  }, [isAdmin, isProjectManager, projectName]);
+
+  const remediationExportPermission = useMemo(() => {
+    return (actionPermission || hasOpPermission) && !projectArchive;
+  }, [actionPermission, hasOpPermission, projectArchive]);
+
+  const exportButtonDisabled = exporting || remediationExporting;
+
+  const scanTypeExportMenuItems: MenuProps['items'] = useMemo(() => {
+    const items: MenuProps['items'] = [];
+
+    if (remediationExportPermission) {
+      items.push({
+        key: 'remediation',
+        label: t('managementConf.detail.exportRemediationReport')
+      });
+    }
+
+    items.push({
+      key: 'scanTask',
+      label: t('managementConf.detail.exportScanTaskReport')
+    });
+
+    return items;
+  }, [remediationExportPermission, t]);
+
+  const onScanTypeExportMenuClick: MenuProps['onClick'] = ({ key }) => {
+    if (key === 'remediation') {
+      exportScanTypeRemediation();
+      return;
+    }
+    if (key === 'scanTask') {
+      exportScanTypeSqlDetail();
+    }
+  };
+
   const items: SegmentedTabsProps['items'] = [
     {
       label: t('managementConf.detail.overview.title'),
@@ -127,6 +175,8 @@ const ConfDetail: React.FC = () => {
           instanceType={data.instance_type ?? ''}
           exportPending={exportPending}
           exportDone={exportDone}
+          remediationExportPending={remediationExportPending}
+          remediationExportDone={remediationExportDone}
         />
       )
     })) ?? [])
@@ -142,6 +192,41 @@ const ConfDetail: React.FC = () => {
 
   const exportScanTypeSqlDetail = () => {
     eventEmitter.emit(EmitterKey.Export_Sql_Management_Conf_Detail_Sql_List);
+  };
+
+  const exportScanTypeRemediation = () => {
+    eventEmitter.emit(EmitterKey.Export_Sql_Management_Conf_Detail_Remediation);
+  };
+
+  const exportDataSourceRemediation = () => {
+    if (!remediationExportPermission || !data?.instance_id) {
+      return;
+    }
+    remediationExportPending();
+    const hideLoading = messageApi.loading(
+      t('managementConf.detail.remediationExportTips'),
+      0
+    );
+
+    SqlManage.exportSqlManageRemediationV1(
+      {
+        project_name: projectName,
+        export_scope: exportSqlManageRemediationV1ExportScopeEnum.data_source,
+        filter_instance_id: data.instance_id
+      },
+      { responseType: 'blob' }
+    )
+      .then((res) => {
+        if (res.status === 200) {
+          messageApi.success(
+            t('managementConf.detail.remediationExportSuccessTips')
+          );
+        }
+      })
+      .finally(() => {
+        hideLoading();
+        remediationExportDone();
+      });
   };
 
   const onAuditImmediately = () => {
@@ -197,12 +282,20 @@ const ConfDetail: React.FC = () => {
             <Space>
               <EmptyBox if={activeKey !== SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY}>
                 <Space>
-                  <BasicButton
-                    disabled={exporting}
-                    onClick={exportScanTypeSqlDetail}
+                  <Dropdown
+                    menu={{
+                      items: scanTypeExportMenuItems,
+                      onClick: onScanTypeExportMenuClick
+                    }}
+                    disabled={exportButtonDisabled}
                   >
-                    {t('managementConf.detail.export')}
-                  </BasicButton>
+                    <BasicButton
+                      icon={<DownArrowLineOutlined />}
+                      disabled={exportButtonDisabled}
+                    >
+                      {t('managementConf.detail.exportReport')}
+                    </BasicButton>
+                  </Dropdown>
                   {hasOpPermission && (
                     <BasicButton
                       loading={auditing}
@@ -213,6 +306,20 @@ const ConfDetail: React.FC = () => {
                     </BasicButton>
                   )}
                 </Space>
+              </EmptyBox>
+              <EmptyBox
+                if={
+                  activeKey === SQL_MANAGEMENT_CONF_OVERVIEW_TAB_KEY &&
+                  remediationExportPermission
+                }
+              >
+                <BasicButton
+                  disabled={remediationExporting}
+                  onClick={exportDataSourceRemediation}
+                  icon={<DownArrowLineOutlined />}
+                >
+                  {t('managementConf.detail.exportDataSourceRemediationReport')}
+                </BasicButton>
               </EmptyBox>
               <TableRefreshButton refresh={onRefresh} />
             </Space>

--- a/packages/sqle/src/testUtils/mockApi/instanceAuditPlan/data.ts
+++ b/packages/sqle/src/testUtils/mockApi/instanceAuditPlan/data.ts
@@ -552,8 +552,13 @@ export const mockAuditPlanSQLMeta: IAuditPlanSQLMetaResV1 = {
       sortable: false
     },
     {
+      field_name: 'first_audit_results',
+      desc: '最初审核结果',
+      sortable: false
+    },
+    {
       field_name: 'audit_results',
-      desc: '审核结果',
+      desc: '当前审核结果',
       sortable: false
     },
     {
@@ -725,6 +730,7 @@ export const mockAuditPlanSQLData: IAuditPlanSQLDataResV1 = {
     {
       id: '1',
       audit_results: 'null',
+      audit_status: 'being_audited',
       counter: '598',
       db_user: '',
       fingerprint: 'SELECT ?,SLEEP(?) LIMIT ?,?',
@@ -738,6 +744,7 @@ export const mockAuditPlanSQLData: IAuditPlanSQLDataResV1 = {
     {
       id: '12',
       audit_results: 'null',
+      audit_status: 'being_audited',
       counter: '299',
       db_user: '',
       fingerprint: 'SELECT ?,?,?,?,?,SLEEP(?) LIMIT ?,?',
@@ -751,6 +758,7 @@ export const mockAuditPlanSQLData: IAuditPlanSQLDataResV1 = {
     {
       id: '123',
       audit_results: 'null',
+      audit_status: 'being_audited',
       counter: '299',
       db_user: '',
       fingerprint: 'SELECT SLEEP(?) LIMIT ?,?',
@@ -763,6 +771,8 @@ export const mockAuditPlanSQLData: IAuditPlanSQLDataResV1 = {
     },
     {
       id: '1234',
+      first_audit_results:
+        '[{"level": "error", "message": "最初审核：建议添加主键", "rule_name": "rule_primary_key"}]',
       audit_results:
         '[{"level": "warn", "message": "语法错误或者解析器不支持，请人工确认SQL正确性", "rule_name": ""}]',
       counter: '2388',
@@ -778,6 +788,7 @@ export const mockAuditPlanSQLData: IAuditPlanSQLDataResV1 = {
     {
       id: '12345',
       audit_results: 'null',
+      audit_status: 'being_audited',
       counter: '8559',
       db_user: '',
       fingerprint: 'COMMIT',
@@ -791,6 +802,7 @@ export const mockAuditPlanSQLData: IAuditPlanSQLDataResV1 = {
     {
       id: '123456',
       audit_results: 'null',
+      audit_status: 'being_audited',
       counter: '299',
       db_user: '',
       fingerprint:

--- a/packages/sqle/src/testUtils/mockApi/sqlManage/index.ts
+++ b/packages/sqle/src/testUtils/mockApi/sqlManage/index.ts
@@ -11,6 +11,8 @@ class MockSqlManageApi implements MockSpyApy {
     this.batchUpdateSqlManage();
     this.getSqlManageList();
     this.exportSqlManage();
+    this.exportSqlManageRemediation();
+    this.exportGlobalSqlManageRemediation();
   }
 
   public getSqlManageRuleTips() {
@@ -47,6 +49,28 @@ class MockSqlManageApi implements MockSpyApy {
   public exportSqlManage() {
     const spy = jest.spyOn(SqlManage, 'exportSqlManageV1');
     spy.mockImplementation(() => createSpySuccessResponse({}));
+    return spy;
+  }
+
+  public getSqlManageRemediation() {
+    const spy = jest.spyOn(SqlManage, 'GetSqlManageRemediationV1');
+    spy.mockImplementation(() =>
+      createSpySuccessResponse({
+        data: {}
+      })
+    );
+    return spy;
+  }
+
+  public exportSqlManageRemediation() {
+    const spy = jest.spyOn(SqlManage, 'exportSqlManageRemediationV1');
+    spy.mockImplementation(() => createSpySuccessResponse({}, { status: 200 }));
+    return spy;
+  }
+
+  public exportGlobalSqlManageRemediation() {
+    const spy = jest.spyOn(SqlManage, 'exportGlobalSqlManageRemediationV1');
+    spy.mockImplementation(() => createSpySuccessResponse({}, { status: 200 }));
     return spy;
   }
 }


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2988

## 描述你的变更

本次 MR 为 EE 端 SQL 管理引入 **SQL 治理（Remediation）** 相关能力，覆盖列表展示、详情对比、导出及审计结果展示增强。

### API 与类型
- 扩展 `SqlManage` API：新增治理查询/导出接口及类型定义，列表响应增加治理跟踪相关字段。

### SQL 管理列表
- 列表新增治理跟踪列，支持从列表进入治理详情。
- 新增治理数据导出能力，注册全局导出事件与 `RemediationDetailDrawer` 弹窗 key。
- 更新状态抽屉（StatusDrawer）标题与审计结果展示，适配治理场景。

### 治理详情与对比
- 新增 `RemediationDetailDrawer` 组件，支持 SQL 修复前后 diff 对比。
- `SqlAnalyze` / `SqlManage` 页面集成治理对比视图。
- `ScanTypeSqlCollection` 重命名入口模块，支持首次审计结果列、治理导出及 `showAnnotation` 配置。

### 审计结果展示增强
- 增强 `AuditResultMessage`：支持审计等级汇总、i18n 展示文案及 `ruleDesc` 模式。
- `ReportDrawer` 审计结果展示规则描述，与 SQL 管理页审计信息保持一致。

### 国际化
- 补充 zh-CN / en-US 文案：治理抽屉、导出操作、首次/当前审计结果等相关标签。

### 测试与其他
- 更新 SQL 管理配置详情、StatusDrawer、SqlAnalyze 等快照与单测，修复治理相关测试稳定性及 `AuditLevelSummary` TS 类型问题。
- 将 `.cursor/` 加入 `.gitignore`，避免本地 IDE 配置入库。

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [X] 我已完成自测
- [X] 我已记录完整日志方便进行诊断
- [X] 我已在关联的issue里补充了实现方案
- [X] 我已在关联的issue里补充了测试影响面
- [X] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [X] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------