### PR TITLE
feat(login): disable multiple device login toggle UI

### DIFF
--- a/packages/base/src/locale/en-US/dmsSystem.ts
+++ b/packages/base/src/locale/en-US/dmsSystem.ts
@@ -153,6 +153,25 @@ export default {
       'Skip the verification of the request sending source, which may put your account at risk. it is recommended to enable this option only in a trusted environment. after enabling, SQLE will no longer verify the state parameter in the callback.'
   },
 
+  loginBasic: {
+    passwordLoginDisabled: 'Disable password login',
+    passwordLoginDisabledTips:
+      'Prevent non-admin users from logging in with username and password',
+    disableMultipleLogin: 'Disable simultaneous multi-device login',
+    disableMultipleLoginTips:
+      'When enabled, only the latest login session is kept per account; logging in on a new device will force logout on other devices',
+    loginButtonText: 'Login button text',
+    loginButtonTextTips: 'Login page button text',
+    enableOAuthFirst: 'Enable OAuth2.0 login first',
+    confirmDisable: 'Are you sure you want to disable this setting?',
+    confirmEnableWithLDAP:
+      'LDAP relies on password login and will be disabled together. Continue?',
+    confirmEnable: 'Are you sure you want to enable this setting?',
+    confirmDisableMultipleLogin:
+      'When enabled, only the latest login session is kept per account. Continue?',
+    confirmEnableMultipleLogin: 'Are you sure you want to disable this setting?'
+  },
+
   dingTalk: {
     titleTips:
       "The approval information will be sent to the corresponding dingtalk account according to the auditor'S mobile number",

--- a/packages/base/src/locale/zh-CN/dmsSystem.ts
+++ b/packages/base/src/locale/zh-CN/dmsSystem.ts
@@ -183,13 +183,19 @@ export default {
   loginBasic: {
     passwordLoginDisabled: '是否禁用账密登录',
     passwordLoginDisabledTips: '禁止除管理员外的普通用户通过账号和密码登录',
+    disableMultipleLogin: '禁止同一账号多设备同时登录',
+    disableMultipleLoginTips:
+      '开启后，同一账号仅保留最近一次登录会话；新设备登录后，旧设备将被强制退出',
     loginButtonText: '登录按钮文字',
     loginButtonTextTips: 'login页面登录按钮文字',
     enableOAuthFirst: '需先启用OAuth2.0登录',
     confirmDisable: '是否确认关闭当前配置？',
     confirmEnableWithLDAP:
       'LDAP服务基于账密登录，会同时被禁用，是否确认开启禁用？',
-    confirmEnable: '是否确认开启当前配置？'
+    confirmEnable: '是否确认开启当前配置？',
+    confirmDisableMultipleLogin:
+      '开启后，同一账号仅保留最近一次登录会话，是否确认开启？',
+    confirmEnableMultipleLogin: '是否确认关闭当前配置？'
   },
 
   dingTalk: {

--- a/packages/base/src/page/System/LoginConnection/LoginBasicSetting/__snapshots__/indes.test.tsx.snap
+++ b/packages/base/src/page/System/LoginConnection/LoginBasicSetting/__snapshots__/indes.test.tsx.snap
@@ -126,6 +126,57 @@ exports[`LoginBasicSetting updateLoginConfig should match snapshot 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="ant-row ant-row-space-between ant-row-middle css-19fu9ar"
+        >
+          <div
+            class="ant-col ant-col-11 config-item-label"
+          >
+            <div
+              class="config-item-label"
+            >
+              <div
+                class="title"
+              >
+                禁止同一账号多设备同时登录
+              </div>
+              <div
+                class="tips"
+              >
+                开启后，同一账号仅保留最近一次登录会话；新设备登录后，旧设备将被强制退出
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-space ant-space-horizontal ant-space-align-center config-item-filed"
+          >
+            <div
+              class="ant-space-item"
+            >
+              <button
+                aria-checked="false"
+                class="ant-switch basic-switch-wrapper css-g6dhbn"
+                data-testid="multiple-login-disabled-switch"
+                role="switch"
+                type="button"
+              >
+                <div
+                  class="ant-switch-handle"
+                />
+                <span
+                  class="ant-switch-inner"
+                >
+                  <span
+                    class="ant-switch-inner-checked"
+                  />
+                  <span
+                    class="ant-switch-inner-unchecked"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/base/src/page/System/LoginConnection/LoginBasicSetting/index.tsx
+++ b/packages/base/src/page/System/LoginConnection/LoginBasicSetting/index.tsx
@@ -12,6 +12,7 @@ const LoginBasicSetting: React.FC = () => {
   const { t } = useTranslation();
   const { isLDAPEnabled, isOAuthEnabled } = useLoginConnectionContext();
   const [isPasswordLoginDisabled, setIsPasswordLoginDisabled] = useState(false);
+  const [isMultipleLoginDisabled, setIsMultipleLoginDisabled] = useState(false);
   const [loginButtonText, setLoginButtonText] = useState<string>();
   const [
     isLoginButtonEditing,
@@ -38,6 +39,7 @@ const LoginBasicSetting: React.FC = () => {
       if (res.data.code === ResponseCode.SUCCESS) {
         setLoginButtonText(res.data.data?.login_button_text);
         setIsPasswordLoginDisabled(!!res.data.data?.disable_user_pwd_login);
+        setIsMultipleLoginDisabled(!!res.data.data?.disable_multiple_login);
       }
     })
   );
@@ -75,6 +77,28 @@ const LoginBasicSetting: React.FC = () => {
       </Popconfirm>
     );
   };
+  const renderMultipleLoginSwitch = () => {
+    const confirmTitle = isMultipleLoginDisabled
+      ? t('dmsSystem.loginBasic.confirmEnableMultipleLogin')
+      : t('dmsSystem.loginBasic.confirmDisableMultipleLogin');
+    return (
+      <Popconfirm
+        title={confirmTitle}
+        okText={t('common.ok')}
+        cancelText={t('common.cancel')}
+        onConfirm={() => {
+          const newValue = !isMultipleLoginDisabled;
+          setIsMultipleLoginDisabled(newValue);
+          updateLoginConfig(newValue, 'disable_multiple_login');
+        }}
+      >
+        <BasicSwitch
+          data-testid="multiple-login-disabled-switch"
+          checked={isMultipleLoginDisabled}
+        />
+      </Popconfirm>
+    );
+  };
   return (
     <Spin spinning={loading} delay={300}>
       <ConfigItem
@@ -106,6 +130,16 @@ const LoginBasicSetting: React.FC = () => {
           </LabelContent>
         }
         inputNode={renderPasswordLoginSwitch()}
+      />
+      <ConfigItem
+        label={
+          <LabelContent
+            tips={t('dmsSystem.loginBasic.disableMultipleLoginTips')}
+          >
+            {t('dmsSystem.loginBasic.disableMultipleLogin')}
+          </LabelContent>
+        }
+        inputNode={renderMultipleLoginSwitch()}
       />
     </Spin>
   );

--- a/packages/base/src/page/System/LoginConnection/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/System/LoginConnection/__snapshots__/index.test.tsx.snap
@@ -2444,6 +2444,57 @@ exports[`base/System/LoginConnection render snap 1`] = `
               </div>
             </div>
           </div>
+          <div
+            class="ant-row ant-row-space-between ant-row-middle css-19fu9ar"
+          >
+            <div
+              class="ant-col ant-col-11 config-item-label"
+            >
+              <div
+                class="config-item-label"
+              >
+                <div
+                  class="title"
+                >
+                  禁止同一账号多设备同时登录
+                </div>
+                <div
+                  class="tips"
+                >
+                  开启后，同一账号仅保留最近一次登录会话；新设备登录后，旧设备将被强制退出
+                </div>
+              </div>
+            </div>
+            <div
+              class="ant-space ant-space-horizontal ant-space-align-center config-item-filed"
+            >
+              <div
+                class="ant-space-item"
+              >
+                <button
+                  aria-checked="false"
+                  class="ant-switch basic-switch-wrapper css-g6dhbn"
+                  data-testid="multiple-login-disabled-switch"
+                  role="switch"
+                  type="button"
+                >
+                  <div
+                    class="ant-switch-handle"
+                  />
+                  <span
+                    class="ant-switch-inner"
+                  >
+                    <span
+                      class="ant-switch-inner-checked"
+                    />
+                    <span
+                      class="ant-switch-inner-unchecked"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>
@@ -4862,6 +4913,57 @@ exports[`base/System/LoginConnection render snap 2`] = `
                     </button>
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-row ant-row-space-between ant-row-middle css-19fu9ar"
+          >
+            <div
+              class="ant-col ant-col-11 config-item-label"
+            >
+              <div
+                class="config-item-label"
+              >
+                <div
+                  class="title"
+                >
+                  禁止同一账号多设备同时登录
+                </div>
+                <div
+                  class="tips"
+                >
+                  开启后，同一账号仅保留最近一次登录会话；新设备登录后，旧设备将被强制退出
+                </div>
+              </div>
+            </div>
+            <div
+              class="ant-space ant-space-horizontal ant-space-align-center config-item-filed"
+            >
+              <div
+                class="ant-space-item"
+              >
+                <button
+                  aria-checked="false"
+                  class="ant-switch basic-switch-wrapper css-g6dhbn"
+                  data-testid="multiple-login-disabled-switch"
+                  role="switch"
+                  type="button"
+                >
+                  <div
+                    class="ant-switch-handle"
+                  />
+                  <span
+                    class="ant-switch-inner"
+                  >
+                    <span
+                      class="ant-switch-inner-checked"
+                    />
+                    <span
+                      class="ant-switch-inner-unchecked"
+                    />
+                  </span>
+                </button>
               </div>
             </div>
           </div>

--- a/packages/shared/lib/api/base/service/common.d.ts
+++ b/packages/shared/lib/api/base/service/common.d.ts
@@ -2315,12 +2315,14 @@ export interface IListUserReply {
 
 export interface ILoginConfiguration {
   disable_user_pwd_login?: boolean;
+  disable_multiple_login?: boolean;
 
   login_button_text?: string;
 }
 
 export interface ILoginTipsResData {
   disable_user_pwd_login?: boolean;
+  disable_multiple_login?: boolean;
 
   login_button_text?: string;
 }

--- a/packages/shared/lib/testUtil/mockApi/base/system/data.ts
+++ b/packages/shared/lib/testUtil/mockApi/base/system/data.ts
@@ -111,5 +111,6 @@ export const mockSMSConfigurationData = {
 
 export const mockGetLoginBasicConfigurationData = {
   login_button_text: 'Login',
-  disable_user_pwd_login: false
+  disable_user_pwd_login: false,
+  disable_multiple_login: false
 };


### PR DESCRIPTION
## Summary
- Expose `disable_multiple_login` in login basic settings
- Add i18n strings and API type updates

Fixes actiontech/dms-ee#924

## Test plan
- [ ] `pnpm checker`
- [ ] Toggle appears in System > Login Connection settings
- [ ] Save and reload reflects backend value
