### PR TITLE
Display 3 metrix

### DIFF
--- a/packages/sqle/src/page/SqlManagement/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/__snapshots__/index.test.tsx.snap
@@ -476,6 +476,9 @@ exports[`page/SqlManagement render sql management page 1`] = `
                           <col />
                           <col />
                           <col />
+                          <col />
+                          <col />
+                          <col />
                           <col
                             style="width: 200px;"
                           />
@@ -563,6 +566,196 @@ exports[`page/SqlManagement render sql management page 1`] = `
                               scope="col"
                             >
                               优先级
+                            </th>
+                            <th
+                              aria-label="出现数量"
+                              class="ant-table-cell ant-table-column-has-sorters"
+                              scope="col"
+                              style="text-align: right;"
+                              tabindex="0"
+                            >
+                              <div
+                                class="ant-table-column-sorters"
+                              >
+                                <span
+                                  class="ant-table-column-title"
+                                >
+                                  出现数量
+                                </span>
+                                <span
+                                  class="ant-table-column-sorter ant-table-column-sorter-full"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-table-column-sorter-inner"
+                                  >
+                                    <span
+                                      aria-label="caret-up"
+                                      class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        data-icon="caret-up"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </span>
+                              </div>
+                            </th>
+                            <th
+                              aria-label="初次出现时间"
+                              class="ant-table-cell ant-table-column-has-sorters"
+                              scope="col"
+                              tabindex="0"
+                            >
+                              <div
+                                class="ant-table-column-sorters"
+                              >
+                                <span
+                                  class="ant-table-column-title"
+                                >
+                                  初次出现时间
+                                </span>
+                                <span
+                                  class="ant-table-column-sorter ant-table-column-sorter-full"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-table-column-sorter-inner"
+                                  >
+                                    <span
+                                      aria-label="caret-up"
+                                      class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        data-icon="caret-up"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </span>
+                              </div>
+                            </th>
+                            <th
+                              aria-label="最后一次出现时间"
+                              class="ant-table-cell ant-table-column-has-sorters"
+                              scope="col"
+                              tabindex="0"
+                            >
+                              <div
+                                class="ant-table-column-sorters"
+                              >
+                                <span
+                                  class="ant-table-column-title"
+                                >
+                                  最后一次出现时间
+                                </span>
+                                <span
+                                  class="ant-table-column-sorter ant-table-column-sorter-full"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-table-column-sorter-inner"
+                                  >
+                                    <span
+                                      aria-label="caret-up"
+                                      class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        data-icon="caret-up"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                    <span
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </span>
+                              </div>
                             </th>
                             <th
                               class="ant-table-cell"
