### PR TITLE
feat: show SQL online fail stage and reason on workflow detail

### DIFF
--- a/packages/shared/lib/api/sqle/service/common.d.ts
+++ b/packages/shared/lib/api/sqle/service/common.d.ts
@@ -752,6 +752,18 @@ export interface IAuditTaskResV1 {
 
   exec_end_time?: string;
 
+  /** 任务级上线失败主导阶段（backend §5.2） */
+  exec_fail_stage?: string;
+
+  /** 任务级代表失败原因 */
+  exec_fail_reason?: string;
+
+  /** 同阶段失败 SQL 计数 */
+  exec_fail_sql_count?: number;
+
+  /** 可选摘要素材，如「SQL 备份失败」 */
+  exec_fail_summary?: string;
+
   exec_mode?: string;
 
   exec_start_time?: string;
@@ -4673,6 +4685,12 @@ export interface IAuditTaskSQLResV2 {
   exec_sql_id?: number;
 
   exec_status?: string;
+
+  /** 失败/未执行阶段（backend §5.1） */
+  fail_stage?: string;
+
+  /** 原因行优先字段；缺省回退 exec_result */
+  fail_reason?: string;
 
   number?: number;
 

--- a/packages/shared/lib/api/sqle/service/common.d.ts
+++ b/packages/shared/lib/api/sqle/service/common.d.ts
@@ -761,6 +761,12 @@ export interface IAuditTaskResV1 {
   /** 同阶段失败 SQL 计数 */
   exec_fail_sql_count?: number;
 
+  /** 出错 SQL 的 number（AC-010 定位主键） */
+  exec_fail_sql_number?: number;
+
+  /** 出错 SQL 的 exec_sql_id（可选双保险） */
+  exec_fail_sql_id?: number;
+
   /** 可选摘要素材，如「SQL 备份失败」 */
   exec_fail_summary?: string;
 

--- a/packages/shared/lib/api/sqle/service/task/index.enum.ts
+++ b/packages/shared/lib/api/sqle/service/task/index.enum.ts
@@ -49,7 +49,10 @@ export enum getAuditTaskSQLsV2FilterExecStatusEnum {
 
   'terminate_failed' = 'terminate_failed',
 
-  'execute_rollback' = 'execute_rollback'
+  'execute_rollback' = 'execute_rollback',
+
+  /** 前序失败导致本条未跑（backend / frontend §6.3） */
+  'not_executed' = 'not_executed'
 }
 
 export enum getAuditTaskSQLsV2FilterAuditStatusEnum {

--- a/packages/sqle/src/hooks/useStaticStatus/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/hooks/useStaticStatus/__snapshots__/index.test.tsx.snap
@@ -552,12 +552,29 @@ exports[`useRuleTemplate should render static option for exec status 2`] = `
                 <div
                   aria-selected="false"
                   class="ant-select-item ant-select-item-option"
-                  title="执行回滚"
+                  title="已回滚"
                 >
                   <div
                     class="ant-select-item-option-content"
                   >
-                    执行回滚
+                    已回滚
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-item-option-state"
+                    style="user-select: none;"
+                    unselectable="on"
+                  />
+                </div>
+                <div
+                  aria-selected="false"
+                  class="ant-select-item ant-select-item-option"
+                  title="未执行"
+                >
+                  <div
+                    class="ant-select-item-option-content"
+                  >
+                    未执行
                   </div>
                   <span
                     aria-hidden="true"

--- a/packages/sqle/src/hooks/useStaticStatus/index.data.ts
+++ b/packages/sqle/src/hooks/useStaticStatus/index.data.ts
@@ -39,7 +39,9 @@ export const execStatusDictionary: StaticEnumDictionary<getAuditTaskSQLsV2Filter
     [getAuditTaskSQLsV2FilterExecStatusEnum.terminating]:
       'audit.execStatus.terminating',
     [getAuditTaskSQLsV2FilterExecStatusEnum.execute_rollback]:
-      'audit.execStatus.rollback'
+      'audit.execStatus.rollback',
+    [getAuditTaskSQLsV2FilterExecStatusEnum.not_executed]:
+      'audit.execStatus.not_executed'
   };
 
 export const auditStatusDictionary: StaticEnumDictionary<getAuditTaskSQLsV1FilterAuditStatusEnum> =

--- a/packages/sqle/src/locale/en-US/audit.ts
+++ b/packages/sqle/src/locale/en-US/audit.ts
@@ -41,6 +41,7 @@ export default {
     terminate_succ: 'Termination success',
     terminating: 'Terminating',
     allStatus: 'All status',
+    rollback: 'Rolled back',
     not_executed: 'Not executed'
   },
 

--- a/packages/sqle/src/locale/en-US/audit.ts
+++ b/packages/sqle/src/locale/en-US/audit.ts
@@ -40,7 +40,8 @@ export default {
     terminate_fail: 'Termination failed',
     terminate_succ: 'Termination success',
     terminating: 'Terminating',
-    allStatus: 'All status'
+    allStatus: 'All status',
+    not_executed: 'Not executed'
   },
 
   auditStatus: {

--- a/packages/sqle/src/locale/en-US/execWorkflow.ts
+++ b/packages/sqle/src/locale/en-US/execWorkflow.ts
@@ -145,6 +145,7 @@ export default {
     failDisplay: {
       headerPrefix: 'Execution failed: ',
       headerWithCount: 'Execution failed: {{count}} SQL(s) {{phrase}}',
+      headerWithSqlNumber: 'Execution failed: SQL #{{number}} execution failed',
       statusLabel: 'Status',
       stageLabel: 'Stage',
       reasonLabel: 'Reason',
@@ -168,7 +169,8 @@ export default {
         backupFailed: 'Backup failed',
         executeFailed: 'Execution failed',
         connectFailed: 'Connection failed',
-        notExecuted: 'Not executed'
+        notExecuted: 'Not executed',
+        rolledBack: 'Rolled back'
       }
     },
     operator: {

--- a/packages/sqle/src/locale/en-US/execWorkflow.ts
+++ b/packages/sqle/src/locale/en-US/execWorkflow.ts
@@ -142,6 +142,35 @@ export default {
   },
 
   detail: {
+    failDisplay: {
+      headerPrefix: 'Execution failed: ',
+      headerWithCount: 'Execution failed: {{count}} SQL(s) {{phrase}}',
+      statusLabel: 'Status',
+      stageLabel: 'Stage',
+      reasonLabel: 'Reason',
+      stage: {
+        sqlBackup: 'SQL backup',
+        sqlExecute: 'SQL execution',
+        datasourceConnect: 'Data source connection',
+        preCheck: 'Pre-check',
+        terminate: 'Task terminated',
+        unknown: 'Unknown'
+      },
+      phrase: {
+        sqlBackup: 'SQL backup failed',
+        sqlExecute: 'SQL execution failed',
+        datasourceConnect: 'Data source connection failed',
+        preCheck: 'Pre-check failed',
+        terminate: 'Task terminated',
+        unknown: 'Unknown'
+      },
+      status: {
+        backupFailed: 'Backup failed',
+        executeFailed: 'Execution failed',
+        connectFailed: 'Connection failed',
+        notExecuted: 'Not executed'
+      }
+    },
     operator: {
       buttonText: 'Workflow details',
       title: 'Workflow information',

--- a/packages/sqle/src/locale/zh-CN/audit.ts
+++ b/packages/sqle/src/locale/zh-CN/audit.ts
@@ -41,7 +41,7 @@ export default {
     terminate_succ: '中止成功',
     terminating: '正在中止',
     allStatus: '全部状态',
-    rollback: '执行回滚',
+    rollback: '已回滚',
     not_executed: '未执行'
   },
 

--- a/packages/sqle/src/locale/zh-CN/audit.ts
+++ b/packages/sqle/src/locale/zh-CN/audit.ts
@@ -41,7 +41,8 @@ export default {
     terminate_succ: '中止成功',
     terminating: '正在中止',
     allStatus: '全部状态',
-    rollback: '执行回滚'
+    rollback: '执行回滚',
+    not_executed: '未执行'
   },
 
   auditStatus: {

--- a/packages/sqle/src/locale/zh-CN/execWorkflow.ts
+++ b/packages/sqle/src/locale/zh-CN/execWorkflow.ts
@@ -159,6 +159,35 @@ export default {
   },
 
   detail: {
+    failDisplay: {
+      headerPrefix: '上线失败：',
+      headerWithCount: '上线失败：{{count}} 条 {{phrase}}',
+      statusLabel: '状态',
+      stageLabel: '阶段',
+      reasonLabel: '原因',
+      stage: {
+        sqlBackup: 'SQL 备份',
+        sqlExecute: 'SQL 执行',
+        datasourceConnect: '数据源连接',
+        preCheck: '前置校验',
+        terminate: '任务中止',
+        unknown: '未知'
+      },
+      phrase: {
+        sqlBackup: 'SQL 备份失败',
+        sqlExecute: 'SQL 执行失败',
+        datasourceConnect: '数据源连接失败',
+        preCheck: '前置校验失败',
+        terminate: '任务中止',
+        unknown: '未知'
+      },
+      status: {
+        backupFailed: '备份失败',
+        executeFailed: '执行失败',
+        connectFailed: '连接失败',
+        notExecuted: '未执行'
+      }
+    },
     operator: {
       buttonText: '工单详情',
       title: '工单信息',

--- a/packages/sqle/src/locale/zh-CN/execWorkflow.ts
+++ b/packages/sqle/src/locale/zh-CN/execWorkflow.ts
@@ -162,6 +162,7 @@ export default {
     failDisplay: {
       headerPrefix: '上线失败：',
       headerWithCount: '上线失败：{{count}} 条 {{phrase}}',
+      headerWithSqlNumber: '上线失败：第 {{number}} 条 SQL 执行失败',
       statusLabel: '状态',
       stageLabel: '阶段',
       reasonLabel: '原因',
@@ -185,7 +186,8 @@ export default {
         backupFailed: '备份失败',
         executeFailed: '执行失败',
         connectFailed: '连接失败',
-        notExecuted: '未执行'
+        notExecuted: '未执行',
+        rolledBack: '已回滚'
       }
     },
     operator: {

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`sqle/ExecWorkflow/BasicInfoWrapper render snap when has all params 1`] 
 <body>
   <div>
     <div
-      class="custom-class-name-a css-n0dig9"
+      class="custom-class-name-a css-kgsw91"
     >
       <div
         class="workflow-base-info-status"
@@ -118,7 +118,7 @@ exports[`sqle/ExecWorkflow/BasicInfoWrapper render snap when has need params 1`]
 <body>
   <div>
     <div
-      class="css-rgmylz"
+      class="css-14tz7m1"
     >
       <div
         class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.tsx
@@ -19,7 +19,8 @@ const BasicInfoWrapper: React.FC<BasicInfoWrapperProps> = ({
   className,
   status,
   gap = 12,
-  sqlVersion
+  sqlVersion,
+  failSummary
 }) => {
   const { t } = useTranslation();
   const { projectID } = useCurrentProject();
@@ -87,6 +88,10 @@ const BasicInfoWrapper: React.FC<BasicInfoWrapperProps> = ({
             {status && t(execWorkflowStatusDictionary[status])}
           </span>
         </div>
+      </EmptyBox>
+
+      <EmptyBox if={!!failSummary}>
+        <div className="workflow-base-info-fail-summary">{failSummary}</div>
       </EmptyBox>
 
       <Space className="workflow-base-info-title">

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/index.type.ts
@@ -8,4 +8,6 @@ export type BasicInfoWrapperProps = {
   className?: string;
   gap?: number;
   sqlVersion?: ISqlVersion;
+  /** 上线失败时的阶段摘要（如「上线失败：SQL 备份失败」） */
+  failSummary?: string | null;
 };

--- a/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Common/BasicInfoWrapper/style.ts
@@ -51,6 +51,16 @@ export const BasicInfoStyleWrapper = styled('div')<{
     }
   }
 
+  .workflow-base-info-fail-summary {
+    color: ${({ theme }) =>
+      theme.sqleTheme.statistics.auditResultStatusColor.exec_failed};
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 22px;
+    margin-bottom: 12px;
+    max-width: 800px;
+  }
+
   .workflow-base-info-title {
     color: ${({ theme }) =>
       theme.sqleTheme.execWorkflow.common.basicInfo.titleColor};

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -5372,7 +5372,7 @@ from
             </div>
           </div>
           <div
-            class="css-rgmylz"
+            class="css-14tz7m1"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -7824,7 +7824,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
             </div>
           </div>
           <div
-            class="css-rgmylz"
+            class="css-14tz7m1"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -9955,7 +9955,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
             </div>
           </div>
           <div
-            class="css-rgmylz"
+            class="css-14tz7m1"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -12261,7 +12261,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
             </div>
           </div>
           <div
-            class="css-rgmylz"
+            class="css-14tz7m1"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -15021,7 +15021,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
             </div>
           </div>
           <div
-            class="css-rgmylz"
+            class="css-14tz7m1"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -19221,7 +19221,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
             </div>
           </div>
           <div
-            class="css-rgmylz"
+            class="css-14tz7m1"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -29986,7 +29986,7 @@ from
             </div>
           </div>
           <div
-            class="css-rgmylz"
+            class="css-14tz7m1"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -32590,7 +32590,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
+                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -32624,26 +32624,26 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                               </div>
                               <span
                                 aria-hidden="true"
-                                class="ant-select-arrow ant-select-arrow-loading"
+                                class="ant-select-arrow"
                                 style="user-select: none;"
                                 unselectable="on"
                               >
                                 <span
-                                  aria-label="loading"
-                                  class="anticon anticon-loading anticon-spin"
+                                  aria-label="down"
+                                  class="anticon anticon-down ant-select-suffix"
                                   role="img"
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    data-icon="loading"
+                                    data-icon="down"
                                     fill="currentColor"
                                     focusable="false"
                                     height="1em"
-                                    viewBox="0 0 1024 1024"
+                                    viewBox="64 64 896 896"
                                     width="1em"
                                   >
                                     <path
-                                      d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
                                     />
                                   </svg>
                                 </span>

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,22 +2,6 @@
 
 exports[`sqle/SqlExecWorkflow/Create render associated version when create workflow 1`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -154,7 +138,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -163,7 +147,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -203,7 +187,8 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -218,6 +203,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -230,9 +216,10 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -1862,22 +1849,6 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
 
 exports[`sqle/SqlExecWorkflow/Create render associated version when create workflow 2`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -2014,7 +1985,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -2023,7 +1994,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -2063,7 +2034,8 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -2078,6 +2050,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -2090,9 +2063,10 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -3726,22 +3700,6 @@ from
 
 exports[`sqle/SqlExecWorkflow/Create render associated version when create workflow 3`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -3878,7 +3836,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -3887,7 +3845,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -3927,7 +3885,8 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -3942,6 +3901,7 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -3954,9 +3914,10 @@ exports[`sqle/SqlExecWorkflow/Create render associated version when create workf
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -6160,22 +6121,6 @@ from
 
 exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -6312,7 +6257,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -6321,7 +6266,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -6361,7 +6306,8 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -6376,6 +6322,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -6388,9 +6335,10 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -8291,22 +8239,6 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 1`] = `
 
 exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -8443,7 +8375,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -8452,7 +8384,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -8492,7 +8424,8 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -8507,6 +8440,7 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -8519,9 +8453,10 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -10796,22 +10731,6 @@ exports[`sqle/SqlExecWorkflow/Create render create rollback workflow 2`] = `
 
 exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit action for different SQLs 1`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -10948,7 +10867,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -10957,7 +10876,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -10997,7 +10916,8 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -11012,6 +10932,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -11024,9 +10945,10 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -13556,22 +13478,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
 
 exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit action for different SQLs 2`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -13708,7 +13614,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -13717,7 +13623,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -13757,7 +13663,8 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -13772,6 +13679,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -13784,9 +13692,10 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -16513,7 +16422,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-1jlm9cy"
+                      class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                     >
                       <div
                         class="ant-row ant-form-item-row"
@@ -16562,7 +16471,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow ant-select-loading"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -16589,9 +16498,10 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     />
                                   </span>
                                   <span
-                                    class="ant-select-selection-placeholder"
+                                    class="ant-select-selection-item"
+                                    title="1"
                                   >
-                                    请选择审批流程模板
+                                    1
                                   </span>
                                 </div>
                                 <span
@@ -17756,22 +17666,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
 
 exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit action for different SQLs 3`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -17908,7 +17802,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -17917,7 +17811,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -17957,7 +17851,8 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -17972,6 +17867,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -17984,9 +17880,10 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -21181,7 +21078,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                       </div>
                     </div>
                     <div
-                      class="ant-form-item css-1jlm9cy"
+                      class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                     >
                       <div
                         class="ant-row ant-form-item-row"
@@ -21190,7 +21087,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                           class="ant-col ant-form-item-label"
                         >
                           <label
-                            class=""
+                            class="ant-form-item-required"
                             for="workflow_template_id"
                             title="审批流程模板"
                           >
@@ -21230,7 +21127,8 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                               class="ant-form-item-control-input-content"
                             >
                               <div
-                                class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                                aria-required="true"
+                                class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                               >
                                 <div
                                   class="ant-select-selector"
@@ -21245,6 +21143,7 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                       aria-expanded="false"
                                       aria-haspopup="listbox"
                                       aria-owns="workflow_template_id_list"
+                                      aria-required="true"
                                       autocomplete="off"
                                       class="ant-select-selection-search-input"
                                       id="workflow_template_id"
@@ -21257,9 +21156,10 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
                                     />
                                   </span>
                                   <span
-                                    class="ant-select-selection-placeholder"
+                                    class="ant-select-selection-item"
+                                    title="700300-WorkflowTemplate"
                                   >
-                                    请选择审批流程模板
+                                    700300-WorkflowTemplate
                                   </span>
                                 </div>
                                 <span
@@ -22752,22 +22652,6 @@ exports[`sqle/SqlExecWorkflow/Create should handle form submission and audit act
 
 exports[`sqle/SqlExecWorkflow/Create should reset form fields and snapshot UI after reset action 1`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -22913,7 +22797,7 @@ exports[`sqle/SqlExecWorkflow/Create should reset form fields and snapshot UI af
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -22953,6 +22837,7 @@ exports[`sqle/SqlExecWorkflow/Create should reset form fields and snapshot UI af
                             class="ant-form-item-control-input-content"
                           >
                             <div
+                              aria-required="true"
                               class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
@@ -22968,6 +22853,7 @@ exports[`sqle/SqlExecWorkflow/Create should reset form fields and snapshot UI af
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -24188,22 +24074,6 @@ exports[`sqle/SqlExecWorkflow/Create should reset form fields and snapshot UI af
 
 exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in the same mode 1`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -24340,7 +24210,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -24349,7 +24219,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -24389,7 +24259,8 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -24404,6 +24275,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -24416,9 +24288,10 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -26220,22 +26093,6 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
 
 exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in the same mode 2`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -26372,7 +26229,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -26381,7 +26238,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -26421,7 +26278,8 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -26436,6 +26294,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -26448,9 +26307,10 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -28340,22 +28200,6 @@ from
 
 exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in the same mode 3`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -28492,7 +28336,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -28501,7 +28345,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -28541,7 +28385,8 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -28556,6 +28401,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -28568,9 +28414,10 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot UI and perform SQL audit in
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -32368,43 +32215,11 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
       </div>
     </div>
   </div>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
 </body>
 `;
 
 exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow creation UI when current is clone workflow mode 1`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -32541,7 +32356,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -32550,7 +32365,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -32590,7 +32405,8 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -32605,6 +32421,7 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -32617,9 +32434,10 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span
@@ -36195,22 +36013,6 @@ exports[`sqle/SqlExecWorkflow/Create should snapshot render initial workflow cre
 
 exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prevent audit with invalid name 1`] = `
 <body>
-  <textarea
-    aria-hidden="true"
-    style="letter-spacing:normal;line-height:1.5714285714285714;padding-top:4px;padding-bottom:4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji';font-weight:;font-size:14px;font-variant:;text-rendering:auto;text-transform:none;width:100%;text-indent:0;padding-left:11px;padding-right:11px;border-width:;box-sizing:border-box;word-break:;white-space:pre-wrap;
-  min-height:0 !important;
-  max-height:none !important;
-  height:0 !important;
-  visibility:hidden !important;
-  overflow:hidden !important;
-  position:absolute !important;
-  z-index:-1000 !important;
-  top:0 !important;
-  right:0 !important;
-  pointer-events: none !important;
-"
-    tab-index="-1"
-  />
   <div>
     <div
       class="ant-spin-nested-loading"
@@ -36371,7 +36173,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                     </div>
                   </section>
                   <div
-                    class="ant-form-item css-1jlm9cy"
+                    class="ant-form-item css-1jlm9cy ant-form-item-has-success"
                   >
                     <div
                       class="ant-row ant-form-item-row"
@@ -36380,7 +36182,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                         class="ant-col ant-form-item-label ant-form-item-label-left"
                       >
                         <label
-                          class="ant-form-item-no-colon"
+                          class="ant-form-item-required ant-form-item-no-colon"
                           for="workflow_template_id"
                           title="审批流程模板"
                         >
@@ -36420,7 +36222,8 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                             class="ant-form-item-control-input-content"
                           >
                             <div
-                              class="ant-select ant-select-in-form-item basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
+                              aria-required="true"
+                              class="ant-select ant-select-in-form-item ant-select-status-success basic-select-wrapper css-16awv9j ant-select-single ant-select-show-arrow"
                             >
                               <div
                                 class="ant-select-selector"
@@ -36435,6 +36238,7 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                     aria-expanded="false"
                                     aria-haspopup="listbox"
                                     aria-owns="workflow_template_id_list"
+                                    aria-required="true"
                                     autocomplete="off"
                                     class="ant-select-selection-search-input"
                                     id="workflow_template_id"
@@ -36447,9 +36251,10 @@ exports[`sqle/SqlExecWorkflow/Create should validate "workflow_subject" and prev
                                   />
                                 </span>
                                 <span
-                                  class="ant-select-selection-placeholder"
+                                  class="ant-select-selection-item"
+                                  title="700300-WorkflowTemplate"
                                 >
-                                  请选择审批流程模板
+                                  700300-WorkflowTemplate
                                 </span>
                               </div>
                               <span

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/__tests__/index.test.tsx
@@ -15,6 +15,7 @@ import execWorkflow from '@actiontech/shared/lib/testUtil/mockApi/sqle/execWorkf
 import instance from '@actiontech/shared/lib/testUtil/mockApi/sqle/instance';
 import task from '@actiontech/shared/lib/testUtil/mockApi/sqle/task';
 import system from '@actiontech/shared/lib/testUtil/mockApi/sqle/system';
+import workflowTemplate from '@actiontech/shared/lib/testUtil/mockApi/sqle/workflowTemplate';
 import { getInstanceTipListV1FunctionalModuleEnum } from '@actiontech/shared/lib/api/sqle/service/instance/index.enum';
 import { instanceTipsMockData } from '@actiontech/shared/lib/testUtil/mockApi/sqle/instance/data';
 import { createSpySuccessResponse } from '@actiontech/shared/lib/testUtil/mockApi';
@@ -60,6 +61,19 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     return sqleSuperRender(<CreateSqlExecWorkflow />);
   };
 
+  const clearTextAreaMeasuringNodes = () => {
+    document
+      .querySelectorAll('textarea[aria-hidden="true"]')
+      .forEach((node) => {
+        node.remove();
+      });
+  };
+
+  const expectBaseElementSnapshot = (baseElement: Element) => {
+    clearTextAreaMeasuringNodes();
+    expect(baseElement).toMatchSnapshot();
+  };
+
   ignoreConsoleErrors([
     UtilsConsoleErrorStringsEnum.UNIQUE_KEY_REQUIRED,
     UtilsConsoleErrorStringsEnum.INVALID_CSS_VALUE,
@@ -67,6 +81,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
   ]);
 
   beforeEach(() => {
+    clearTextAreaMeasuringNodes();
     MockDate.set(dayjs('2023-12-18 12:00:00').valueOf());
     jest.useFakeTimers({ legacyFakeTimers: true });
 
@@ -74,6 +89,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     mockUseCurrentProject();
     mockUseCurrentUser();
     execWorkflow.mockAllApi();
+    workflowTemplate.mockAllApi();
     RequestCreateWorkflow = execWorkflow.createWorkflow();
     requestInstanceTip = instance.getInstanceTipList();
     requestInstanceSchemas = instance.getInstanceSchemas();
@@ -151,6 +167,8 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     jest.clearAllTimers();
     MockDate.reset();
     cleanup();
+    // Ant Design TextArea autoSize may leave measuring nodes on document.body
+    clearTextAreaMeasuringNodes();
   });
 
   it('should snapshot render initial workflow creation UI', async () => {
@@ -162,7 +180,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     expect(screen.getByText('工单描述')).toBeInTheDocument();
     expect(screen.getByText('审核SQL语句信息')).toBeInTheDocument();
 
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
   });
 
   it('should snapshot render initial workflow creation UI when current is clone workflow mode', async () => {
@@ -191,7 +209,11 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     expect(requestInstance).toHaveBeenCalledTimes(3);
     expect(requestGetModalStatus).toHaveBeenCalledTimes(3);
     expect(getSqlFileOrderMethodV1Spy).toHaveBeenCalledTimes(1);
-    expect(baseElement).toMatchSnapshot();
+    await act(async () => jest.advanceTimersByTime(3000));
+    expect(
+      queryBySelector('.ant-select-loading', baseElement)
+    ).not.toBeInTheDocument();
+    expectBaseElementSnapshot(baseElement);
   });
 
   it('should reset form fields and snapshot UI after reset action', async () => {
@@ -273,7 +295,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
       1
     );
 
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
   });
 
   it('should snapshot UI and perform SQL audit in the same mode', async () => {
@@ -316,7 +338,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     await act(async () => jest.advanceTimersByTime(0));
     fireEvent.click(getBySelector(`div[title="test123"]`));
     await act(async () => jest.advanceTimersByTime(3000));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
 
     // SQL美化
     const monacoEditor = getBySelector('.custom-monaco-editor', baseElement);
@@ -338,7 +360,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
       instance_name: instanceTipsMockData[0].instance_name,
       project_name: projectName
     });
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
 
     fireEvent.click(screen.getByText('审 核'));
     await act(async () => jest.advanceTimersByTime(0));
@@ -359,7 +381,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     });
 
     await act(async () => jest.advanceTimersByTime(3000));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
   });
 
   it('should handle form submission and audit action for different SQLs', async () => {
@@ -436,12 +458,12 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     await act(async () => jest.advanceTimersByTime(3000));
     expect(getAuditTaskSQLsSpy).toHaveBeenCalledTimes(1);
     await act(async () => jest.advanceTimersByTime(500));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
 
     // 编辑工单信息
     fireEvent.click(screen.getByText('修改工单'));
     await act(async () => jest.advanceTimersByTime(400));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
 
     fireEvent.click(screen.getAllByText('上传SQL文件')[1]);
     await act(async () => jest.advanceTimersByTime(300));
@@ -483,9 +505,10 @@ describe('sqle/SqlExecWorkflow/Create', () => {
       desc: 'workflow desc',
       project_name: projectName,
       task_ids: [18],
-      workflow_subject: 'workflow_name_2'
+      workflow_subject: 'workflow_name_2',
+      workflow_template_id: 1
     });
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
   });
 
   it('should prevent workflow creation when task SQL list is empty', async () => {
@@ -804,7 +827,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
 
     await act(async () => jest.advanceTimersByTime(0));
     expect(requestAuditTask).not.toHaveBeenCalled();
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
   });
 
   it('should clear exec_mode data when disabled execute mode selector', async () => {
@@ -918,7 +941,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     await act(async () => jest.advanceTimersByTime(0));
     fireEvent.click(getBySelector(`div[title="test123"]`));
     await act(async () => jest.advanceTimersByTime(3000));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
 
     // SQL美化
     const monacoEditor = getBySelector('.custom-monaco-editor', baseElement);
@@ -934,7 +957,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
       instance_name: instanceTipsMockData[0].instance_name,
       project_name: projectName
     });
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
 
     fireEvent.click(screen.getByText('审 核'));
     await act(async () => jest.advanceTimersByTime(0));
@@ -955,7 +978,7 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     });
 
     await act(async () => jest.advanceTimersByTime(3000));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
     fireEvent.click(screen.getByText('提交工单'));
     await act(async () => jest.advanceTimersByTime(0));
 
