### PR TITLE
feat: export SQL manage visible columns

### DIFF
--- a/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
+++ b/packages/shared/lib/api/sqle/service/SqlManage/index.d.ts
@@ -104,6 +104,8 @@ export interface IExportSqlManageV1Params {
   sort_field?: exportSqlManageV1SortFieldEnum;
 
   sort_order?: exportSqlManageV1SortOrderEnum;
+
+  export_column_keys?: string;
 }
 
 export interface IGetSqlManageRuleTipsParams {

--- a/packages/sqle/src/locale/en-US/sqlManagement.ts
+++ b/packages/sqle/src/locale/en-US/sqlManagement.ts
@@ -5,7 +5,8 @@ export default {
     action: {
       export: 'Export',
       exporting: 'Exporting file',
-      exportSuccessTips: 'Export file successfully'
+      exportSuccessTips: 'Export file successfully',
+      noExportColumnTips: 'Please select at least one export column'
     }
   },
   statistics: {

--- a/packages/sqle/src/locale/zh-CN/sqlManagement.ts
+++ b/packages/sqle/src/locale/zh-CN/sqlManagement.ts
@@ -5,7 +5,8 @@ export default {
     action: {
       export: '导出',
       exporting: '正在导出文件',
-      exportSuccessTips: '导出文件成功'
+      exportSuccessTips: '导出文件成功',
+      noExportColumnTips: '请至少选择一个导出列'
     }
   },
   statistics: {

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/exportColumnKeys.test.ts
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/exportColumnKeys.test.ts
@@ -1,0 +1,97 @@
+import LocalStorageWrapper from '@actiontech/shared/lib/utils/LocalStorageWrapper';
+import SqlManagementColumn from './column';
+import {
+  getSqlManagementExportColumnKeys,
+  SQL_MANAGEMENT_TABLE_NAME
+} from './exportColumnKeys';
+
+const mockUpdateRemark = jest.fn();
+const mockOpenModal = jest.fn();
+
+const columns = SqlManagementColumn(
+  '700300',
+  true,
+  mockUpdateRemark,
+  mockOpenModal
+);
+
+describe('page/SqlManagement/SQLEEIndex/exportColumnKeys', () => {
+  afterEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('return default export columns when current user has no settings', () => {
+    expect(getSqlManagementExportColumnKeys(columns, 'admin')).toEqual([
+      'sql_fingerprint',
+      'sql',
+      'source',
+      'audit_result',
+      'instance_name',
+      'schema_name',
+      'priority',
+      'assignees',
+      'endpoints',
+      'status',
+      'remark'
+    ]);
+  });
+
+  it('return visible business columns by local settings order', () => {
+    LocalStorageWrapper.set(
+      SQL_MANAGEMENT_TABLE_NAME,
+      JSON.stringify({
+        admin: {
+          sql_fingerprint: { order: 2, show: true },
+          sql: { order: 1, show: true },
+          source: { order: 3, show: false },
+          audit_result: { order: 4, show: true },
+          selection: { order: 5, show: true },
+          action: { order: 6, show: true },
+          filter_business: { order: 7, show: true }
+        }
+      })
+    );
+
+    expect(getSqlManagementExportColumnKeys(columns, 'admin')).toEqual([
+      'sql',
+      'sql_fingerprint',
+      'audit_result',
+      'instance_name',
+      'schema_name',
+      'priority',
+      'assignees',
+      'endpoints',
+      'status',
+      'remark'
+    ]);
+  });
+
+  it('return empty array when all export columns are hidden', () => {
+    LocalStorageWrapper.set(
+      SQL_MANAGEMENT_TABLE_NAME,
+      JSON.stringify({
+        admin: Object.fromEntries(
+          [
+            'sql_fingerprint',
+            'sql',
+            'source',
+            'audit_result',
+            'instance_name',
+            'schema_name',
+            'priority',
+            'assignees',
+            'endpoints',
+            'status',
+            'remark'
+          ].map((columnKey, index) => [
+            columnKey,
+            { order: index + 1, show: false }
+          ])
+        )
+      })
+    );
+
+    expect(getSqlManagementExportColumnKeys(columns, 'admin')).toEqual([]);
+  });
+});

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/exportColumnKeys.ts
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/exportColumnKeys.ts
@@ -1,0 +1,92 @@
+import LocalStorageWrapper from '@actiontech/shared/lib/utils/LocalStorageWrapper';
+import { ActiontechTableColumn } from '@actiontech/shared/lib/components/ActiontechTable';
+import { ISqlManage } from '@actiontech/shared/lib/api/sqle/service/common';
+import { SqlManagementTableFilterParamType } from './column';
+
+export const SQL_MANAGEMENT_TABLE_NAME = 'sql_management_list';
+
+const SQL_MANAGEMENT_EXPORT_COLUMN_KEYS = [
+  'sql_fingerprint',
+  'sql',
+  'source',
+  'audit_result',
+  'instance_name',
+  'schema_name',
+  'priority',
+  'assignees',
+  'endpoints',
+  'status',
+  'remark'
+] as const;
+
+type SqlManagementExportColumnKey =
+  (typeof SQL_MANAGEMENT_EXPORT_COLUMN_KEYS)[number];
+
+type SqlManagementColumnSettings = Partial<
+  Record<
+    string,
+    {
+      order?: number;
+      show?: boolean;
+    }
+  >
+>;
+
+const exportColumnKeySet = new Set<string>(SQL_MANAGEMENT_EXPORT_COLUMN_KEYS);
+
+const getColumnDataIndex = (
+  dataIndex: ActiontechTableColumn<
+    ISqlManage,
+    SqlManagementTableFilterParamType
+  >[number]['dataIndex']
+) => {
+  return typeof dataIndex === 'string' ? dataIndex : undefined;
+};
+
+const readLocalColumnSettings = (
+  tableName: string,
+  username: string
+): SqlManagementColumnSettings => {
+  try {
+    const localColumns = JSON.parse(
+      LocalStorageWrapper.getOrDefault(tableName, '{}')
+    );
+    return localColumns?.[username] ?? {};
+  } catch {
+    return {};
+  }
+};
+
+export const getSqlManagementExportColumnKeys = (
+  columns: ActiontechTableColumn<ISqlManage, SqlManagementTableFilterParamType>,
+  username: string,
+  tableName = SQL_MANAGEMENT_TABLE_NAME
+): SqlManagementExportColumnKey[] => {
+  const localColumnSettings = readLocalColumnSettings(tableName, username);
+
+  return columns
+    .map((column, index) => {
+      const columnKey = getColumnDataIndex(column.dataIndex);
+      if (!columnKey || !exportColumnKeySet.has(columnKey)) {
+        return undefined;
+      }
+
+      const localSetting = localColumnSettings[columnKey];
+      return {
+        key: columnKey as SqlManagementExportColumnKey,
+        show: localSetting?.show ?? column.show ?? true,
+        order: localSetting?.order ?? index + 1,
+        defaultOrder: index + 1
+      };
+    })
+    .filter((column): column is NonNullable<typeof column> => {
+      return !!column && column.show;
+    })
+    .sort((currentColumn, nextColumn) => {
+      return (
+        currentColumn.order - nextColumn.order ||
+        currentColumn.defaultOrder - nextColumn.defaultOrder
+      );
+    })
+    .map((column) => column.key);
+};

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.test.tsx
@@ -24,6 +24,8 @@ import {
   GetSqlManageListV2FilterPriorityEnum,
   exportSqlManageV1FilterPriorityEnum
 } from '@actiontech/shared/lib/api/sqle/service/SqlManage/index.enum';
+import LocalStorageWrapper from '@actiontech/shared/lib/utils/LocalStorageWrapper';
+import { SQL_MANAGEMENT_TABLE_NAME } from './exportColumnKeys';
 
 jest.mock('react-redux', () => {
   return {
@@ -83,6 +85,7 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
     jest.clearAllTimers();
+    localStorage.clear();
     cleanup();
   });
 
@@ -236,7 +239,9 @@ describe('page/SqlManagement/SQLEEIndex', () => {
       {
         ...exportParams,
         filter_assignee: mockCurrentUserReturn.uid,
-        filter_priority: exportSqlManageV1FilterPriorityEnum.high
+        filter_priority: exportSqlManageV1FilterPriorityEnum.high,
+        export_column_keys:
+          'sql_fingerprint,sql,source,audit_result,instance_name,schema_name,priority,assignees,endpoints,status,remark'
       },
       {
         responseType: 'blob'
@@ -244,6 +249,93 @@ describe('page/SqlManagement/SQLEEIndex', () => {
     );
     await act(async () => jest.advanceTimersByTime(3000));
     expect(screen.getByText('导出文件成功')).toBeInTheDocument();
+  });
+
+  it('export data with current visible column settings order', async () => {
+    const request = sqlManage.getSqlManageList();
+    const exportRequest = sqlManage.exportSqlManage();
+    superRender(<SQLEEIndex />);
+    expect(request).toHaveBeenCalled();
+
+    LocalStorageWrapper.set(
+      SQL_MANAGEMENT_TABLE_NAME,
+      JSON.stringify({
+        [mockCurrentUserReturn.username]: {
+          sql_fingerprint: { order: 2, show: true },
+          sql: { order: 1, show: true },
+          source: { order: 3, show: false },
+          audit_result: { order: 4, show: true },
+          instance_name: { order: 5, show: true },
+          schema_name: { order: 6, show: true },
+          priority: { order: 7, show: true },
+          assignees: { order: 8, show: false },
+          endpoints: { order: 9, show: true },
+          status: { order: 10, show: true },
+          remark: { order: 11, show: false },
+          selection: { order: 12, show: true }
+        }
+      })
+    );
+
+    const searchText = 'fingerprint keyword';
+    const inputEle = getBySelector('#actiontech-table-search-input');
+    fireEvent.change(inputEle, {
+      target: { value: searchText }
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(inputEle, {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13
+      });
+      await jest.advanceTimersByTime(300);
+    });
+    await act(async () => jest.advanceTimersByTime(3000));
+
+    fireEvent.click(screen.getByText('导出'));
+
+    expect(exportRequest).toHaveBeenCalledWith(
+      {
+        ...exportParams,
+        fuzzy_search_sql_fingerprint: searchText,
+        export_column_keys:
+          'sql,sql_fingerprint,audit_result,instance_name,schema_name,priority,endpoints,status'
+      },
+      {
+        responseType: 'blob'
+      }
+    );
+  });
+
+  it('show tips without export request when no visible export columns', async () => {
+    const request = sqlManage.getSqlManageList();
+    const exportRequest = sqlManage.exportSqlManage();
+    superRender(<SQLEEIndex />);
+    expect(request).toHaveBeenCalled();
+
+    LocalStorageWrapper.set(
+      SQL_MANAGEMENT_TABLE_NAME,
+      JSON.stringify({
+        [mockCurrentUserReturn.username]: {
+          sql_fingerprint: { order: 1, show: false },
+          sql: { order: 2, show: false },
+          source: { order: 3, show: false },
+          audit_result: { order: 4, show: false },
+          instance_name: { order: 5, show: false },
+          schema_name: { order: 6, show: false },
+          priority: { order: 7, show: false },
+          assignees: { order: 8, show: false },
+          endpoints: { order: 9, show: false },
+          status: { order: 10, show: false },
+          remark: { order: 11, show: false }
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByText('导出'));
+    expect(exportRequest).not.toHaveBeenCalled();
+    expect(screen.getByText('请至少选择一个导出列')).toBeInTheDocument();
   });
 
   it('batch assignment operation for sql', async () => {

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
@@ -51,6 +51,10 @@ import useGetTableFilterInfo from './hooks/useGetTableFilterInfo';
 import { DownArrowLineOutlined } from '@actiontech/icons';
 import useSqlManagementExceptionRedux from '../../../SqlManagementException/hooks/useSqlManagementExceptionRedux';
 import useWhitelistRedux from '../../../Whitelist/hooks/useWhitelistRedux';
+import {
+  getSqlManagementExportColumnKeys,
+  SQL_MANAGEMENT_TABLE_NAME
+} from './exportColumnKeys';
 
 const SQLEEIndex = () => {
   const { t } = useTranslation();
@@ -268,7 +272,7 @@ const SQLEEIndex = () => {
 
   const tableSetting = useMemo<ColumnsSettingProps>(
     () => ({
-      tableName: 'sql_management_list',
+      tableName: SQL_MANAGEMENT_TABLE_NAME,
       username: username
     }),
     [username]
@@ -306,6 +310,18 @@ const SQLEEIndex = () => {
     { setFalse: finishExport, setTrue: startExport }
   ] = useBoolean(false);
   const handleExport = () => {
+    const exportColumnKeys = getSqlManagementExportColumnKeys(
+      columns,
+      username
+    );
+
+    if (!exportColumnKeys.length) {
+      messageApi.warning(
+        t('sqlManagement.pageHeader.action.noExportColumnTips')
+      );
+      return;
+    }
+
     startExport();
     const hideLoading = messageApi.loading(
       t('sqlManagement.pageHeader.action.exporting')
@@ -327,7 +343,8 @@ const SQLEEIndex = () => {
       filter_db_type: filter_rule_name?.split(DB_TYPE_RULE_NAME_SEPARATOR)?.[0],
       filter_rule_name: filter_rule_name?.split(
         DB_TYPE_RULE_NAME_SEPARATOR
-      )?.[1]
+      )?.[1],
+      export_column_keys: exportColumnKeys.join(',')
     } as IExportSqlManageV1Params;
     SqlManage.exportSqlManageV1(params, { responseType: 'blob' })
       .then((res) => {


### PR DESCRIPTION
## Summary
- SQL 管控导出继续使用当前筛选条件决定导出行
- 导出列改为跟随 SQL 管控列表表格设置的可见业务列与顺序
- 补充无可导出列提示与前端导出列单元测试

## Validation
- 见 `docs/test/report.md` 与 Playwright 验收记录

Issue: https://github.com/actiontech/sqle-ee/issues/3026