@@ -731,13 +924,40 @@ exports[`page/SqlManagement render sql management page 1`] = `
                                  
                               </div>
                             </td>
+                            <td
+                              style="padding: 0px; border: 0px; height: 0px;"
+                            >
+                              <div
+                                style="height: 0px; overflow: hidden;"
+                              >
+                                 
+                              </div>
+                            </td>
+                            <td
+                              style="padding: 0px; border: 0px; height: 0px;"
+                            >
+                              <div
+                                style="height: 0px; overflow: hidden;"
+                              >
+                                 
+                              </div>
+                            </td>
+                            <td
+                              style="padding: 0px; border: 0px; height: 0px;"
+                            >
+                              <div
+                                style="height: 0px; overflow: hidden;"
+                              >
+                                 
+                              </div>
+                            </td>
                           </tr>
                           <tr
                             class="ant-table-placeholder"
                           >
                             <td
                               class="ant-table-cell"
-                              colspan="14"
+                              colspan="17"
                             >
                               <div
                                 class="ant-table-expanded-row-fixed"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/__snapshots__/index.test.tsx.snap
@@ -834,6 +834,9 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                         <col />
                         <col />
                         <col />
+                        <col />
+                        <col />
+                        <col />
                         <col
                           style="width: 200px;"
                         />
@@ -922,6 +925,196 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                             优先级
                           </th>
                           <th
+                            aria-label="出现数量"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            style="text-align: right;"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                出现数量
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="初次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                初次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="最后一次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                最后一次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
                             class="ant-table-cell"
                             scope="col"
                           >
@@ -962,6 +1155,33 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                           class="ant-table-measure-row"
                           style="height: 0px; font-size: 0px;"
                         >
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                           <td
                             style="padding: 0px; border: 0px; height: 0px;"
                           >
@@ -1193,6 +1413,22 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
                             class="ant-table-cell"
                           >
                             高优先
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                            style="text-align: right;"
+                          >
+                            0
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            2024-01-02 11:28:34
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            2024-01-03 11:28:34
                           </td>
                           <td
                             class="ant-table-cell"
@@ -1716,6 +1952,984 @@ exports[`page/SqlManagement/SQLEEIndex filter data with rule name 1`] = `
 </body>
 `;
 
+exports[`page/SqlManagement/SQLEEIndex filter data with sort 1`] = `
+<body>
+  <div>
+    <div
+      class="ant-spin-nested-loading css-dev-only-do-not-override-txh9fw"
+    >
+      <div
+        class="ant-spin-container"
+      >
+        <div
+          class="actiontech-page-header-namespace css-1xspr0w"
+        >
+          <div
+            class="title"
+          >
+            SQL管控
+          </div>
+          <div
+            class="extra"
+          >
+            <button
+              class="ant-btn css-dev-only-do-not-override-674gwq ant-btn-default ant-dropdown-trigger basic-button-wrapper css-geipcv"
+              type="button"
+            >
+              <span
+                class="ant-btn-icon"
+              >
+                <svg
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M1.75 11.083h10.5v1.167H1.75zm5.833-3.4 3.542-3.541.825.824L7 9.916 2.05 4.968l.825-.825 3.542 3.54V1.167h1.166z"
+                  />
+                </svg>
+              </span>
+              <span>
+                导出报表
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="css-wl13ms"
+        >
+          <div
+            class="ant-card ant-card-bordered card-wrapper css-dev-only-do-not-override-txh9fw"
+          >
+            <div
+              class="ant-card-body"
+            >
+              <div
+                class="cont-item"
+              >
+                <strong
+                  class="num total"
+                >
+                  0
+                </strong>
+                <span
+                  class="desc"
+                >
+                  SQL总数
+                </span>
+              </div>
+              <div
+                class="cont-item"
+              >
+                <div>
+                  <strong
+                    class="num problem"
+                  >
+                    0
+                  </strong>
+                  <span
+                    class="desc problemSQlNum"
+                  >
+                    问题SQL数
+                  </span>
+                </div>
+              </div>
+              <div
+                class="cont-item"
+              >
+                <strong
+                  class="num optimized"
+                >
+                  0
+                </strong>
+                <span
+                  class="desc"
+                >
+                  已优化SQL数
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-spin-nested-loading css-dev-only-do-not-override-1kh50jg"
+        >
+          <div
+            class="ant-spin-container"
+          >
+            <div
+              class="ant-space css-dev-only-do-not-override-1kh50jg ant-space-horizontal ant-space-align-center full-width-element flex-space-between actiontech-table-toolbar-namespace css-c38ntt"
+              style="flex-wrap: wrap; margin-bottom: -8px;"
+            >
+              <div
+                class="ant-space-item"
+                style="margin-right: 8px; padding-bottom: 8px;"
+              >
+                <div
+                  class="ant-space css-dev-only-do-not-override-1kh50jg ant-space-horizontal ant-space-align-center"
+                >
+                  <div
+                    class="ant-space-item"
+                    style="margin-right: 12px;"
+                  >
+                    <div
+                      class="ant-segmented basic-segmented-wrapper css-192b3m1 css-dev-only-do-not-override-1kh50jg"
+                    >
+                      <div
+                        class="ant-segmented-group"
+                      >
+                        <label
+                          class="ant-segmented-item"
+                        >
+                          <input
+                            class="ant-segmented-item-input"
+                            type="radio"
+                          />
+                          <div
+                            class="ant-segmented-item-label"
+                            title="全部"
+                          >
+                            全部
+                          </div>
+                        </label>
+                        <label
+                          class="ant-segmented-item ant-segmented-item-selected"
+                        >
+                          <input
+                            checked=""
+                            class="ant-segmented-item-input"
+                            type="radio"
+                          />
+                          <div
+                            class="ant-segmented-item-label"
+                            title="未处理"
+                          >
+                            未处理
+                          </div>
+                        </label>
+                        <label
+                          class="ant-segmented-item"
+                        >
+                          <input
+                            class="ant-segmented-item-input"
+                            type="radio"
+                          />
+                          <div
+                            class="ant-segmented-item-label"
+                            title="已解决"
+                          >
+                            已解决
+                          </div>
+                        </label>
+                        <label
+                          class="ant-segmented-item"
+                        >
+                          <input
+                            class="ant-segmented-item-input"
+                            type="radio"
+                          />
+                          <div
+                            class="ant-segmented-item-label"
+                            title="已忽略"
+                          >
+                            已忽略
+                          </div>
+                        </label>
+                        <label
+                          class="ant-segmented-item"
+                        >
+                          <input
+                            class="ant-segmented-item-input"
+                            type="radio"
+                          />
+                          <div
+                            class="ant-segmented-item-label"
+                            title="已人工审核"
+                          >
+                            已人工审核
+                          </div>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                    style="margin-right: 12px;"
+                  >
+                    <span
+                      class="ant-input-affix-wrapper basic-input-wrapper actiontech-table-search-input-namespace css-1f6svkh ant-input-affix-wrapper-sm css-dev-only-do-not-override-mlhibv"
+                    >
+                      <input
+                        class="ant-input ant-input-sm css-dev-only-do-not-override-mlhibv"
+                        id="actiontech-table-search-input"
+                        placeholder="输入关键字搜索"
+                        type="text"
+                        value=""
+                      />
+                      <span
+                        class="ant-input-suffix"
+                      >
+                        <svg
+                          class="custom-icon custom-icon-search"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m10.518 9.693 2.499 2.498-.826.825-2.498-2.498a5.252 5.252 0 0 1-8.527-4.101 5.25 5.25 0 0 1 5.25-5.25 5.252 5.252 0 0 1 4.102 8.526m-1.17-.433a4.082 4.082 0 0 0-2.931-6.927 4.08 4.08 0 0 0-4.084 4.084 4.082 4.082 0 0 0 6.927 2.93z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm ant-btn-two-chinese-chars actiontech-filter-button-namespace basic-button-wrapper css-geipcv"
+                      style="padding: 0px 6px 0px 10px;"
+                      type="button"
+                    >
+                      <div
+                        class="ant-space css-dev-only-do-not-override-czn7jp ant-space-horizontal ant-space-align-center css-1nt49ug"
+                      >
+                        <div
+                          class="ant-space-item"
+                          style="margin-right: 2px;"
+                        >
+                          筛选
+                        </div>
+                        <div
+                          class="ant-space-item"
+                        >
+                          <svg
+                            color="currrentColor"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            width="14"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m8 8.781 3.3-3.3.943.943L8 10.667 3.757 6.424l.943-.943z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+                style="padding-bottom: 8px;"
+              >
+                <div
+                  class="ant-space css-dev-only-do-not-override-1kh50jg ant-space-horizontal ant-space-align-center"
+                >
+                  <div
+                    class="ant-space-item"
+                    style="margin-right: 12px;"
+                  >
+                    <div
+                      class="ant-space css-dev-only-do-not-override-1kh50jg ant-space-horizontal ant-space-align-center"
+                    >
+                      <div
+                        class="ant-space-item"
+                        style="margin-right: 8px;"
+                      >
+                        <button
+                          class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm actiontech-table-actions-button switch-btn-default basic-button-wrapper css-geipcv"
+                          type="button"
+                        >
+                          <span>
+                            查看高优先级SQL
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="ant-space-item"
+                        style="margin-right: 8px;"
+                      >
+                        <button
+                          class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm actiontech-table-actions-button switch-btn-default basic-button-wrapper css-geipcv"
+                          type="button"
+                        >
+                          <span>
+                            与我相关
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="ant-space-item"
+                        style="margin-right: 8px;"
+                      >
+                        <button
+                          class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm actiontech-table-actions-button basic-button-wrapper css-geipcv"
+                          disabled=""
+                          type="button"
+                        >
+                          <span>
+                            批量指派
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="ant-space-item"
+                        style="margin-right: 8px;"
+                      >
+                        <button
+                          class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm actiontech-table-actions-button basic-button-wrapper css-geipcv"
+                          disabled=""
+                          type="button"
+                        >
+                          <span>
+                            批量解决
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="ant-space-item"
+                      >
+                        <button
+                          class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm actiontech-table-actions-button basic-button-wrapper css-geipcv"
+                          disabled=""
+                          type="button"
+                        >
+                          <span>
+                            批量忽略
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                    style="margin-right: 12px;"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm actiontech-table-setting-namespace basic-button-wrapper css-geipcv"
+                      style="padding: 0px 6px 0px 8px;"
+                      type="button"
+                    >
+                      <div
+                        class="ant-space css-dev-only-do-not-override-czn7jp ant-space-horizontal ant-space-align-center css-1nt49ug"
+                      >
+                        <div
+                          class="ant-space-item"
+                          style="margin-right: 5px;"
+                        >
+                          <svg
+                            class="custom-icon custom-icon-setting"
+                            height="11"
+                            viewBox="0 0 13 11"
+                            width="13"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M.167 8.5H4.25v1.167H.167zm0-4.083h5.25v1.166H.167zm0-4.084h11.666V1.5H.167zM11.06 5.598l.674-.228.584 1.01-.535.47c.067.319.067.648 0 .967l.535.47-.584 1.01-.674-.228c-.24.216-.524.382-.837.484l-.14.697H8.917l-.14-.698a2.3 2.3 0 0 1-.837-.484l-.674.229-.583-1.01.534-.47a2.3 2.3 0 0 1 0-.967l-.534-.47.583-1.01.674.228c.24-.216.524-.382.837-.484l.14-.697h1.166l.14.697c.313.102.598.269.837.485zM9.5 8.5a1.167 1.167 0 1 0 0-2.333 1.167 1.167 0 0 0 0 2.333"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="ant-space-item"
+                          style="margin-right: 5px;"
+                        >
+                          表格设置
+                        </div>
+                        <div
+                          class="ant-space-item"
+                        >
+                          <svg
+                            class="custom-icon custom-icon-arrow-down"
+                            color="currentColor"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            width="14"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m8 8.781 3.3-3.3.943.943L8 10.667 3.757 6.424l.943-.943z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-czn7jp ant-btn-default ant-btn-sm ant-btn-icon-only basic-button-wrapper css-geipcv"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        class="ant-btn-icon"
+                      >
+                        <svg
+                          class="custom-icon custom-icon-refresh"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M3.187 2.586a5.833 5.833 0 0 1 8.59 7.762L9.918 7h1.75a4.667 4.667 0 0 0-7.899-3.367zm7.626 8.828a5.833 5.833 0 0 1-8.59-7.762L4.083 7h-1.75a4.667 4.667 0 0 0 7.899 3.367z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-table-wrapper actiontech-table-namespace table-row-cursor css-fxd6ka css-dev-only-do-not-override-bj9uhl"
+        >
+          <div
+            class="ant-spin-nested-loading css-dev-only-do-not-override-bj9uhl"
+          >
+            <div
+              class="ant-spin-container"
+            >
+              <div
+                class="ant-table ant-table-empty ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-right"
+              >
+                <div
+                  class="ant-table-container"
+                >
+                  <div
+                    class="ant-table-content"
+                    style="overflow-x: auto; overflow-y: hidden;"
+                  >
+                    <table
+                      style="min-width: 100%; table-layout: auto;"
+                    >
+                      <colgroup>
+                        <col
+                          class="ant-table-selection-col"
+                        />
+                        <col />
+                        <col />
+                        <col />
+                        <col
+                          style="width: 200px;"
+                        />
+                        <col
+                          style="width: 200px;"
+                        />
+                        <col />
+                        <col />
+                        <col />
+                        <col />
+                        <col />
+                        <col />
+                        <col
+                          style="width: 200px;"
+                        />
+                        <col />
+                        <col />
+                        <col />
+                        <col
+                          style="width: 246px;"
+                        />
+                      </colgroup>
+                      <thead
+                        class="ant-table-thead"
+                      >
+                        <tr>
+                          <th
+                            class="ant-table-cell ant-table-selection-column"
+                            scope="col"
+                          >
+                            <div
+                              class="ant-table-selection"
+                            >
+                              <label
+                                class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled css-dev-only-do-not-override-bj9uhl"
+                              >
+                                <span
+                                  class="ant-checkbox css-dev-only-do-not-override-bj9uhl ant-checkbox-disabled"
+                                >
+                                  <input
+                                    aria-label="Select all"
+                                    class="ant-checkbox-input"
+                                    disabled=""
+                                    type="checkbox"
+                                  />
+                                  <span
+                                    class="ant-checkbox-inner"
+                                  />
+                                </span>
+                              </label>
+                            </div>
+                          </th>
+                          <th
+                            class="ant-table-cell ellipsis-column-width"
+                            scope="col"
+                          >
+                            SQL指纹
+                          </th>
+                          <th
+                            class="ant-table-cell ellipsis-column-width"
+                            scope="col"
+                          >
+                            SQL
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            来源
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            最初审核结果
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            当前审核结果
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            数据源
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            Schema
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            优先级
+                          </th>
+                          <th
+                            aria-label="出现数量"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            style="text-align: right;"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                出现数量
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="初次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                初次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="最后一次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                最后一次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            负责人
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            端点信息
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                            scope="col"
+                          >
+                            状态
+                          </th>
+                          <th
+                            class="ant-table-cell ellipsis-column-width"
+                            scope="col"
+                          >
+                            备注
+                          </th>
+                          <th
+                            class="ant-table-cell actiontech-table-actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                            scope="col"
+                            style="position: sticky; right: 0px;"
+                          >
+                            操作
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody
+                        class="ant-table-tbody"
+                      >
+                        <tr
+                          aria-hidden="true"
+                          class="ant-table-measure-row"
+                          style="height: 0px; font-size: 0px;"
+                        >
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                        </tr>
+                        <tr
+                          class="ant-table-placeholder"
+                        >
+                          <td
+                            class="ant-table-cell"
+                            colspan="17"
+                          >
+                            <div
+                              class="ant-table-expanded-row-fixed"
+                              style="width: 0px; position: sticky; left: 0px; overflow: hidden;"
+                            />
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
 <body>
   <div>