@@ -967,7 +990,8 @@ describe('sqle/SqlExecWorkflow/Create', () => {
       task_ids: [1, 2],
       workflow_subject: 'mysql-1_20231218120000',
       desc: undefined,
-      sql_version_id: 1
+      sql_version_id: 1,
+      workflow_template_id: 1
     });
   });
 
@@ -1059,7 +1083,8 @@ describe('sqle/SqlExecWorkflow/Create', () => {
       project_name: 'default',
       sql_version_id: undefined,
       task_ids: [1, 2],
-      workflow_subject: 'workflow_name_2'
+      workflow_subject: 'workflow_name_2',
+      workflow_template_id: 1
     });
     expect(screen.getByText('提交工单').closest('button')).toHaveClass(
       'ant-btn-loading'
@@ -1138,10 +1163,10 @@ describe('sqle/SqlExecWorkflow/Create', () => {
     await act(async () => jest.advanceTimersByTime(3000));
     expect(getAuditTaskSQLsSpy).toHaveBeenCalledTimes(1);
     await act(async () => jest.advanceTimersByTime(500));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
 
     await act(async () => jest.advanceTimersByTime(3000));
-    expect(baseElement).toMatchSnapshot();
+    expectBaseElementSnapshot(baseElement);
     fireEvent.click(screen.getByText('提交工单'));
     await act(async () => jest.advanceTimersByTime(0));
 
@@ -1154,7 +1179,8 @@ describe('sqle/SqlExecWorkflow/Create', () => {
       workflow_subject: 'workflow-name-Rollback',
       desc: 'test desc',
       rollback_sql_ids: [1, 2],
-      workflow_id: '1'
+      workflow_id: '1',
+      workflow_template_id: 1
     });
   });
 

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/__snapshots__/index.ce.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`test AuditResultStep ce render init snap 1`] = `
       </div>
     </div>
     <div
-      class="css-rgmylz"
+      class="css-14tz7m1"
     >
       <div
         class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"

--- a/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Create/components/AuditResultStep/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`test AuditResultStep render switch backup policy button 1`] = `
       </div>
     </div>
     <div
