### PR TITLE
fix: gate Global Dashboard v2 behind EE for community edition

### DIFF
--- a/packages/base/src/page/Home/__tests__/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/base/src/page/Home/__tests__/__snapshots__/index.ce.test.tsx.snap
@@ -15,36 +15,6 @@ exports[`test base/page/Home should match snapshot 1`] = `
         class="extra"
       />
     </div>
-    <div
-      class="css-rl9ym1"
-    >
-      <div
-        class="ant-card ant-card-loading ant-card-bordered workflow-cards-card"
-      >
-        <div
-          class="ant-card-body"
-        >
-          <div
-            class="ant-skeleton ant-skeleton-active"
-          >
-            <div
-              class="ant-skeleton-content"
-            >
-              <ul
-                class="ant-skeleton-paragraph"
-              >
-                <li />
-                <li />
-                <li />
-                <li
-                  style="width: 61%;"
-                />
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
     <section
       class="css-1wil037"
     >

--- a/packages/base/src/page/Home/__tests__/index.ce.test.tsx
+++ b/packages/base/src/page/Home/__tests__/index.ce.test.tsx
@@ -5,8 +5,7 @@
 import { cleanup, screen } from '@testing-library/react';
 import {
   mockUseCurrentUser,
-  mockUsePermission,
-  sqleMockApi
+  mockUsePermission
 } from '@actiontech/shared/lib/testUtil';
 import Home from '..';
 import { baseSuperRender } from '../../../testUtils/superRender';
@@ -18,7 +17,6 @@ describe('test base/page/Home', () => {
       { checkActionPermission: jest.fn().mockReturnValue(true) },
       { useSpyOnMockHooks: true }
     );
-    sqleMockApi.globalDashboard.getGlobalWorkflowStatistics();
   });
 
   afterEach(() => {

--- a/packages/base/src/page/Home/index.tsx
+++ b/packages/base/src/page/Home/index.tsx
@@ -3,7 +3,9 @@ import { PageHeader } from '@actiontech/dms-kit';
 import { useTranslation } from 'react-i18next';
 import CEDefaultScene from './DefaultScene/index.ce';
 import AIBanner from './AIBanner';
+// #if [ee]
 import WorkflowStatCards from './WorkflowStatCards';
+// #endif
 
 const Home: React.FC = () => {
   const { t } = useTranslation();
@@ -11,8 +13,8 @@ const Home: React.FC = () => {
   return (
     <>
       <PageHeader title={t('dmsHome.pageTitle')} />
-      <WorkflowStatCards />
       {/* #if [ee] */}
+      <WorkflowStatCards />
       <AIBanner />
       <DefaultScene />
       {/* #elif [ce] */}

--- a/packages/base/src/page/Nav/SideMenu/QuickActions/index.tsx
+++ b/packages/base/src/page/Nav/SideMenu/QuickActions/index.tsx
@@ -1,5 +1,7 @@
 import {
+  // #if [ee]
   TodoListOutlined,
+  // #endif
   SignalFilled,
   ProfileSquareFilled,
   RingOutlined,
@@ -16,7 +18,9 @@ import system from '@actiontech/shared/lib/api/sqle/service/system';
 import { useRequest } from 'ahooks';
 import { ResponseCode } from '@actiontech/dms-kit';
 import { Space } from 'antd';
+// #if [ee]
 import { ModuleRedDotModuleNameEnum } from '@actiontech/shared/lib/api/sqle/service/common.enum';
+// #endif
 import {
   PERMISSIONS,
   PermissionsConstantType,
@@ -62,6 +66,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({
   );
   const actionItems: Array<QuickActionItemType> = useMemo(() => {
     const actionList: Array<QuickActionItemType> = [
+      // #if [ee]
       {
         key: 'global-dashboard',
         title: t('dmsMenu.quickActions.globalDashboard'),
@@ -73,6 +78,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({
             i.has_red_dot
         )
       },
+      // #endif
       {
         key: 'report-statistics',
         title: t('dmsMenu.globalSettings.reportStatistics'),

--- a/packages/base/src/page/Nav/SideMenu/__tests__/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/base/src/page/Nav/SideMenu/__tests__/__snapshots__/index.ce.test.tsx.snap
@@ -64,40 +64,6 @@ exports[`test base/Nav/SideMenu/index.ce should match snapshot 1`] = `
             >
               <div
                 class="ant-space-item"
-                style="margin-right: 8px;"
-              >
-                <div
-                  class="ant-space ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                >
-                  <div
-                    class="ant-space-item"
-                  >
-                    <div
-                      class="action-item global-dashboard"
-                    >
-                      <svg
-                        class="TodoListOutlined_svg__icon"
-                        color="currentColor"
-                        height="18"
-                        viewBox="0 0 1024 1024"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M924 540c-19.9 0-36 16.1-36 36v312H136V136h568c19.9 0 36-16.1 36-36s-16.1-36-36-36H136c-39.8 0-72 32.2-72 72v752c0 39.8 32.2 72 72 72h752c39.8 0 72-32.2 72-72V576c0-19.9-16.1-36-36-36"
-                          fill="currentColor"
-                        />
-                        <path
-                          d="M316.5 478.5c-14.1-14.1-36.9-14.1-50.9 0-14.1 14.1-14.1 36.9 0 50.9l178.2 178.2c5.7 5.7 12.8 9.1 20.1 10.2 11.2 1.9 23.1-1.4 31.7-10l454.2-454.2c14.1-14.1 14.1-36.9 0-50.9-14.1-14.1-36.9-14.1-50.9 0l-429.2 429z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="ant-space-item"
               >
                 <div
                   class="ant-space ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