@@ -2191,6 +3405,9 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
                         <col />
                         <col />
                         <col />
+                        <col />
+                        <col />
+                        <col />
                         <col
                           style="width: 200px;"
                         />
@@ -2278,6 +3495,196 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
                             scope="col"
                           >
                             优先级
+                          </th>
+                          <th
+                            aria-label="出现数量"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            style="text-align: right;"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                出现数量
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="初次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                初次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="最后一次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                最后一次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
                           </th>
                           <th
                             class="ant-table-cell"
@@ -2446,13 +3853,40 @@ exports[`page/SqlManagement/SQLEEIndex render sql statics data 1`] = `
                                
                             </div>
                           </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                         </tr>
                         <tr
                           class="ant-table-placeholder"
                         >
                           <td
                             class="ant-table-cell"
-                            colspan="14"
+                            colspan="17"
                           >
                             <div
                               class="ant-table-expanded-row-fixed"
@@ -2948,6 +4382,9 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                         <col />
                         <col />
                         <col />
+                        <col />
+                        <col />
+                        <col />
                         <col
                           style="width: 200px;"
                         />
@@ -3036,6 +4473,196 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             优先级
                           </th>
                           <th
+                            aria-label="出现数量"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            style="text-align: right;"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                出现数量
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="初次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                初次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="最后一次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                最后一次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
                             class="ant-table-cell"
                             scope="col"
                           >
@@ -3076,6 +4703,33 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           class="ant-table-measure-row"
                           style="height: 0px; font-size: 0px;"
                         >
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                           <td
                             style="padding: 0px; border: 0px; height: 0px;"
                           >
@@ -3307,6 +4961,22 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             高优先
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                            style="text-align: right;"
+                          >
+                            0
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            2024-01-02 11:28:34
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            2024-01-03 11:28:34
                           </td>
                           <td
                             class="ant-table-cell"
@@ -3647,6 +5317,22 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             低优先
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                            style="text-align: right;"
+                          >
+                            0
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -4066,6 +5752,22 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           </td>
                           <td
                             class="ant-table-cell"
+                            style="text-align: right;"
+                          >
+                            0
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
+                          </td>
+                          <td
+                            class="ant-table-cell"
                           >
                             -
                           </td>
@@ -4447,6 +6149,22 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                           </td>
                           <td
                             class="ant-table-cell"
+                            style="text-align: right;"
+                          >
+                            0
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
+                          </td>
+                          <td
+                            class="ant-table-cell"
                           >
                             -
                           </td>
@@ -4734,6 +6452,22 @@ exports[`page/SqlManagement/SQLEEIndex render table data 1`] = `
                             class="ant-table-cell"
                           >
                             db1
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                            style="text-align: right;"
+                          >
+                            0
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            -
                           </td>
                           <td
                             class="ant-table-cell"