-      class="css-rgmylz"
+      class="css-14tz7m1"
     >
       <div
         class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -655,7 +655,7 @@ exports[`test AuditResultStep render switch data source backup policy 1`] = `
       </div>
     </div>
     <div
-      class="css-rgmylz"
+      class="css-14tz7m1"
     >
       <div
         class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -1713,7 +1713,7 @@ exports[`test AuditResultStep should match snapshot 1`] = `
     </div>
   </div>
   <div
-    class="css-rgmylz"
+    class="css-14tz7m1"
   >
     <div
       class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/__tests__/__snapshots__/index.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`sqle/ExecWorkflow/Detail render current workflow status is wait for exe
               </div>
             </div>
             <div
-              class="clearPaddingTop css-xcpaj5"
+              class="clearPaddingTop css-1h49nkl"
             >
               <div
                 class="workflow-base-info-status"
@@ -951,7 +951,7 @@ exports[`sqle/ExecWorkflow/Detail render snap detail 1`] = `
               </div>
             </div>
             <div
-              class="clearPaddingTop css-ddk1y4"
+              class="clearPaddingTop css-1v892o2"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center workflow-base-info-title"
@@ -1522,7 +1522,7 @@ exports[`sqle/ExecWorkflow/Detail render snap detail 2`] = `
               </div>
             </div>
             <div
-              class="clearPaddingTop css-1yb6xb6"
+              class="clearPaddingTop css-1vc47j"
             >
               <div
                 class="workflow-base-info-status"
@@ -2414,7 +2414,7 @@ exports[`sqle/ExecWorkflow/Detail render snap detail 3`] = `
               </div>
             </div>
             <div