@@ -1026,63 +992,6 @@ exports[`test base/Nav/SideMenu/index.ce should match snapshot 2`] = `
             <div
               class="ant-space ant-space-horizontal ant-space-align-center action-space-wrapper"
             >
-              <div
-                class="ant-space-item"
-                style="margin-right: 8px;"
-              >
-                <div
-                  class="ant-space ant-space-horizontal ant-space-align-center basic-tooltips-wrapper css-4jbtl9"
-                >
-                  <div
-                    class="ant-space-item"
-                  >
-                    <div
-                      class="action-item global-dashboard"
-                    >
-                      <svg
-                        class="TodoListOutlined_svg__icon"
-                        color="currentColor"
-                        height="18"
-                        viewBox="0 0 1024 1024"
-                        width="18"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M924 540c-19.9 0-36 16.1-36 36v312H136V136h568c19.9 0 36-16.1 36-36s-16.1-36-36-36H136c-39.8 0-72 32.2-72 72v752c0 39.8 32.2 72 72 72h752c39.8 0 72-32.2 72-72V576c0-19.9-16.1-36-36-36"
-                          fill="currentColor"
-                        />
-                        <path
-                          d="M316.5 478.5c-14.1-14.1-36.9-14.1-50.9 0-14.1 14.1-14.1 36.9 0 50.9l178.2 178.2c5.7 5.7 12.8 9.1 20.1 10.2 11.2 1.9 23.1-1.4 31.7-10l454.2-454.2c14.1-14.1 14.1-36.9 0-50.9-14.1-14.1-36.9-14.1-50.9 0l-429.2 429z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        class="action-item-dot"
-                        fill="none"
-                        height="16"
-                        viewBox="0 0 14 12"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <circle
-                          cx="6"
-                          cy="6"
-                          fill="#F66074"
-                          r="2.5"
-                        />
-                        <circle
-                          cx="6"
-                          cy="6"
-                          r="4"
-                          stroke="#F66074"
-                          stroke-opacity="0.2"
-                          stroke-width="3"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              </div>
               <div
                 class="ant-space-item"
               >

--- a/packages/base/src/router/test/__snapshots__/router.ce.base.test.tsx.snap
+++ b/packages/base/src/router/test/__snapshots__/router.ce.base.test.tsx.snap
@@ -202,13 +202,6 @@ exports[`base/router-base-ce render base route data snap 1`] = `
   },
   {
     "element": <div>
-      globalDashboard
-    </div>,
-    "key": "globalDashboard",
-    "path": "/sqle/global-dashboard",
-  },
-  {
-    "element": <div>
       globalOperationRecord
     </div>,
     "key": "globalOperationRecord",

--- a/packages/sqle/src/router/config.tsx
+++ b/packages/sqle/src/router/config.tsx
@@ -214,7 +214,9 @@ const PipelineConfigurationUpdate = React.lazy(
 
 const VersionManagement = React.lazy(() => import('../page/VersionManagement'));
 
+// #if [ee]
 const GlobalDashboard = React.lazy(() => import('../page/GlobalDashboard'));
+// #endif
 const SqlInsights = React.lazy(() => import('../page/SqlInsights'));
 
 export const projectDetailRouterConfig: RouterConfigItem[] = [
@@ -583,12 +585,12 @@ export const globalRouterConfig: RouterConfigItem[] = [
     key: 'ruleKnowledge',
     element: <RuleKnowledge />
   },
-  // #endif
   {
     path: ROUTE_PATHS.SQLE.GLOBAL_DASHBOARD.index.path,
     key: 'globalDashboard',
     element: <GlobalDashboard />
   },
+  // #endif
   {
     path: ROUTE_PATHS.SQLE.GLOBAL_OPERATION_LOG.index,
     key: 'globalOperationRecord',


### PR DESCRIPTION
## Summary
- Align CE frontend with backend enterprise-only Global Dashboard v2 APIs (`/v2/dashboard/workflows*`, sql_manage, accounts)
- Hide Global Dashboard route, QuickActions entry, and Home workflow stat cards under `#if [ee]` so CE no longer calls unsupported APIs
- Update CE snapshots accordingly

## Test plan
- [ ] CE build: Global Dashboard route/menu/quick action unavailable; Home has no workflow stat cards; no `/sqle/v2/dashboard/workflows*` requests
- [ ] EE build: Global Dashboard page, QuickActions entry, and Home workflow cards still work as before
- [ ] CE unit tests for Home and SideMenu pass with updated snapshots