@@ -5496,6 +7230,9 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                         <col />
                         <col />
                         <col />
+                        <col />
+                        <col />
+                        <col />
                         <col
                           style="width: 200px;"
                         />
@@ -5584,6 +7321,196 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                             优先级
                           </th>
                           <th
+                            aria-label="出现数量"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            style="text-align: right;"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                出现数量
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="初次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                初次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="最后一次出现时间"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            scope="col"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                最后一次出现时间
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="img"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
                             class="ant-table-cell"
                             scope="col"
                           >
@@ -5624,6 +7551,33 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                           class="ant-table-measure-row"
                           style="height: 0px; font-size: 0px;"
                         >
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
+                          <td
+                            style="padding: 0px; border: 0px; height: 0px;"
+                          >
+                            <div
+                              style="height: 0px; overflow: hidden;"
+                            >
+                               
+                            </div>
+                          </td>
                           <td
                             style="padding: 0px; border: 0px; height: 0px;"
                           >
@@ -5855,6 +7809,22 @@ exports[`page/SqlManagement/SQLEEIndex render table for not admin 1`] = `
                             class="ant-table-cell"
                           >
                             高优先
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                            style="text-align: right;"
+                          >
+                            0
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            2024-01-02 11:28:34
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            2024-01-03 11:28:34
                           </td>
                           <td
                             class="ant-table-cell"

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/column.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/column.tsx
@@ -23,6 +23,7 @@ import { Avatar } from 'antd';
 import StatusTag from './StatusTag';
 import { BasicTag, BasicTypographyEllipsis } from '@actiontech/shared';
 import { ACTIONTECH_TABLE_ACTION_BUTTON_WIDTH } from '@actiontech/shared/lib/components/ActiontechTable/hooks/useTableAction';
+import { formatTime } from '@actiontech/shared/lib/utils/Common';
 import { SQLAuditRecordListUrlParamsKey } from './index.data';
 export type SqlManagementTableFilterParamType = PageInfoWithoutIndexAndSize<
   IGetSqlManageListV2Params,
@@ -347,31 +348,31 @@ const SqlManagementColumn: (
         return '-';
       }
     },
-    // {
-    //   dataIndex: 'first_appear_timestamp',
-    //   title: () => t('sqlManagement.table.column.firstOccurrence'),
-    //   render: (value) => {
-    //     return formatTime(value, '-');
-    //   },
-    //   sorter: true,
-    //   sortDirections: ['descend', 'ascend']
-    // },
-    // {
-    //   dataIndex: 'last_receive_timestamp',
-    //   title: () => t('sqlManagement.table.column.lastOccurrence'),
-    //   render: (value) => {
-    //     return formatTime(value, '-');
-    //   },
-    //   sorter: true,
-    //   sortDirections: ['descend', 'ascend']
-    // },
-    // {
-    //   dataIndex: 'fp_count',
-    //   align: 'right',
-    //   title: () => t('sqlManagement.table.column.occurrenceCount'),
-    //   sorter: true,
-    //   sortDirections: ['descend', 'ascend']
-    // },
+    {
+      dataIndex: 'fp_count',
+      align: 'right',
+      title: () => t('sqlManagement.table.column.occurrenceCount'),
+      sorter: true,
+      sortDirections: ['descend', 'ascend']
+    },
+    {
+      dataIndex: 'first_appear_timestamp',
+      title: () => t('sqlManagement.table.column.firstOccurrence'),
+      render: (value) => {
+        return formatTime(value, '-');
+      },
+      sorter: true,
+      sortDirections: ['descend', 'ascend']
+    },
+    {
+      dataIndex: 'last_receive_timestamp',
+      title: () => t('sqlManagement.table.column.lastOccurrence'),
+      render: (value) => {
+        return formatTime(value, '-');
+      },
+      sorter: true,
+      sortDirections: ['descend', 'ascend']
+    },
     {
       dataIndex: 'assignees',
       title: () => t('sqlManagement.table.column.personInCharge'),

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
@@ -185,21 +185,21 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     });
   });
 
-  // it('filter data with sort', async () => {
-  //   const request = sqlManage.getSqlManageList();
-  //   const { baseElement } = superRender(<SQLEEIndex />);
-  //   expect(request).toHaveBeenCalled();
-  //   expect(baseElement).toMatchSnapshot();
+  it('filter data with sort', async () => {
+    const request = sqlManage.getSqlManageList();
+    const { baseElement } = superRender(<SQLEEIndex />);
+    expect(request).toHaveBeenCalled();
+    expect(baseElement).toMatchSnapshot();
 
-  //   const sortButtons = getAllBySelector('.ant-table-column-sorter');
-  //   expect(sortButtons.length).toBe(3);
-  //   fireEvent.click(sortButtons[sortButtons.length - 1]);
-  //   expect(request).toHaveBeenCalledWith({
-  //     ...requestParams,
-  //     sort_field: 'fp_count',
-  //     sort_order: 'desc'
-  //   });
-  // });
+    const sortButtons = getAllBySelector('.ant-table-column-sorter');
+    expect(sortButtons.length).toBe(3);
+    fireEvent.click(sortButtons[0]);
+    expect(request).toHaveBeenCalledWith({
+      ...requestParams,
+      sort_field: 'fp_count',
+      sort_order: 'desc'
+    });
+  });
 
   it('filter data with search', async () => {
     const request = sqlManage.getSqlManageList();


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/sqle-ee/pull/3017  
设计说明文档：https://actiontech.feishu.cn/docx/Z4q1dic16oJZcJxea16cn3K0nKc

## 描述你的变更

SQL 管控列表恢复展示「出现数量 / 初次出现时间 / 最后一次出现时间」三列，对接后端列表接口已返回的 `fp_count`、`first_appear_timestamp`、`last_receive_timestamp`；后端未写入时前端按空值展示为 `-`，不造数。

主要改动：
1. **列表列配置**（`SQLEEIndex/column.tsx`）：恢复三列并接入既有 i18n  
   - 出现数量：`fp_count`  
   - 初次出现时间：`first_appear_timestamp`（`formatTime`）  
   - 最后一次出现时间：`last_receive_timestamp`（`formatTime`）
2. **排序**：三列开启 `sorter`，通过现有 `sort_field` / `sort_order` 传给列表接口（与后端 `fp_count | first_appear_timestamp | last_receive_timestamp` 对齐）
3. **单测**：更新相关 snapshot；恢复排序用例，并按当前列顺序修正点击 `fp_count` 的断言

不改接口契约与 API 客户端；字段类型与文案本已存在，仅恢复列表展示能力。

影响范围：SQL 管控列表页（EE）；依赖后端 enterprise 列表接口返回上述字段。

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的 issue 里补充了实现方案
- [x] 我已在关联的 issue 里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在 issue 里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在 issue 里标记 `need_update_doc`
----------------------------------------------------------------------

**建议自测关注点：**
- 列表可见「出现数量 / 初次出现时间 / 最后一次出现时间」三列
- 有指标数据源：数值与时间正确展示；无指标数据源：三列为空（`-`）
- 按「出现数量 / 初次出现时间 / 最后一次出现时间」表头排序，请求参数 `sort_field` / `sort_order` 正确且列表顺序变化
- 与后端 PR #3017 联调：空值不会被展示成 `0` 或无效时间