### PR TITLE
fix: include scan-source extra columns in SQL manage export keys

### DIFF
--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/exportColumnKeys.ts
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/exportColumnKeys.ts
@@ -57,23 +57,35 @@ const readLocalColumnSettings = (
   }
 };
 
+const isExportableColumnKey = (
+  columnKey: string,
+  extraKeySet: Set<string> | undefined
+) => {
+  return (
+    exportColumnKeySet.has(columnKey as SqlManagementExportColumnKey) ||
+    !!extraKeySet?.has(columnKey)
+  );
+};
+
 export const getSqlManagementExportColumnKeys = (
   columns: ActiontechTableColumn<ISqlManage, SqlManagementTableFilterParamType>,
   username: string,
+  extraKeys?: readonly string[],
   tableName = SQL_MANAGEMENT_TABLE_NAME
-): SqlManagementExportColumnKey[] => {
+): string[] => {
   const localColumnSettings = readLocalColumnSettings(tableName, username);
+  const extraKeySet = extraKeys?.length ? new Set(extraKeys) : undefined;
 
   return columns
     .map((column, index) => {
       const columnKey = getColumnDataIndex(column.dataIndex);
-      if (!columnKey || !exportColumnKeySet.has(columnKey)) {
+      if (!columnKey || !isExportableColumnKey(columnKey, extraKeySet)) {
         return undefined;
       }
 
       const localSetting = localColumnSettings[columnKey];
       return {
-        key: columnKey as SqlManagementExportColumnKey,
+        key: columnKey,
         show: localSetting?.show ?? column.show ?? true,
         order: localSetting?.order ?? index + 1,
         defaultOrder: index + 1

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/hooks/useSqlManageSourceExtra.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/hooks/useSqlManageSourceExtra.tsx
@@ -218,6 +218,7 @@ const useSqlManageSourceExtra = ({
 
   return {
     columns,
+    sourceExtraHeadList,
     filterButtonMeta,
     filterContainerMeta,
     filterCustomProps,

--- a/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
+++ b/packages/sqle/src/page/SqlManagement/component/SQLEEIndex/index.tsx
@@ -174,6 +174,7 @@ const SQLEEIndex = () => {
 
   const {
     columns,
+    sourceExtraHeadList,
     filterButtonMeta,
     filterContainerMeta,
     filterCustomProps,
@@ -374,9 +375,15 @@ const SQLEEIndex = () => {
     { setFalse: finishExport, setTrue: startExport }
   ] = useBoolean(false);
   const handleExport = () => {
+    const extraKeys = sourceExtraHeadList.length
+      ? sourceExtraHeadList
+          .map((head) => head.name)
+          .filter((name): name is string => !!name)
+      : undefined;
     const exportColumnKeys = getSqlManagementExportColumnKeys(
       columns,
-      username
+      username,
+      extraKeys
     );
 
     if (!exportColumnKeys.length) {


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/sqle-ee/issues/3039

## 描述你的变更

- `getSqlManagementExportColumnKeys` 支持传入当前扫描来源的 `source_extra` head names
- 导出时将可见的额外列（如平均检查行数）一并写入 `export_column_keys`，与表格勾选一致

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

Made with [Cursor](https://cursor.com)