-              class="clearPaddingTop css-1yb6xb6"
+              class="clearPaddingTop css-1vc47j"
             >
               <div
                 class="workflow-base-info-status"
@@ -3338,7 +3338,7 @@ exports[`sqle/ExecWorkflow/Detail render snap detail when have multiple states 1
               </div>
             </div>
             <div
-              class="clearPaddingTop css-fljemo"
+              class="clearPaddingTop css-1w6w5vt"
             >
               <div
                 class="workflow-base-info-status"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/SqlMode.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/SqlMode.tsx
@@ -44,6 +44,7 @@ import {
   PermissionControl,
   PERMISSIONS
 } from '@actiontech/shared/lib/features';
+import { buildExecResultDisplay } from '../../../../../utils/failDisplay';
 
 const SqlMode: React.FC<SqlExecuteResultCardProps> = ({
   projectID,
@@ -157,6 +158,23 @@ const SqlMode: React.FC<SqlExecuteResultCardProps> = ({
       ? t('execWorkflow.audit.table.backupExecuteBeforeTips')
       : '';
   }, [props.taskStatus, props.backup_result, t]);
+  const execResultDisplay = useMemo(
+    () =>
+      buildExecResultDisplay({
+        execStatus: props.exec_status,
+        failStage: props.fail_stage,
+        failReason: props.fail_reason,
+        execResult: props.exec_result,
+        backupStatus: props.backup_status
+      }),
+    [
+      props.backup_status,
+      props.exec_result,
+      props.exec_status,
+      props.fail_reason,
+      props.fail_stage
+    ]
+  );
   return (
     <TasksResultCardStyleWrapper>
       {contextHolder}
@@ -168,6 +186,8 @@ const SqlMode: React.FC<SqlExecuteResultCardProps> = ({
               status={
                 props.exec_status as getAuditTaskSQLsV2FilterExecStatusEnum
               }
+              failStage={props.fail_stage}
+              backupStatus={props.backup_status}
             />
             <Divider type="vertical" className="result-card-status-divider" />
             <AuditResultTag
@@ -280,7 +300,36 @@ const SqlMode: React.FC<SqlExecuteResultCardProps> = ({
               {
                 value: TaskResultContentTypeEnum.exec_result,
                 label: t('execWorkflow.audit.table.execResult'),
-                children: props.exec_result || '-'
+                children: execResultDisplay.structured ? (
+                  <div className="exec-fail-result">
+                    <div className="exec-fail-result-row">
+                      <span className="exec-fail-result-label">
+                        {t('execWorkflow.detail.failDisplay.statusLabel')}：
+                      </span>
+                      <span>
+                        {execResultDisplay.statusI18nKey
+                          ? t(execResultDisplay.statusI18nKey)
+                          : '-'}
+                      </span>
+                    </div>
+                    <div className="exec-fail-result-row">
+                      <span className="exec-fail-result-label">
+                        {t('execWorkflow.detail.failDisplay.stageLabel')}：
+                      </span>
+                      <span>{t(execResultDisplay.stageI18nKey)}</span>
+                    </div>
+                    <div className="exec-fail-result-row">
+                      <span className="exec-fail-result-label">
+                        {t('execWorkflow.detail.failDisplay.reasonLabel')}：
+                      </span>
+                      <span className="exec-fail-result-reason">
+                        {execResultDisplay.reasonText}
+                      </span>
+                    </div>
+                  </div>
+                ) : (
+                  execResultDisplay.reasonText
+                )
               }
             ]}
             segmentedRowExtraContent={

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/SqlMode.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/SqlMode.tsx
@@ -52,6 +52,7 @@ const SqlMode: React.FC<SqlExecuteResultCardProps> = ({
   onUpdateDescription,
   pagination,
   enableRetryExecute,
+  isExecFailHighlight,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -176,7 +177,10 @@ const SqlMode: React.FC<SqlExecuteResultCardProps> = ({
     ]
   );
   return (
-    <TasksResultCardStyleWrapper>
+    <TasksResultCardStyleWrapper
+      className={isExecFailHighlight ? 'exec-fail-highlight' : undefined}
+      data-exec-fail-anchor={isExecFailHighlight ? 'true' : undefined}
+    >
       {contextHolder}
       <div className="result-card-header">
         <Space>
@@ -312,12 +316,18 @@ const SqlMode: React.FC<SqlExecuteResultCardProps> = ({
                           : '-'}
                       </span>
                     </div>
-                    <div className="exec-fail-result-row">
-                      <span className="exec-fail-result-label">
-                        {t('execWorkflow.detail.failDisplay.stageLabel')}：
-                      </span>
-                      <span>{t(execResultDisplay.stageI18nKey)}</span>
-                    </div>
+                    <EmptyBox if={!execResultDisplay.hideStage}>
+                      <div className="exec-fail-result-row">
+                        <span className="exec-fail-result-label">
+                          {t('execWorkflow.detail.failDisplay.stageLabel')}：
+                        </span>
+                        <span>
+                          {execResultDisplay.stageI18nKey
+                            ? t(execResultDisplay.stageI18nKey)
+                            : '-'}
+                        </span>
+                      </div>
+                    </EmptyBox>
                     <div className="exec-fail-result-row">
                       <span className="exec-fail-result-label">
                         {t('execWorkflow.detail.failDisplay.reasonLabel')}：

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/FileMode.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/FileMode.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`test TaskResultList/Result/FileMode should match snapshot 1`] = `
 <div>
   <div
-    class="css-1gxdwqg"
+    class="css-1nbx0m0"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -166,7 +166,7 @@ exports[`test TaskResultList/Result/FileMode should match snapshot 1`] = `
 exports[`test TaskResultList/Result/FileMode should match snapshot 2`] = `
 <div>
   <div
-    class="css-1gxdwqg"
+    class="css-1nbx0m0"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -329,7 +329,7 @@ exports[`test TaskResultList/Result/FileMode should match snapshot 2`] = `
 exports[`test TaskResultList/Result/FileMode should render audit result count 1`] = `
 <div>
   <div
-    class="css-1gxdwqg"
+    class="css-1nbx0m0"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -515,7 +515,7 @@ exports[`test TaskResultList/Result/FileMode should render audit result count 1`
 exports[`test TaskResultList/Result/FileMode should render collapse children and called request 1`] = `
 <div>
   <div
-    class="css-1gxdwqg"
+    class="css-1nbx0m0"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.ce.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.ce.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode ce render init snap 1`] = `
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render associated rollback workfl
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -408,7 +408,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render backup strategy tip 1`] = 
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -868,7 +868,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -1251,7 +1251,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -1696,7 +1696,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -2141,7 +2141,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -2591,7 +2591,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click add desc 1`] = `
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -2965,7 +2965,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click add desc 2`] = `
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -3363,7 +3363,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click icon arrow when has 
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -3760,7 +3760,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click icon arrow when no c
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -4165,7 +4165,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render has backup conflict 1`] = 
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -4625,7 +4625,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render no sql execution result 1`
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -5118,7 +5118,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render no sql execution result an
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -5610,7 +5610,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render snap when data is empty 1`
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -5984,7 +5984,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render sql execution result 1`] =
 <body>
   <div>
     <div
-      class="css-1gxdwqg"
+      class="css-1nbx0m0"
     >
       <div
         class="result-card-header"
@@ -6476,7 +6476,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render sql execution result 1`] =
 exports[`sqle/ExecWorkflow/AuditDetail/SqlMode should render retry execute action when exec status is failed or initialized 1`] = `
 <div>
   <div
-    class="css-1gxdwqg"
+    class="css-1nbx0m0"
   >
     <div
       class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/components/ExecStatusTag.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/components/ExecStatusTag.tsx
@@ -3,6 +3,12 @@ import { getAuditTaskSQLsV2FilterExecStatusEnum } from '@actiontech/shared/lib/a
 import { BasicTagColor } from '@actiontech/dms-kit/es/theme/theme.type';
 import { useTranslation } from 'react-i18next';
 import { execStatusDictionary } from '../../../../../../../../../hooks/useStaticStatus/index.data';
+import {
+  failProductStatusI18nKey,
+  ONLINE_FAIL_STAGE,
+  resolveFailStage
+} from '../../../../../../utils/failDisplay';
+
 const execStatusMap: {
   [key in getAuditTaskSQLsV2FilterExecStatusEnum]?: BasicTagColor;
 } = {
@@ -14,16 +20,31 @@ const execStatusMap: {
   [getAuditTaskSQLsV2FilterExecStatusEnum.terminate_failed]: 'red',
   [getAuditTaskSQLsV2FilterExecStatusEnum.terminate_succeeded]: 'green',
   [getAuditTaskSQLsV2FilterExecStatusEnum.terminating]: 'geekblue',
-  [getAuditTaskSQLsV2FilterExecStatusEnum.execute_rollback]: 'orange'
+  [getAuditTaskSQLsV2FilterExecStatusEnum.execute_rollback]: 'orange',
+  [getAuditTaskSQLsV2FilterExecStatusEnum.not_executed]: 'orange'
 };
 export interface ExecStatusTagProps {
   status: getAuditTaskSQLsV2FilterExecStatusEnum;
+  failStage?: string;
+  backupStatus?: string;
 }
-const ExecStatusTag: React.FC<ExecStatusTagProps> = ({ status }) => {
+const ExecStatusTag: React.FC<ExecStatusTagProps> = ({
+  status,
+  failStage,
+  backupStatus
+}) => {
   const { t } = useTranslation();
+  const productStatusKey =
+    status === getAuditTaskSQLsV2FilterExecStatusEnum.failed
+      ? failProductStatusI18nKey[resolveFailStage(failStage, backupStatus)] ??
+        failProductStatusI18nKey[ONLINE_FAIL_STAGE.unknown]
+      : null;
+  const label = productStatusKey
+    ? t(productStatusKey)
+    : t(execStatusDictionary[status]);
   return (
     <BasicTag color={execStatusMap[status]} size="large" bordered={false}>
-      {t(execStatusDictionary[status])}
+      {label}
     </BasicTag>
   );
 };

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/index.type.ts
@@ -25,6 +25,8 @@ export type SqlExecuteResultCardProps = BaseProps &
     instanceName?: string;
     schema?: string;
     pagination?: TablePagination;
+    /** AC-010：是否为定位命中的出错 SQL（唯一失败高亮） */
+    isExecFailHighlight?: boolean;
   };
 
 export type FileExecuteResultCardProps = BaseProps &

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/style.ts
@@ -69,6 +69,26 @@ export const TasksResultCardStyleWrapper = styled('div')`
           width: max-content;
         }
       }
+
+      .exec-fail-result {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        color: ${({ theme }) => theme.sharedTheme.uiToken.colorText};
+        font-size: 14px;
+        line-height: 22px;
+        white-space: pre-wrap;
+        word-break: break-word;
+
+        .exec-fail-result-label {
+          color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextTertiary};
+          margin-right: 4px;
+        }
+
+        .exec-fail-result-reason {
+          white-space: pre-wrap;
+        }
+      }
     }
 
     & .ant-collapse.result-record-collapse .ant-collapse-header {

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/style.ts
@@ -8,6 +8,12 @@ export const TasksResultCardStyleWrapper = styled('div')`
   background: ${({ theme }) => theme.sharedTheme.uiToken.colorBgBase};
   margin-bottom: 20px;
 
+  &.exec-fail-highlight {
+    border-color: ${({ theme }) => theme.sharedTheme.uiToken.colorError};
+    box-shadow: inset 0 0 0 1px
+      ${({ theme }) => theme.sharedTheme.uiToken.colorError};
+  }
+
   & .result-card-header {
     height: 60px;
     padding: 16px 20px;

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/SqlStatementResultTable/columns.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/SqlStatementResultTable/columns.tsx
@@ -58,9 +58,11 @@ export const SQLStatementResultColumns = (
       className: 'exec-status-column',
       render: (status, record) => {
         return (
-          <BasicToolTip title={record.exec_result}>
+          <BasicToolTip title={record.fail_reason || record.exec_result}>
             <ExecStatusTag
               status={status as getAuditTaskSQLsV2FilterExecStatusEnum}
+              failStage={record.fail_stage}
+              backupStatus={record.backup_status}
             />
           </BasicToolTip>
         );

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -304,7 +304,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1gxdwqg"
+              class="css-1nbx0m0"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -466,7 +466,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1gxdwqg"
+              class="css-1nbx0m0"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -604,7 +604,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1gxdwqg"
+              class="css-1nbx0m0"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -766,7 +766,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1gxdwqg"
+              class="css-1nbx0m0"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -904,7 +904,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1gxdwqg"
+              class="css-1nbx0m0"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -1066,7 +1066,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1gxdwqg"
+              class="css-1nbx0m0"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`test PaginationList/SQLExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1gxdwqg"
+              class="css-1nbx0m0"
             >
               <div
                 class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/index.tsx
@@ -8,6 +8,11 @@ import { useCurrentProject } from '@actiontech/shared/lib/features';
 import ResultCard from '../../Common/ResultCard';
 import { WORKFLOW_OVERVIEW_TAB_KEY } from '../../../../../hooks/useAuditExecResultPanelSetup';
 import { TaskResultListLayoutEnum } from '../../../index.enum';
+import { useMemo } from 'react';
+import {
+  isExecFailHighlightSql,
+  locateExecFailSql
+} from '../../../../../utils/failDisplay';
 
 const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
   tableChange,
@@ -25,7 +30,9 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
   taskStatus,
   instanceName,
   schema,
-  enableRetryExecute
+  enableRetryExecute,
+  execFailSqlNumber,
+  execFailSqlId
 }) => {
   const { t } = useTranslation();
 
@@ -70,6 +77,15 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
     }
   );
 
+  const locatedExecFailSql = useMemo(
+    () =>
+      locateExecFailSql(currentAuditTaskList?.list ?? [], {
+        execFailSqlNumber,
+        execFailSqlId
+      }),
+    [currentAuditTaskList?.list, execFailSqlId, execFailSqlNumber]
+  );
+
   return (
     <List
       bordered={false}
@@ -94,6 +110,10 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
               schema={schema}
               pagination={pagination}
               enableRetryExecute={enableRetryExecute}
+              isExecFailHighlight={isExecFailHighlightSql(
+                item,
+                locatedExecFailSql
+              )}
             />
           </List.Item>
         );

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/SqlFileStatementOverview/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/SqlFileStatementOverview/__tests__/__snapshots__/index.test.tsx.snap
@@ -116,7 +116,12 @@ exports[`test AuditDetail/SqlFileStatementOverview should match snapshot 1`] = `
           <div
             class="custom-segmented-filter-item"
           >
-            执行回滚
+            已回滚
+          </div>
+          <div
+            class="custom-segmented-filter-item"
+          >
+            未执行
           </div>
         </div>
       </div>
@@ -529,7 +534,12 @@ exports[`test AuditDetail/SqlFileStatementOverview should match snapshot 2`] = `
           <div
             class="custom-segmented-filter-item"
           >
-            执行回滚
+            已回滚
+          </div>
+          <div
+            class="custom-segmented-filter-item"
+          >
+            未执行
           </div>
         </div>
       </div>

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -328,7 +328,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -466,7 +466,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -628,7 +628,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -766,7 +766,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -928,7 +928,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`test WaterfallList/SQLExecuteMode render onUpdateDescription 1`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="result-card-header"
@@ -538,7 +538,7 @@ exports[`test WaterfallList/SQLExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/index.tsx
@@ -4,13 +4,17 @@ import { useInfiniteScroll } from 'ahooks';
 import task from '@actiontech/shared/lib/api/sqle/service/task';
 import { useCurrentProject } from '@actiontech/shared/lib/features';
 import ResultCard from '../../Common/ResultCard';
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { IAuditTaskSQLResV2 } from '@actiontech/shared/lib/api/sqle/service/common';
 import { cloneDeep } from 'lodash';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { WorkflowResV2ExecModeEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
 import { WORKFLOW_OVERVIEW_TAB_KEY } from '../../../../../hooks/useAuditExecResultPanelSetup';
 import { TaskResultListLayoutEnum } from '../../../index.enum';
+import {
+  isExecFailHighlightSql,
+  locateExecFailSql
+} from '../../../../../utils/failDisplay';
 
 const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
   tableFilterInfo,
@@ -26,7 +30,9 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
   taskStatus,
   instanceName,
   schema,
-  enableRetryExecute
+  enableRetryExecute,
+  execFailSqlNumber,
+  execFailSqlId
 }) => {
   const { projectID } = useCurrentProject();
   const scrollPageNumber = useRef(0);
@@ -147,6 +153,15 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
     onRefreshScrollList(number, currentPage);
   };
 
+  const locatedExecFailSql = useMemo(
+    () =>
+      locateExecFailSql(currentAuditTaskInfiniteList?.list ?? [], {
+        execFailSqlNumber,
+        execFailSqlId
+      }),
+    [currentAuditTaskInfiniteList?.list, execFailSqlId, execFailSqlNumber]
+  );
+
   return (
     <InfiniteScroll
       hasMore={!noMore}
@@ -179,6 +194,10 @@ const SqlExecuteMode: React.FC<SqlExecuteModeProps> = ({
                 instanceName={instanceName}
                 schema={schema}
                 enableRetryExecute={enableRetryExecute}
+                isExecFailHighlight={isExecFailHighlightSql(
+                  item,
+                  locatedExecFailSql
+                )}
               />
             </List.Item>
           );

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/index.type.ts
@@ -24,4 +24,7 @@ export type TasksResultListBaseProps = {
   instanceName?: string;
   schema?: string;
   enableRetryExecute: boolean;
+  /** AC-010 定位主键 */
+  execFailSqlNumber?: number;
+  execFailSqlId?: number;
 };

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/__tests__/__snapshots__/index.test.tsx.snap
@@ -335,7 +335,12 @@ exports[`test AuditExecResultPanel matches snapshot and selects task on initial 
         <div
           class="custom-segmented-filter-item"
         >
-          执行回滚
+          已回滚
+        </div>
+        <div
+          class="custom-segmented-filter-item"
+        >
+          未执行
         </div>
       </div>
       <div
@@ -936,7 +941,12 @@ exports[`test AuditExecResultPanel matches snapshot and selects task on initial 
         <div
           class="custom-segmented-filter-item"
         >
-          执行回滚
+          已回滚
+        </div>
+        <div
+          class="custom-segmented-filter-item"
+        >
+          未执行
         </div>
       </div>
       <div
@@ -1020,7 +1030,7 @@ exports[`test AuditExecResultPanel matches snapshot and selects task on initial 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="result-card-header"
@@ -2759,7 +2769,12 @@ exports[`test AuditExecResultPanel sql retry execute permission should enable re
         <div
           class="custom-segmented-filter-item"
         >
-          执行回滚
+          已回滚
+        </div>
+        <div
+          class="custom-segmented-filter-item"
+        >
+          未执行
         </div>
       </div>
       <div
@@ -2819,7 +2834,7 @@ exports[`test AuditExecResultPanel sql retry execute permission should enable re
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1gxdwqg"
+                  class="css-1nbx0m0"
                 >
                   <div
                     class="result-card-header"
@@ -3743,7 +3758,12 @@ exports[`test AuditExecResultPanel updates layout to waterfall and retrieves tas
         <div
           class="custom-segmented-filter-item"
         >
-          执行回滚
+          已回滚
+        </div>
+        <div
+          class="custom-segmented-filter-item"
+        >
+          未执行
         </div>
       </div>
       <div
@@ -3834,7 +3854,7 @@ exports[`test AuditExecResultPanel updates layout to waterfall and retrieves tas
                     class="ant-list-item ant-list-item-no-flex"
                   >
                     <div
-                      class="css-1gxdwqg"
+                      class="css-1nbx0m0"
                     >
                       <div
                         class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/index.tsx
@@ -242,6 +242,8 @@ const AuditExecResultPanel: React.FC<AuditExecResultPanelProps> = ({
           instanceName={currentTask?.instance_name}
           schema={currentTask?.instance_schema}
           enableRetryExecute={enableRetryExecute}
+          execFailSqlNumber={currentTask?.exec_fail_sql_number}
+          execFailSqlId={currentTask?.exec_fail_sql_id}
         />
       </EmptyBox>
       <RetryExecuteModal />

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/SqlRollback/index.data.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/SqlRollback/index.data.ts
@@ -60,6 +60,12 @@ export const SqlExecStatusOptions: Array<{
       execStatusDictionary[getAuditTaskSQLsV2FilterExecStatusEnum.terminating]
     ),
     value: getAuditTaskSQLsV2FilterExecStatusEnum.terminating
+  },
+  {
+    label: t(
+      execStatusDictionary[getAuditTaskSQLsV2FilterExecStatusEnum.not_executed]
+    ),
+    value: getAuditTaskSQLsV2FilterExecStatusEnum.not_executed
   }
 ];
 

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/index.tsx
@@ -18,11 +18,21 @@ import RejectReason from './components/RejectReason';
 import useModifySql from './hooks/useModifySql';
 import WorkflowRecordInfo from './components/RecordInfo';
 import ModifySqlStatement from './components/ModifySqlStatement';
-import useAuditExecResultPanelSetup from './hooks/useAuditExecResultPanelSetup';
+import useAuditExecResultPanelSetup, {
+  WORKFLOW_OVERVIEW_TAB_KEY
+} from './hooks/useAuditExecResultPanelSetup';
 import AuditExecResultPanel from './components/AuditExecResultPanel';
 import SqlRollback from './components/SqlRollback';
+import { useTranslation } from 'react-i18next';
+import {
+  failStagePhraseI18nKey,
+  ONLINE_FAIL_STAGE,
+  pickTaskForFailSummary,
+  resolveHeaderFailSummary
+} from './utils/failDisplay';
 
 const SqlWorkflowDetail: React.FC = () => {
+  const { t } = useTranslation();
   const { username } = useCurrentUser();
   const [
     workflowStepsVisibility,
@@ -77,6 +87,41 @@ const SqlWorkflowDetail: React.FC = () => {
       (v) => v.state === WorkflowStepResV2StateEnum.rejected
     );
   }, [workflowInfo?.record?.workflow_step_list]);
+
+  const failSummary = useMemo(() => {
+    const task = pickTaskForFailSummary(
+      taskInfos,
+      activeTabKey,
+      WORKFLOW_OVERVIEW_TAB_KEY
+    );
+    const plan = resolveHeaderFailSummary({
+      workflowStatus: workflowInfo?.record?.status,
+      taskStatus: task?.status,
+      execFailStage: task?.exec_fail_stage,
+      execFailSqlCount: task?.exec_fail_sql_count,
+      execFailSummary: task?.exec_fail_summary
+    });
+    if (!plan) {
+      return null;
+    }
+    if (plan.mode === 'backend_summary') {
+      return `${t('execWorkflow.detail.failDisplay.headerPrefix')}${
+        plan.summary
+      }`;
+    }
+    const phraseKey =
+      failStagePhraseI18nKey[plan.stage] ??
+      failStagePhraseI18nKey[ONLINE_FAIL_STAGE.unknown];
+    const phrase = t(phraseKey);
+    if (plan.mode === 'count') {
+      return t('execWorkflow.detail.failDisplay.headerWithCount', {
+        count: plan.count,
+        phrase
+      });
+    }
+    return `${t('execWorkflow.detail.failDisplay.headerPrefix')}${phrase}`;
+  }, [activeTabKey, t, taskInfos, workflowInfo?.record?.status]);
+
   return (
     <Spin spinning={initLoading} delay={400}>
       {messageContextHolder}
@@ -116,6 +161,7 @@ const SqlWorkflowDetail: React.FC = () => {
             className="clearPaddingTop"
             gap={24}
             sqlVersion={workflowInfo?.sql_version}
+            failSummary={failSummary}
           />
 
           <EmptyBox

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/index.tsx
@@ -99,6 +99,7 @@ const SqlWorkflowDetail: React.FC = () => {
       taskStatus: task?.status,
       execFailStage: task?.exec_fail_stage,
       execFailSqlCount: task?.exec_fail_sql_count,
+      execFailSqlNumber: task?.exec_fail_sql_number,
       execFailSummary: task?.exec_fail_summary
     });
     if (!plan) {
@@ -108,6 +109,11 @@ const SqlWorkflowDetail: React.FC = () => {
       return `${t('execWorkflow.detail.failDisplay.headerPrefix')}${
         plan.summary
       }`;
+    }
+    if (plan.mode === 'sql_number') {
+      return t('execWorkflow.detail.failDisplay.headerWithSqlNumber', {
+        number: plan.sqlNumber
+      });
     }
     const phraseKey =
       failStagePhraseI18nKey[plan.stage] ??

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/utils/failDisplay.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/utils/failDisplay.ts
@@ -105,6 +105,7 @@ export const resolveFailStage = (
 
 export type HeaderFailSummaryPlan =
   | { mode: 'backend_summary'; summary: string }
+  | { mode: 'sql_number'; stage: string; sqlNumber: number }
   | { mode: 'count'; stage: string; count: number }
   | { mode: 'phrase'; stage: string }
   | null;
@@ -114,8 +115,11 @@ export type HeaderFailSummaryInput = {
   taskStatus?: string;
   execFailStage?: string;
   execFailSqlCount?: number;
+  execFailSqlNumber?: number;
   execFailSummary?: string;
 };
+
+const HEADER_SQL_NUMBER_RE = /第\s*\d+\s*条/;
 
 export const resolveHeaderFailSummary = (
   input: HeaderFailSummaryInput
@@ -126,11 +130,21 @@ export const resolveHeaderFailSummary = (
   if (input.taskStatus !== 'exec_failed') {
     return null;
   }
+  const stage = resolveFailStage(input.execFailStage);
+  const sqlNumber = input.execFailSqlNumber ?? 0;
   const summary = input.execFailSummary?.trim();
+
+  // AC-010：sql_execute + 有效序号 →「第 N 条」；若 backend 摘要已含序号则沿用
+  if (stage === ONLINE_FAIL_STAGE.sql_execute && sqlNumber >= 1) {
+    if (summary && HEADER_SQL_NUMBER_RE.test(summary)) {
+      return { mode: 'backend_summary', summary };
+    }
+    return { mode: 'sql_number', stage, sqlNumber };
+  }
+
   if (summary) {
     return { mode: 'backend_summary', summary };
   }
-  const stage = resolveFailStage(input.execFailStage);
   const count = input.execFailSqlCount ?? 0;
   if (count >= 1) {
     return { mode: 'count', stage, count };
@@ -138,13 +152,73 @@ export const resolveHeaderFailSummary = (
   return { mode: 'phrase', stage };
 };
 
+export type ExecFailLocateInput = {
+  execFailSqlNumber?: number;
+  execFailSqlId?: number;
+};
+
+export type ExecFailLocateSql = {
+  number?: number;
+  exec_sql_id?: number;
+  exec_status?: string;
+  fail_stage?: string;
+};
+
+/** §17.1 定位出错 SQL：number → id → 唯一 failed+sql_execute */
+export const locateExecFailSql = <T extends ExecFailLocateSql>(
+  sqls: T[],
+  input: ExecFailLocateInput
+): T | null => {
+  const sqlNumber = input.execFailSqlNumber ?? 0;
+  if (sqlNumber > 0) {
+    const hits = sqls.filter((s) => s.number === sqlNumber);
+    if (hits.length === 1) {
+      return hits[0];
+    }
+  }
+  const sqlId = input.execFailSqlId ?? 0;
+  if (sqlId > 0) {
+    const hits = sqls.filter((s) => s.exec_sql_id === sqlId);
+    if (hits.length === 1) {
+      return hits[0];
+    }
+  }
+  const candidates = sqls.filter(
+    (s) =>
+      s.exec_status === 'failed' &&
+      s.fail_stage === ONLINE_FAIL_STAGE.sql_execute
+  );
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+  return null;
+};
+
+export const isExecFailHighlightSql = (
+  sql: ExecFailLocateSql,
+  located: ExecFailLocateSql | null
+): boolean => {
+  if (!located) {
+    return false;
+  }
+  if (located.number != null && sql.number != null) {
+    return located.number === sql.number;
+  }
+  if (located.exec_sql_id != null && sql.exec_sql_id != null) {
+    return located.exec_sql_id === sql.exec_sql_id;
+  }
+  return false;
+};
+
 export type ExecResultDisplayModel = {
   statusI18nKey: string | null;
   /** 使用既有 execStatusDictionary 时传 status 枚举值 */
   statusFromExecDict?: string;
-  stageI18nKey: string;
+  stageI18nKey: string | null;
   reasonText: string;
   structured: boolean;
+  /** rollback 等不展示失败阶段行 */
+  hideStage?: boolean;
 };
 
 export type BuildExecResultDisplayInput = {
@@ -160,6 +234,7 @@ export const buildExecResultDisplay = (
 ): ExecResultDisplayModel => {
   const isFailed = input.execStatus === 'failed';
   const isNotExecuted = input.execStatus === 'not_executed';
+  const isExecuteRollback = input.execStatus === 'execute_rollback';
   const stage = resolveFailStage(input.failStage, input.backupStatus);
   // AC-008：仅双空（fail_reason + exec_result）才兜底；非空业务错误原样展示，禁止替换/截断
   const reasonRaw = firstNonBlank(input.failReason, input.execResult);
@@ -193,6 +268,17 @@ export const buildExecResultDisplay = (
     };
   }
 
+  // AC-010：execute_rollback → 已回滚；禁止套用 sql_execute 失败态/阶段
+  if (isExecuteRollback) {
+    return {
+      structured: true,
+      statusI18nKey: 'execWorkflow.detail.failDisplay.status.rolledBack',
+      stageI18nKey: null,
+      hideStage: true,
+      reasonText: reasonRaw || '-'
+    };
+  }
+
   // 其它态：保持原「执行结果」纯文本；空则 '-'
   return {
     structured: false,
@@ -210,6 +296,8 @@ export const pickTaskForFailSummary = <
     status?: string;
     exec_fail_stage?: string;
     exec_fail_sql_count?: number;
+    exec_fail_sql_number?: number;
+    exec_fail_sql_id?: number;
     exec_fail_summary?: string;
     exec_fail_reason?: string;
   }

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/utils/failDisplay.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/utils/failDisplay.ts
@@ -1,0 +1,228 @@
+/**
+ * 工单详情失败阶段展示纯函数（fe:detail_fail_display）
+ * 字段语义对齐 backend §3/§5；不得另造枚举值。
+ */
+
+export const ONLINE_FAIL_STAGE = {
+  sql_backup: 'sql_backup',
+  sql_execute: 'sql_execute',
+  datasource_connect: 'datasource_connect',
+  pre_check: 'pre_check',
+  terminate: 'terminate',
+  unknown: 'unknown'
+} as const;
+
+export type OnlineFailStage =
+  (typeof ONLINE_FAIL_STAGE)[keyof typeof ONLINE_FAIL_STAGE];
+
+/** 空原因门禁常量（与 product / backend §5.5 / frontend §6.4 一致；AC-008） */
+export const ONLINE_FAIL_REASON_FALLBACK =
+  '上线失败，暂未获取到具体原因，请联系管理员查看服务日志';
+
+export const failStageI18nKey: Record<string, string> = {
+  [ONLINE_FAIL_STAGE.sql_backup]:
+    'execWorkflow.detail.failDisplay.stage.sqlBackup',
+  [ONLINE_FAIL_STAGE.sql_execute]:
+    'execWorkflow.detail.failDisplay.stage.sqlExecute',
+  [ONLINE_FAIL_STAGE.datasource_connect]:
+    'execWorkflow.detail.failDisplay.stage.datasourceConnect',
+  [ONLINE_FAIL_STAGE.pre_check]:
+    'execWorkflow.detail.failDisplay.stage.preCheck',
+  [ONLINE_FAIL_STAGE.terminate]:
+    'execWorkflow.detail.failDisplay.stage.terminate',
+  [ONLINE_FAIL_STAGE.unknown]: 'execWorkflow.detail.failDisplay.stage.unknown'
+};
+
+export const failStagePhraseI18nKey: Record<string, string> = {
+  [ONLINE_FAIL_STAGE.sql_backup]:
+    'execWorkflow.detail.failDisplay.phrase.sqlBackup',
+  [ONLINE_FAIL_STAGE.sql_execute]:
+    'execWorkflow.detail.failDisplay.phrase.sqlExecute',
+  [ONLINE_FAIL_STAGE.datasource_connect]:
+    'execWorkflow.detail.failDisplay.phrase.datasourceConnect',
+  [ONLINE_FAIL_STAGE.pre_check]:
+    'execWorkflow.detail.failDisplay.phrase.preCheck',
+  [ONLINE_FAIL_STAGE.terminate]:
+    'execWorkflow.detail.failDisplay.phrase.terminate',
+  [ONLINE_FAIL_STAGE.unknown]: 'execWorkflow.detail.failDisplay.phrase.unknown'
+};
+
+/** 产品态状态文案（failed + fail_stage → 备份失败 / 执行失败 / 连接失败） */
+export const failProductStatusI18nKey: Record<string, string> = {
+  [ONLINE_FAIL_STAGE.sql_backup]:
+    'execWorkflow.detail.failDisplay.status.backupFailed',
+  [ONLINE_FAIL_STAGE.sql_execute]:
+    'execWorkflow.detail.failDisplay.status.executeFailed',
+  [ONLINE_FAIL_STAGE.datasource_connect]:
+    'execWorkflow.detail.failDisplay.status.connectFailed',
+  [ONLINE_FAIL_STAGE.pre_check]:
+    'execWorkflow.detail.failDisplay.status.executeFailed',
+  [ONLINE_FAIL_STAGE.terminate]:
+    'execWorkflow.detail.failDisplay.status.executeFailed',
+  [ONLINE_FAIL_STAGE.unknown]:
+    'execWorkflow.detail.failDisplay.status.executeFailed'
+};
+
+/** 未执行原因前缀（展示用；不得改写后端业务失败原文） */
+export const NOT_EXECUTED_REASON_PREFIX = '未执行：';
+
+export const DEFAULT_NOT_EXECUTED_REASON = '前序 SQL 上线失败，本条 SQL 未执行';
+
+export const formatNotExecutedReason = (reasonRaw: string): string => {
+  const base = reasonRaw.trim() || DEFAULT_NOT_EXECUTED_REASON;
+  if (
+    base.startsWith(NOT_EXECUTED_REASON_PREFIX) ||
+    base.startsWith('未执行')
+  ) {
+    return base;
+  }
+  return `${NOT_EXECUTED_REASON_PREFIX}${base}`;
+};
+
+export const firstNonBlank = (
+  ...values: Array<string | undefined | null>
+): string => {
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim() !== '') {
+      return v;
+    }
+  }
+  return '';
+};
+
+export const resolveFailStage = (
+  failStage?: string | null,
+  backupStatus?: string | null
+): string => {
+  if (failStage && failStage.trim() !== '') {
+    return failStage;
+  }
+  if (backupStatus === 'failed') {
+    return ONLINE_FAIL_STAGE.sql_backup;
+  }
+  return ONLINE_FAIL_STAGE.unknown;
+};
+
+export type HeaderFailSummaryPlan =
+  | { mode: 'backend_summary'; summary: string }
+  | { mode: 'count'; stage: string; count: number }
+  | { mode: 'phrase'; stage: string }
+  | null;
+
+export type HeaderFailSummaryInput = {
+  workflowStatus?: string;
+  taskStatus?: string;
+  execFailStage?: string;
+  execFailSqlCount?: number;
+  execFailSummary?: string;
+};
+
+export const resolveHeaderFailSummary = (
+  input: HeaderFailSummaryInput
+): HeaderFailSummaryPlan => {
+  if (input.workflowStatus !== 'exec_failed') {
+    return null;
+  }
+  if (input.taskStatus !== 'exec_failed') {
+    return null;
+  }
+  const summary = input.execFailSummary?.trim();
+  if (summary) {
+    return { mode: 'backend_summary', summary };
+  }
+  const stage = resolveFailStage(input.execFailStage);
+  const count = input.execFailSqlCount ?? 0;
+  if (count >= 1) {
+    return { mode: 'count', stage, count };
+  }
+  return { mode: 'phrase', stage };
+};
+
+export type ExecResultDisplayModel = {
+  statusI18nKey: string | null;
+  /** 使用既有 execStatusDictionary 时传 status 枚举值 */
+  statusFromExecDict?: string;
+  stageI18nKey: string;
+  reasonText: string;
+  structured: boolean;
+};
+
+export type BuildExecResultDisplayInput = {
+  execStatus?: string;
+  failStage?: string;
+  failReason?: string;
+  execResult?: string;
+  backupStatus?: string;
+};
+
+export const buildExecResultDisplay = (
+  input: BuildExecResultDisplayInput
+): ExecResultDisplayModel => {
+  const isFailed = input.execStatus === 'failed';
+  const isNotExecuted = input.execStatus === 'not_executed';
+  const stage = resolveFailStage(input.failStage, input.backupStatus);
+  // AC-008：仅双空（fail_reason + exec_result）才兜底；非空业务错误原样展示，禁止替换/截断
+  const reasonRaw = firstNonBlank(input.failReason, input.execResult);
+  const reasonText = isFailed
+    ? firstNonBlank(
+        input.failReason,
+        input.execResult,
+        ONLINE_FAIL_REASON_FALLBACK
+      )
+    : reasonRaw;
+
+  if (isFailed) {
+    return {
+      structured: true,
+      statusI18nKey:
+        failProductStatusI18nKey[stage] ??
+        failProductStatusI18nKey[ONLINE_FAIL_STAGE.unknown],
+      stageI18nKey:
+        failStageI18nKey[stage] ?? failStageI18nKey[ONLINE_FAIL_STAGE.unknown],
+      reasonText
+    };
+  }
+
+  if (isNotExecuted) {
+    return {
+      structured: true,
+      statusI18nKey: 'execWorkflow.detail.failDisplay.status.notExecuted',
+      stageI18nKey:
+        failStageI18nKey[stage] ?? failStageI18nKey[ONLINE_FAIL_STAGE.unknown],
+      reasonText: formatNotExecutedReason(reasonRaw)
+    };
+  }
+
+  // 其它态：保持原「执行结果」纯文本；空则 '-'
+  return {
+    structured: false,
+    statusI18nKey: null,
+    statusFromExecDict: input.execStatus,
+    stageI18nKey:
+      failStageI18nKey[stage] ?? failStageI18nKey[ONLINE_FAIL_STAGE.unknown],
+    reasonText: reasonRaw || '-'
+  };
+};
+
+export const pickTaskForFailSummary = <
+  T extends {
+    task_id?: number;
+    status?: string;
+    exec_fail_stage?: string;
+    exec_fail_sql_count?: number;
+    exec_fail_summary?: string;
+    exec_fail_reason?: string;
+  }
+>(
+  taskInfos: T[],
+  activeTabKey?: string,
+  overviewTabKey = 'WORKFLOW_OVERVIEW_TAB_KEY'
+): T | undefined => {
+  if (activeTabKey && activeTabKey !== overviewTabKey) {
+    return taskInfos.find((v) => v.task_id?.toString() === activeTabKey);
+  }
+  return (
+    taskInfos.find((v) => v.status === 'exec_failed' && !!v.exec_fail_stage) ??
+    taskInfos.find((v) => v.status === 'exec_failed')
+  );
+};


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/sqle-ee/issues/3037

## 描述你的变更

- Workflow detail header shows fail-stage summary from exec_fail_*
- SqlMode exec result shows status/stage/reason with not_executed and empty-result fallbacks
- OpenAPI types and locale strings for fail_stage / not_executed

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
