### PR TITLE
feat: approval comment UI for SQL and data export workflows

### DIFF
--- a/packages/base/src/locale/en-US/dmsDataExport.ts
+++ b/packages/base/src/locale/en-US/dmsDataExport.ts
@@ -5,6 +5,8 @@ export default {
     'When you do not have permission to view a certain DB instance, but need to export data from it, you can use the data export function. by going through the approval process, you can get the corresponding data. this way, even without direct viewing permission, you can still get the data you need.',
   status: {
     wait_for_audit: 'Pending audit',
+    wait_for_masking_approve: 'Pending masking approval',
+    partial_failed: 'Partial export failed',
     wait_for_export: 'Pending export',
     finished: 'Export success',
     exporting: 'Exporting',
@@ -56,6 +58,27 @@ export default {
       submitAction: 'Submit task',
       submitTips: 'Only supports creating export tasks for dql statements'
     },
+    submit: {
+      buttonText: 'Submit task',
+      onlySupportDDLSqls:
+        'Only supports creating export tasks for DQL statements',
+      hasExceptionRule:
+        'There are unchecked audit exception rules. Please fix and re-audit first',
+      continueSubmission: 'Create anyway',
+      plaintextWarning:
+        'Sensitive fields detected. You can choose "Export plaintext data" per SQL.',
+      plaintextReasonPlaceholder:
+        'Please explain the business reason for exporting plaintext data',
+      plaintextReasonRequired:
+        'Please select plaintext SQL statements and fill in the apply reason',
+      plaintextApplyCreateFailed:
+        'Export workflow created, but plaintext apply creation failed. Please verify in approvals later.',
+      plaintextApplyCreateFailedWithDetail:
+        'Export workflow created, but plaintext apply creation failed ({{count}} datasource(s) failed).',
+      plaintextApplyCompensateGuide:
+        'You can open the created workflow first, then complete or re-initiate plaintext approvals from approvals.',
+      plaintextApplyCompensateAction: 'View created workflow'
+    },
     result: {
       success: 'Task created successfully',
       guide: 'View the newly created task'
@@ -89,6 +112,7 @@ export default {
       status: 'Status',
       assignee: 'Assignee',
       workflowTemplate: 'Approval template',
+      plaintextExport: 'Plaintext export',
       viewOrderDetail: 'View task detail'
     },
     actions: {
@@ -98,13 +122,49 @@ export default {
   },
   detail: {
     reject: {
-      reason: '{{name}} rejected the current task, the reason is:',
+      reason: '{{name}} rejected the current task, approval comment:',
       tips: 'When the task is rejected, the task creator needs to modify it and resubmit it for review. (currently, modifying the task is not supported.)'
     },
     exportResult: {
       title: 'Export result',
       overview: {
         title: 'Overview',
+        plaintextNotice: {
+          pending: {
+            message: 'Plaintext export pending approval',
+            description:
+              'A plaintext export request has been submitted. Plaintext data will be downloadable after approval.',
+            link: 'Go to approval page'
+          },
+          approved: {
+            message: 'Plaintext export approved',
+            description:
+              'Please complete the download before {{deadline}}. Time remaining: {{remain}}.'
+          },
+          downloaded: {
+            message: 'Plaintext data downloaded',
+            description:
+              'Current download credential expires at {{deadline}} ({{remain}} remaining). You can re-download within this window.'
+          },
+          rejected: {
+            message: 'Plaintext export request rejected',
+            description:
+              'Please review the rejection details on the approval page and resubmit if needed.',
+            link: 'View approval details'
+          },
+          postDownloadExpired: {
+            message: 'Plaintext data downloaded successfully',
+            description:
+              'The 30-minute re-download window has closed. Submit a new request to download again.'
+          },
+          expired: {
+            message: 'Plaintext export request expired',
+            description:
+              'The download window has expired. Submit a new plaintext export request to get the data.'
+          }
+        },
+        partialFailedNotice:
+          'This workflow is partially failed: successful tasks remain downloadable, failed tasks need retry after fixes.',
         column: {
           dbService: 'DB instance',
           status: 'Status',
@@ -115,8 +175,11 @@ export default {
           exportFileType: 'Export file type',
           action: {
             download: 'Download data',
+            downloadOriginal: 'Download plaintext data',
             downloadTips:
-              'Please download the dataset within 24 hours. if it expires, you will need to resubmit the task.'
+              'Please download the dataset within 24 hours. if it expires, you will need to resubmit the task.',
+            downloadOriginalFailed:
+              'Failed to download plaintext data. Please try again later.'
           }
         }
       },
@@ -135,7 +198,10 @@ export default {
         title: 'Basic info',
         createUser: 'Creator',
         createTime: 'Create time',
-        status: 'Status'
+        status: 'Status',
+        exportMode: 'Export type',
+        exportModePlaintext: 'Plaintext export',
+        exportModeMasked: 'Masked export'
       },
       steps: {
         title: 'Task progress',
@@ -163,7 +229,7 @@ export default {
           title: 'Reject',
           text: 'Reject'
         },
-        reason: 'Reject reason',
+        reason: 'Approval comment',
         text: 'Reject audit',
         tips: 'The current operation will reject all export tasks under the task. please operate with caution!',
         successTips: 'Task rejected successfully!'
@@ -179,7 +245,10 @@ export default {
       unknown: 'Unknown step',
       waitAudit: 'Waiting for auditor operation',
       alreadyRejected: 'Task has been rejected',
-      alreadyClosed: 'Task has been closed'
+      alreadyClosed: 'Task has been closed',
+      approvalComment: 'Approval comment',
+      notFilled: 'Not filled',
+      confirmApprove: 'Confirm approval'
     }
   },
   common: {
@@ -189,7 +258,15 @@ export default {
         execSql: 'Execute statement',
         sqlType: 'Statement type',
         auditResult: 'Audit result',
-        createWhitelist: 'Add to audit whitelist'
+        createWhitelist: 'Add to audit whitelist',
+        exportPlaintext: 'Plaintext Export',
+        exportPlaintextAction: 'Export plaintext data (requires approval)',
+        snapshotInfo: 'Lineage/Masking Snapshot',
+        maskingSnapshotCount: '{{count}} masked field(s)',
+        lineageSnapshotCount: '{{count}} lineage source(s)',
+        snapshotDetail: 'View details',
+        maskingFields: 'Masked fields and rules',
+        lineagePathPreview: 'Lineage path preview'
       }
     }
   }

--- a/packages/base/src/locale/en-US/dmsDataExport.ts
+++ b/packages/base/src/locale/en-US/dmsDataExport.ts
@@ -5,8 +5,6 @@ export default {
     'When you do not have permission to view a certain DB instance, but need to export data from it, you can use the data export function. by going through the approval process, you can get the corresponding data. this way, even without direct viewing permission, you can still get the data you need.',
   status: {
     wait_for_audit: 'Pending audit',
-    wait_for_masking_approve: 'Pending masking approval',
-    partial_failed: 'Partial export failed',
     wait_for_export: 'Pending export',
     finished: 'Export success',
     exporting: 'Exporting',
@@ -58,27 +56,6 @@ export default {
       submitAction: 'Submit task',
       submitTips: 'Only supports creating export tasks for dql statements'
     },
-    submit: {
-      buttonText: 'Submit task',
-      onlySupportDDLSqls:
-        'Only supports creating export tasks for DQL statements',
-      hasExceptionRule:
-        'There are unchecked audit exception rules. Please fix and re-audit first',
-      continueSubmission: 'Create anyway',
-      plaintextWarning:
-        'Sensitive fields detected. You can choose "Export plaintext data" per SQL.',
-      plaintextReasonPlaceholder:
-        'Please explain the business reason for exporting plaintext data',
-      plaintextReasonRequired:
-        'Please select plaintext SQL statements and fill in the apply reason',
-      plaintextApplyCreateFailed:
-        'Export workflow created, but plaintext apply creation failed. Please verify in approvals later.',
-      plaintextApplyCreateFailedWithDetail:
-        'Export workflow created, but plaintext apply creation failed ({{count}} datasource(s) failed).',
-      plaintextApplyCompensateGuide:
-        'You can open the created workflow first, then complete or re-initiate plaintext approvals from approvals.',
-      plaintextApplyCompensateAction: 'View created workflow'
-    },
     result: {
       success: 'Task created successfully',
       guide: 'View the newly created task'
@@ -112,7 +89,6 @@ export default {
       status: 'Status',
       assignee: 'Assignee',
       workflowTemplate: 'Approval template',
-      plaintextExport: 'Plaintext export',
       viewOrderDetail: 'View task detail'
     },
     actions: {
@@ -129,42 +105,6 @@ export default {
       title: 'Export result',
       overview: {
         title: 'Overview',
-        plaintextNotice: {
-          pending: {
-            message: 'Plaintext export pending approval',
-            description:
-              'A plaintext export request has been submitted. Plaintext data will be downloadable after approval.',
-            link: 'Go to approval page'
-          },
-          approved: {
-            message: 'Plaintext export approved',
-            description:
-              'Please complete the download before {{deadline}}. Time remaining: {{remain}}.'
-          },
-          downloaded: {
-            message: 'Plaintext data downloaded',
-            description:
-              'Current download credential expires at {{deadline}} ({{remain}} remaining). You can re-download within this window.'
-          },
-          rejected: {
-            message: 'Plaintext export request rejected',
-            description:
-              'Please review the rejection details on the approval page and resubmit if needed.',
-            link: 'View approval details'
-          },
-          postDownloadExpired: {
-            message: 'Plaintext data downloaded successfully',
-            description:
-              'The 30-minute re-download window has closed. Submit a new request to download again.'
-          },
-          expired: {
-            message: 'Plaintext export request expired',
-            description:
-              'The download window has expired. Submit a new plaintext export request to get the data.'
-          }
-        },
-        partialFailedNotice:
-          'This workflow is partially failed: successful tasks remain downloadable, failed tasks need retry after fixes.',
         column: {
           dbService: 'DB instance',
           status: 'Status',
@@ -175,11 +115,8 @@ export default {
           exportFileType: 'Export file type',
           action: {
             download: 'Download data',
-            downloadOriginal: 'Download plaintext data',
             downloadTips:
-              'Please download the dataset within 24 hours. if it expires, you will need to resubmit the task.',
-            downloadOriginalFailed:
-              'Failed to download plaintext data. Please try again later.'
+              'Please download the dataset within 24 hours. if it expires, you will need to resubmit the task.'
           }
         }
       },
@@ -198,10 +135,7 @@ export default {
         title: 'Basic info',
         createUser: 'Creator',
         createTime: 'Create time',
-        status: 'Status',
-        exportMode: 'Export type',
-        exportModePlaintext: 'Plaintext export',
-        exportModeMasked: 'Masked export'
+        status: 'Status'
       },
       steps: {
         title: 'Task progress',
@@ -258,15 +192,7 @@ export default {
         execSql: 'Execute statement',
         sqlType: 'Statement type',
         auditResult: 'Audit result',
-        createWhitelist: 'Add to audit whitelist',
-        exportPlaintext: 'Plaintext Export',
-        exportPlaintextAction: 'Export plaintext data (requires approval)',
-        snapshotInfo: 'Lineage/Masking Snapshot',
-        maskingSnapshotCount: '{{count}} masked field(s)',
-        lineageSnapshotCount: '{{count}} lineage source(s)',
-        snapshotDetail: 'View details',
-        maskingFields: 'Masked fields and rules',
-        lineagePathPreview: 'Lineage path preview'
+        createWhitelist: 'Add to audit whitelist'
       }
     }
   }

--- a/packages/base/src/locale/zh-CN/dmsDataExport.ts
+++ b/packages/base/src/locale/zh-CN/dmsDataExport.ts
@@ -5,6 +5,8 @@ export default {
     '当您没有某个数据源的查看权限，但需要导出其中的数据时，可以利用数据导出功能。通过进行审批流程，您可以获取相应的数据。这样，即使没有直接的查看权限，您仍然可以获得所需的数据。',
   status: {
     wait_for_audit: '待审核',
+    wait_for_masking_approve: '待脱敏审批',
+    partial_failed: '部分导出失败',
     wait_for_export: '待导出',
     finished: '导出成功',
     exporting: '正在导出',
@@ -52,7 +54,17 @@ export default {
       buttonText: '提交工单',
       onlySupportDDLSqls: '仅支持对DQL语句创建导出工单',
       hasExceptionRule: '当前存在审核规则未被校验，请排除问题后重新触发审核',
-      continueSubmission: '仍要创建'
+      continueSubmission: '仍要创建',
+      plaintextWarning: '已命中脱敏字段，可按 SQL 粒度选择“导出原文数据”。',
+      plaintextReasonPlaceholder: '请说明需要导出原文数据的业务原因',
+      plaintextReasonRequired: '请选择需导出原文的 SQL 并填写申请理由',
+      plaintextApplyCreateFailed:
+        '导出工单已创建，但原文申请创建失败，请稍后在审批中心确认状态',
+      plaintextApplyCreateFailedWithDetail:
+        '导出工单已创建，但原文申请创建失败（失败数据源 {{count}} 个）',
+      plaintextApplyCompensateGuide:
+        '可先进入已创建工单查看审批状态，并在审批中心补齐或重新发起原文申请。',
+      plaintextApplyCompensateAction: '查看已创建工单'
     },
     approvalProcess: {
       title: '审批流程',
@@ -100,6 +112,7 @@ export default {
       status: '状态',
       assignee: '待操作人',
       workflowTemplate: '审批模板',
+      plaintextExport: '原文导出',
       viewOrderDetail: '查看工单详情'
     },
     actions: {
@@ -109,13 +122,48 @@ export default {
   },
   detail: {
     reject: {
-      reason: '{{name}}驳回了当前工单，驳回原因为：',
+      reason: '{{name}}驳回了当前工单，审批意见为：',
       tips: '当工单被驳回时，工单创建者需要对其进行修改，然后重新提交审核。（目前暂不支持修改工单。）'
     },
     exportResult: {
       title: '导出结果',
       overview: {
         title: '概览',
+        plaintextNotice: {
+          pending: {
+            message: '原文导出申请审批中',
+            description:
+              '当前工单已提交原文导出申请，审批通过后方可下载原文数据。',
+            link: '前往审批页面'
+          },
+          approved: {
+            message: '原文导出申请已通过',
+            description:
+              '请在 {{deadline}} 前完成原文数据下载，剩余时间：{{remain}}。'
+          },
+          downloaded: {
+            message: '原文数据已下载',
+            description:
+              '当前下载凭证将于 {{deadline}} 失效（剩余 {{remain}}），窗口期内可重复下载。'
+          },
+          rejected: {
+            message: '原文导出申请已被驳回',
+            description: '请前往审批页面查看驳回详情，了解原因后重新提交申请。',
+            link: '查看审批详情'
+          },
+          postDownloadExpired: {
+            message: '原文数据已成功下载',
+            description:
+              '30 分钟重复下载窗口已关闭，如需再次下载请重新提交原文导出申请。'
+          },
+          expired: {
+            message: '原文数据下载申请已失效',
+            description:
+              '原文下载时限已过期，如需获取原文数据请重新提交原文导出申请。'
+          }
+        },
+        partialFailedNotice:
+          '当前工单存在“部分导出失败”：已成功任务可继续下载，失败任务请修复后重试。',
         column: {
           dbService: '数据源',
           status: '状态',
@@ -126,7 +174,10 @@ export default {
           exportFileType: '导出文件类型',
           action: {
             download: '下载数据',
-            downloadTips: '请在24小时内下载数据集，如超期，则需要重新提交工单。'
+            downloadOriginal: '下载原文数据',
+            downloadTips:
+              '请在24小时内下载数据集，如超期，则需要重新提交工单。',
+            downloadOriginalFailed: '下载原文数据失败，请稍后重试'
           }
         }
       },
@@ -145,7 +196,10 @@ export default {
         title: '基本信息',
         createUser: '创建人',
         createTime: '创建时间',
-        status: '状态'
+        status: '状态',
+        exportMode: '导出类型',
+        exportModePlaintext: '原文导出',
+        exportModeMasked: '脱敏导出'
       },
       steps: {
         title: '工单进度',
@@ -173,7 +227,7 @@ export default {
           title: '驳回',
           text: '驳回'
         },
-        reason: '驳回原因',
+        reason: '审批意见',
         text: '审核驳回',
         tips: '当前操作将驳回工单下所有导出任务，请谨慎操作！',
         successTips: '工单驳回成功！'
@@ -189,7 +243,10 @@ export default {
       unknown: '未知步骤',
       waitAudit: '等待审核人操作',
       alreadyRejected: '工单已被驳回',
-      alreadyClosed: '工单已被关闭'
+      alreadyClosed: '工单已被关闭',
+      approvalComment: '审批意见',
+      notFilled: '未填写',
+      confirmApprove: '确认通过'
     }
   },
   common: {
@@ -199,7 +256,15 @@ export default {
         execSql: '执行语句',
         sqlType: '语句类型',
         auditResult: '审核结果',
-        createWhitelist: '添加为审核SQL例外'
+        createWhitelist: '添加为审核SQL例外',
+        exportPlaintext: '导出原文',
+        exportPlaintextAction: '导出原文数据（需审批）',
+        snapshotInfo: '血缘/脱敏快照',
+        maskingSnapshotCount: '脱敏字段 {{count}} 个',
+        lineageSnapshotCount: '血缘来源 {{count}} 条',
+        snapshotDetail: '查看详情',
+        maskingFields: '脱敏字段与规则',
+        lineagePathPreview: '血缘路径预览'
       }
     }
   }

--- a/packages/base/src/locale/zh-CN/dmsDataExport.ts
+++ b/packages/base/src/locale/zh-CN/dmsDataExport.ts
@@ -5,8 +5,6 @@ export default {
     '当您没有某个数据源的查看权限，但需要导出其中的数据时，可以利用数据导出功能。通过进行审批流程，您可以获取相应的数据。这样，即使没有直接的查看权限，您仍然可以获得所需的数据。',
   status: {
     wait_for_audit: '待审核',
-    wait_for_masking_approve: '待脱敏审批',
-    partial_failed: '部分导出失败',
     wait_for_export: '待导出',
     finished: '导出成功',
     exporting: '正在导出',
@@ -54,17 +52,7 @@ export default {
       buttonText: '提交工单',
       onlySupportDDLSqls: '仅支持对DQL语句创建导出工单',
       hasExceptionRule: '当前存在审核规则未被校验，请排除问题后重新触发审核',
-      continueSubmission: '仍要创建',
-      plaintextWarning: '已命中脱敏字段，可按 SQL 粒度选择“导出原文数据”。',
-      plaintextReasonPlaceholder: '请说明需要导出原文数据的业务原因',
-      plaintextReasonRequired: '请选择需导出原文的 SQL 并填写申请理由',
-      plaintextApplyCreateFailed:
-        '导出工单已创建，但原文申请创建失败，请稍后在审批中心确认状态',
-      plaintextApplyCreateFailedWithDetail:
-        '导出工单已创建，但原文申请创建失败（失败数据源 {{count}} 个）',
-      plaintextApplyCompensateGuide:
-        '可先进入已创建工单查看审批状态，并在审批中心补齐或重新发起原文申请。',
-      plaintextApplyCompensateAction: '查看已创建工单'
+      continueSubmission: '仍要创建'
     },
     approvalProcess: {
       title: '审批流程',
@@ -112,7 +100,6 @@ export default {
       status: '状态',
       assignee: '待操作人',
       workflowTemplate: '审批模板',
-      plaintextExport: '原文导出',
       viewOrderDetail: '查看工单详情'
     },
     actions: {
@@ -129,41 +116,6 @@ export default {
       title: '导出结果',
       overview: {
         title: '概览',
-        plaintextNotice: {
-          pending: {
-            message: '原文导出申请审批中',
-            description:
-              '当前工单已提交原文导出申请，审批通过后方可下载原文数据。',
-            link: '前往审批页面'
-          },
-          approved: {
-            message: '原文导出申请已通过',
-            description:
-              '请在 {{deadline}} 前完成原文数据下载，剩余时间：{{remain}}。'
-          },
-          downloaded: {
-            message: '原文数据已下载',
-            description:
-              '当前下载凭证将于 {{deadline}} 失效（剩余 {{remain}}），窗口期内可重复下载。'
-          },
-          rejected: {
-            message: '原文导出申请已被驳回',
-            description: '请前往审批页面查看驳回详情，了解原因后重新提交申请。',
-            link: '查看审批详情'
-          },
-          postDownloadExpired: {
-            message: '原文数据已成功下载',
-            description:
-              '30 分钟重复下载窗口已关闭，如需再次下载请重新提交原文导出申请。'
-          },
-          expired: {
-            message: '原文数据下载申请已失效',
-            description:
-              '原文下载时限已过期，如需获取原文数据请重新提交原文导出申请。'
-          }
-        },
-        partialFailedNotice:
-          '当前工单存在“部分导出失败”：已成功任务可继续下载，失败任务请修复后重试。',
         column: {
           dbService: '数据源',
           status: '状态',
@@ -174,10 +126,7 @@ export default {
           exportFileType: '导出文件类型',
           action: {
             download: '下载数据',
-            downloadOriginal: '下载原文数据',
-            downloadTips:
-              '请在24小时内下载数据集，如超期，则需要重新提交工单。',
-            downloadOriginalFailed: '下载原文数据失败，请稍后重试'
+            downloadTips: '请在24小时内下载数据集，如超期，则需要重新提交工单。'
           }
         }
       },
@@ -196,10 +145,7 @@ export default {
         title: '基本信息',
         createUser: '创建人',
         createTime: '创建时间',
-        status: '状态',
-        exportMode: '导出类型',
-        exportModePlaintext: '原文导出',
-        exportModeMasked: '脱敏导出'
+        status: '状态'
       },
       steps: {
         title: '工单进度',
@@ -256,15 +202,7 @@ export default {
         execSql: '执行语句',
         sqlType: '语句类型',
         auditResult: '审核结果',
-        createWhitelist: '添加为审核SQL例外',
-        exportPlaintext: '导出原文',
-        exportPlaintextAction: '导出原文数据（需审批）',
-        snapshotInfo: '血缘/脱敏快照',
-        maskingSnapshotCount: '脱敏字段 {{count}} 个',
-        lineageSnapshotCount: '血缘来源 {{count}} 条',
-        snapshotDetail: '查看详情',
-        maskingFields: '脱敏字段与规则',
-        lineagePathPreview: '血缘路径预览'
+        createWhitelist: '添加为审核SQL例外'
       }
     }
   }

--- a/packages/base/src/page/DataExportManagement/Detail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/__tests__/__snapshots__/index.test.tsx.snap
@@ -848,6 +848,17 @@ exports[`test base/DataExport/Detail should match snapshot 1`] = `
                                 </span>
                               </div>
                             </div>
+                            <div
+                              class="step-info-approval-comment"
+                            >
+                              <span>
+                                审批意见
+                                ：
+                              </span>
+                              <span>
+                                未填写
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -3453,6 +3464,17 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                                 </span>
                               </div>
                             </div>
+                            <div
+                              class="step-info-approval-comment"
+                            >
+                              <span>
+                                审批意见
+                                ：
+                              </span>
+                              <span>
+                                未填写
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -6033,6 +6055,17 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                                   2024-01-30 11:32:12
                                 </span>
                               </div>
+                            </div>
+                            <div
+                              class="step-info-approval-comment"
+                            >
+                              <span>
+                                审批意见
+                                ：
+                              </span>
+                              <span>
+                                未填写
+                              </span>
                             </div>
                           </div>
                         </div>
@@ -8615,6 +8648,17 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                                 </span>
                               </div>
                             </div>
+                            <div
+                              class="step-info-approval-comment"
+                            >
+                              <span>
+                                审批意见
+                                ：
+                              </span>
+                              <span>
+                                未填写
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -8922,7 +8966,7 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                 <div
                   class="reject-workflow-reason-content-text"
                 >
-                  admin驳回了当前工单，驳回原因为：
+                  admin驳回了当前工单，审批意见为：
                   <span
                     class="reject-workflow-reason-content-text-reason"
                   />
@@ -11228,6 +11272,17 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                             >
                               <span>
                                 工单已被驳回
+                              </span>
+                            </div>
+                            <div
+                              class="step-info-approval-comment"
+                            >
+                              <span>
+                                审批意见
+                                ：
+                              </span>
+                              <span>
+                                未填写
                               </span>
                             </div>
                           </div>

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/ApproveWorkflowModal/index.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/ApproveWorkflowModal/index.tsx
@@ -1,0 +1,73 @@
+import { BasicButton, BasicInput, BasicModal } from '@actiontech/dms-kit';
+import { Form } from 'antd';
+import { useTranslation } from 'react-i18next';
+import {
+  ApproveWorkflowModalFormFields,
+  ApproveWorkflowModalProps
+} from './index.type';
+
+const APPROVAL_COMMENT_MAX_LENGTH = 255;
+
+const ApproveWorkflowModal: React.FC<ApproveWorkflowModalProps> = ({
+  open,
+  close,
+  loading,
+  approve
+}) => {
+  const [form] = Form.useForm<ApproveWorkflowModalFormFields>();
+  const { t } = useTranslation();
+  const resetAndCloseApproveModal = () => {
+    form.resetFields();
+    close();
+  };
+  return (
+    <BasicModal
+      title={t('dmsDataExport.detail.action.approve.text')}
+      open={open}
+      closable={false}
+      footer={
+        <>
+          <BasicButton onClick={resetAndCloseApproveModal} disabled={loading}>
+            {t('common.cancel')}
+          </BasicButton>
+          <BasicButton
+            type="primary"
+            loading={loading}
+            disabled={loading}
+            onClick={async () => {
+              const values = await form.validateFields();
+              await approve({
+                reason: values.reason?.trim()
+              });
+              resetAndCloseApproveModal();
+            }}
+          >
+            {t('dmsDataExport.detail.operator.confirmApprove')}
+          </BasicButton>
+        </>
+      }
+    >
+      <Form form={form} layout="vertical">
+        <Form.Item
+          label={t('dmsDataExport.detail.operator.approvalComment')}
+          name="reason"
+          rules={[
+            {
+              max: APPROVAL_COMMENT_MAX_LENGTH,
+              message: t('common.form.rule.maxLength', {
+                max: APPROVAL_COMMENT_MAX_LENGTH
+              })
+            }
+          ]}
+        >
+          <BasicInput.TextArea
+            placeholder={t('common.form.placeholder.input')}
+            rows={3}
+            maxLength={APPROVAL_COMMENT_MAX_LENGTH}
+          />
+        </Form.Item>
+      </Form>
+    </BasicModal>
+  );
+};
+export default ApproveWorkflowModal;

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/ApproveWorkflowModal/index.type.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/ApproveWorkflowModal/index.type.ts
@@ -1,0 +1,12 @@
+export type ApproveWorkflowModalProps = {
+  open: boolean;
+  approve: (
+    values: ApproveWorkflowModalFormFields
+  ) => Promise<void> | undefined;
+  loading: boolean;
+  close: () => void;
+};
+
+export type ApproveWorkflowModalFormFields = {
+  reason?: string;
+};

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/__tests__/index.test.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/__tests__/index.test.tsx
@@ -9,7 +9,7 @@ import {
   mockDataExportDetailRedux,
   mockUseDataExportDetailReduxManage
 } from '../../../testUtils/mockUseDataExportDetailReduxManage';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { mockUsePermission } from '@actiontech/shared/lib/testUtil/mockHook/mockUsePermission';
 
 describe('test base/DataExport/Detail/PageHeaderAction', () => {
@@ -48,9 +48,16 @@ describe('test base/DataExport/Detail/PageHeaderAction', () => {
     ).toHaveBeenCalledTimes(1);
   });
 
-  it('clicked approve workflow button', () => {
+  it('clicked approve workflow button', async () => {
     baseSuperRender(<ExportDetailPageHeaderAction />);
     fireEvent.click(screen.getByText('审核通过'));
+    expect(
+      mockActionButtonStateData.approveWorkflowButtonMeta.action
+    ).not.toHaveBeenCalled();
+    expect(screen.getByText('确认通过')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText('确认通过'));
+    });
     expect(
       mockActionButtonStateData.approveWorkflowButtonMeta.action
     ).toHaveBeenCalledTimes(1);

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/__tests__/useActionButtonState.test.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/__tests__/useActionButtonState.test.tsx
@@ -238,7 +238,8 @@ describe('test useActionButtonState', () => {
     result.current.approveWorkflowButtonMeta.action();
     expect(mockExportDetailActionData.approveWorkflow).toHaveBeenCalledTimes(1);
     expect(mockExportDetailActionData.approveWorkflow).toHaveBeenCalledWith(
-      workflowID
+      workflowID,
+      undefined
     );
 
     result.current.closeWorkflowButtonMeta.action();

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/actions.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/actions.tsx
@@ -4,7 +4,7 @@ import {
   PermissionControl
 } from '@actiontech/shared/lib/features';
 import { ActionButton } from '@actiontech/shared';
-import { ActionMeta } from './index.type';
+import { ActionMeta, ApproveActionMeta } from './index.type';
 import { Divider } from 'antd';
 export const CloseWorkflowAction = (closeWorkflowButtonMeta: ActionMeta) => {
   return (
@@ -41,7 +41,8 @@ export const RejectWorkflowAction = (rejectWorkflowButtonMeta: ActionMeta) => {
   );
 };
 export const ApproveWorkflowAction = (
-  approveWorkflowButtonMeta: ActionMeta
+  approveWorkflowButtonMeta: ApproveActionMeta,
+  openApproveModal: () => void
 ) => {
   return (
     <PermissionControl
@@ -52,7 +53,7 @@ export const ApproveWorkflowAction = (
         text={t('dmsDataExport.detail.action.approve.text')}
         hidden={approveWorkflowButtonMeta.hidden}
         disabled={approveWorkflowButtonMeta.disabled}
-        onClick={approveWorkflowButtonMeta.action}
+        onClick={openApproveModal}
         loading={approveWorkflowButtonMeta.loading}
         type="primary"
       />

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/index.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/index.tsx
@@ -3,6 +3,7 @@ import useDataExportDetailReduxManage from '../../hooks/index.redux';
 import { ExportDetailPageHeaderExtraStyleWrapper } from './style';
 import { EmptyBox } from '@actiontech/dms-kit';
 import { Divider, message } from 'antd';
+import { useBoolean } from 'ahooks';
 import useActionButtonState from './useActionButtonState';
 import {
   CloseWorkflowAction,
@@ -10,11 +11,17 @@ import {
   ApproveWorkflowAction,
   ExecuteWorkflowAction
 } from './actions';
+import ApproveWorkflowModal from './ApproveWorkflowModal';
+
 const ExportDetailPageHeaderAction: React.FC = () => {
   const { t } = useTranslation();
   const [messageApi, messageContextHolder] = message.useMessage();
   const { workflowStepOpen, updateWorkflowStepOpen } =
     useDataExportDetailReduxManage();
+  const [
+    approveModalVisible,
+    { setTrue: openApproveModal, setFalse: closeApproveModal }
+  ] = useBoolean();
   const workflowDetailClickHandle = () => {
     updateWorkflowStepOpen(true);
   };
@@ -30,7 +37,7 @@ const ExportDetailPageHeaderAction: React.FC = () => {
 
       {CloseWorkflowAction(closeWorkflowButtonMeta)}
       {RejectWorkflowAction(rejectWorkflowButtonMeta)}
-      {ApproveWorkflowAction(approveWorkflowButtonMeta)}
+      {ApproveWorkflowAction(approveWorkflowButtonMeta, openApproveModal)}
       {ExecuteWorkflowAction(executeExportButtonMeta)}
 
       <EmptyBox
@@ -55,6 +62,15 @@ const ExportDetailPageHeaderAction: React.FC = () => {
       >
         {t('dmsDataExport.detail.action.workflowDetail')}
       </div>
+
+      <ApproveWorkflowModal
+        open={approveModalVisible}
+        approve={async (values) => {
+          await approveWorkflowButtonMeta.action(values.reason);
+        }}
+        loading={approveWorkflowButtonMeta.loading}
+        close={closeApproveModal}
+      />
     </ExportDetailPageHeaderExtraStyleWrapper>
   );
 };

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/index.type.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/index.type.ts
@@ -4,3 +4,10 @@ export type ActionMeta = {
   hidden: boolean;
   disabled?: boolean;
 };
+
+export type ApproveActionMeta = {
+  action: (reason?: string) => void | Promise<void>;
+  loading: boolean;
+  hidden: boolean;
+  disabled?: boolean;
+};

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/useActionButtonState.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/useActionButtonState.ts
@@ -1,18 +1,22 @@
 import useDataExportDetailReduxManage from '../../hooks/index.redux';
 import useExportDetailAction from '../../hooks/useExportDetailAction';
 import { useMemo } from 'react';
-import { WorkflowRecordStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+import {
+  DataExportRelatedUnmaskingWorkflowApprovalStatusEnum,
+  WorkflowRecordStatusEnum
+} from '@actiontech/shared/lib/api/base/service/common.enum';
 import {
   useCurrentUser,
   usePermission,
   PERMISSIONS
 } from '@actiontech/shared/lib/features';
 import { MessageInstance } from 'antd/es/message/interface';
-import { ActionMeta } from './index.type';
+import { ActionMeta, ApproveActionMeta } from './index.type';
+import { getRelatedUnmaskingWorkflows } from '../../utils/unmaskingWorkflow';
 
 const useActionButtonState: (messageApi: MessageInstance) => {
   closeWorkflowButtonMeta: ActionMeta;
-  approveWorkflowButtonMeta: ActionMeta;
+  approveWorkflowButtonMeta: ApproveActionMeta;
   rejectWorkflowButtonMeta: ActionMeta;
   executeExportButtonMeta: ActionMeta;
 } = (messageApi) => {
@@ -94,11 +98,22 @@ const useActionButtonState: (messageApi: MessageInstance) => {
     if (!workflowStatus || !currentStep) {
       return false;
     }
+    const relatedUnmaskingWorkflows =
+      getRelatedUnmaskingWorkflows(workflowInfo);
+    const hasRelatedUnmaskingWorkflow = relatedUnmaskingWorkflows.length > 0;
+    const allUnmaskingApproved = relatedUnmaskingWorkflows.every(
+      (workflow) =>
+        workflow.approval_status ===
+        DataExportRelatedUnmaskingWorkflowApprovalStatusEnum.approved
+    );
+    const canExecuteWithMasking =
+      !hasRelatedUnmaskingWorkflow || allUnmaskingApproved;
     return (
       workflowStatus === WorkflowRecordStatusEnum.wait_for_export &&
-      workflowInfo.create_user?.uid === userId
+      workflowInfo.create_user?.uid === userId &&
+      canExecuteWithMasking
     );
-  }, [currentStep, userId, workflowInfo?.create_user?.uid, workflowStatus]);
+  }, [currentStep, userId, workflowInfo, workflowStatus]);
 
   return {
     closeWorkflowButtonMeta: {
@@ -107,7 +122,7 @@ const useActionButtonState: (messageApi: MessageInstance) => {
       loading: closeWorkflowLoading
     },
     approveWorkflowButtonMeta: {
-      action: () => approveWorkflow(workflowID),
+      action: (reason?: string) => approveWorkflow(workflowID, reason),
       hidden: !approveWorkflowButtonVisibility,
       loading: approveWorkflowLoading,
       disabled: isExportApproveBWPDisabled

--- a/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/useActionButtonState.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/components/PageHeaderAction/useActionButtonState.ts
@@ -1,10 +1,7 @@
 import useDataExportDetailReduxManage from '../../hooks/index.redux';
 import useExportDetailAction from '../../hooks/useExportDetailAction';
 import { useMemo } from 'react';
-import {
-  DataExportRelatedUnmaskingWorkflowApprovalStatusEnum,
-  WorkflowRecordStatusEnum
-} from '@actiontech/shared/lib/api/base/service/common.enum';
+import { WorkflowRecordStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
 import {
   useCurrentUser,
   usePermission,
@@ -12,7 +9,6 @@ import {
 } from '@actiontech/shared/lib/features';
 import { MessageInstance } from 'antd/es/message/interface';
 import { ActionMeta, ApproveActionMeta } from './index.type';
-import { getRelatedUnmaskingWorkflows } from '../../utils/unmaskingWorkflow';
 
 const useActionButtonState: (messageApi: MessageInstance) => {
   closeWorkflowButtonMeta: ActionMeta;
@@ -98,22 +94,11 @@ const useActionButtonState: (messageApi: MessageInstance) => {
     if (!workflowStatus || !currentStep) {
       return false;
     }
-    const relatedUnmaskingWorkflows =
-      getRelatedUnmaskingWorkflows(workflowInfo);
-    const hasRelatedUnmaskingWorkflow = relatedUnmaskingWorkflows.length > 0;
-    const allUnmaskingApproved = relatedUnmaskingWorkflows.every(
-      (workflow) =>
-        workflow.approval_status ===
-        DataExportRelatedUnmaskingWorkflowApprovalStatusEnum.approved
-    );
-    const canExecuteWithMasking =
-      !hasRelatedUnmaskingWorkflow || allUnmaskingApproved;
     return (
       workflowStatus === WorkflowRecordStatusEnum.wait_for_export &&
-      workflowInfo.create_user?.uid === userId &&
-      canExecuteWithMasking
+      workflowInfo.create_user?.uid === userId
     );
-  }, [currentStep, userId, workflowInfo, workflowStatus]);
+  }, [currentStep, userId, workflowInfo?.create_user?.uid, workflowStatus]);
 
   return {
     closeWorkflowButtonMeta: {

--- a/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/RejectWorkflowModal/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/RejectWorkflowModal/__snapshots__/index.test.tsx.snap
@@ -57,9 +57,9 @@ exports[`test RejectWorkflowModal should match snapshot 1`] = `
                       <label
                         class="ant-form-item-required"
                         for="reason"
-                        title="驳回原因"
+                        title="审批意见"
                       >
-                        驳回原因
+                        审批意见
                       </label>
                     </div>
                     <div

--- a/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/RejectWorkflowModal/index.test.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/RejectWorkflowModal/index.test.tsx
@@ -35,7 +35,7 @@ describe('test RejectWorkflowModal', () => {
     const rejectSpy = dataExport.RejectDataExportWorkflow();
     baseSuperRender(<RejectWorkflowModal />);
 
-    fireEvent.change(screen.getByLabelText('驳回原因'), {
+    fireEvent.change(screen.getByLabelText('审批意见'), {
       target: { value: 'reject reason' }
     });
 
@@ -67,7 +67,7 @@ describe('test RejectWorkflowModal', () => {
     expect(emitSpy).toHaveBeenCalledWith(
       EmitterKey.DMS_Refresh_Export_Data_Workflow
     );
-    expect(screen.getByLabelText('驳回原因')).toHaveValue('');
+    expect(screen.getByLabelText('审批意见')).toHaveValue('');
     expect(
       mockDataExportDetailRedux.updateWorkflowRejectOpen
     ).toHaveBeenCalledTimes(1);
@@ -79,13 +79,13 @@ describe('test RejectWorkflowModal', () => {
   it('should clear form and close modal', async () => {
     baseSuperRender(<RejectWorkflowModal />);
 
-    fireEvent.change(screen.getByLabelText('驳回原因'), {
+    fireEvent.change(screen.getByLabelText('审批意见'), {
       target: { value: 'reject reason' }
     });
     await act(async () => jest.advanceTimersByTime(0));
 
     fireEvent.click(screen.getByText('取 消'));
-    expect(screen.getByLabelText('驳回原因')).toHaveValue('');
+    expect(screen.getByLabelText('审批意见')).toHaveValue('');
     expect(
       mockDataExportDetailRedux.updateWorkflowRejectOpen
     ).toHaveBeenCalledTimes(1);

--- a/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/RejectWorkflowModal/index.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/RejectWorkflowModal/index.tsx
@@ -84,7 +84,7 @@ const RejectWorkflowModal: React.FC = () => {
       <>
         <Form form={form} layout="vertical">
           <Form.Item
-            label={t('dmsDataExport.detail.action.reject.reason')}
+            label={t('dmsDataExport.detail.operator.approvalComment')}
             name="reason"
             rules={[
               {

--- a/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/components/RejectReason/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`test base/DataExport/Detail/RejectReason should match snapshot 1`] = `
       <div
         class="reject-workflow-reason-content-text"
       >
-        admin驳回了当前工单，驳回原因为：
+        admin驳回了当前工单，审批意见为：
         <span
           class="reject-workflow-reason-content-text-reason"
         />

--- a/packages/base/src/page/DataExportManagement/Detail/components/WorkflowRecordInfo/WorkflowSteps.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/WorkflowRecordInfo/WorkflowSteps.tsx
@@ -7,7 +7,10 @@ import { Space } from 'antd';
 import { formatTime } from '@actiontech/dms-kit';
 import { EmptyBox } from '@actiontech/dms-kit';
 import useThemeStyleData from '../../../../../hooks/useThemeStyleData';
-import { WorkflowRecordStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+import {
+  WorkflowRecordStatusEnum,
+  WorkflowStepStateEnum
+} from '@actiontech/shared/lib/api/base/service/common.enum';
 import { IWorkflowStep } from '@actiontech/shared/lib/api/base/service/common';
 import classNames from 'classnames';
 import {
@@ -16,6 +19,14 @@ import {
   PlusCircleFilled,
   CheckCircleFilled
 } from '@actiontech/icons';
+import { formatApprovalComment } from './formatApprovalComment';
+
+const isCompletedApproveStep = (step: IWorkflowStep) =>
+  step.type !== 'execute' &&
+  step.type !== 'create' &&
+  (step.state === WorkflowStepStateEnum.finish ||
+    step.state === WorkflowStepStateEnum.rejected);
+
 const WorkflowSteps: React.FC<WorkflowStepsProps> = ({
   workflowSteps,
   currentStepNumber,
@@ -137,6 +148,20 @@ const WorkflowSteps: React.FC<WorkflowStepsProps> = ({
           <EmptyBox if={workflowStatus === WorkflowRecordStatusEnum.cancel}>
             <div className="step-info-rejected">
               <span>{t('dmsDataExport.detail.operator.alreadyClosed')}</span>
+            </div>
+          </EmptyBox>
+
+          <EmptyBox if={isCompletedApproveStep(step)}>
+            <div className="step-info-approval-comment">
+              <span>
+                {t('dmsDataExport.detail.operator.approvalComment')}：
+              </span>
+              <span>
+                {formatApprovalComment(
+                  step.reason,
+                  t('dmsDataExport.detail.operator.notFilled')
+                )}
+              </span>
             </div>
           </EmptyBox>
         </>

--- a/packages/base/src/page/DataExportManagement/Detail/components/WorkflowRecordInfo/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/components/WorkflowRecordInfo/__tests__/__snapshots__/index.test.tsx.snap
@@ -314,6 +314,17 @@ exports[`test base/DataExport/Detail/WorkflowRecordInfo should match snapshot 1`
                         </span>
                       </div>
                     </div>
+                    <div
+                      class="step-info-approval-comment"
+                    >
+                      <span>
+                        审批意见
+                        ：
+                      </span>
+                      <span>
+                        未填写
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/packages/base/src/page/DataExportManagement/Detail/components/WorkflowRecordInfo/formatApprovalComment.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/components/WorkflowRecordInfo/formatApprovalComment.ts
@@ -1,0 +1,13 @@
+/**
+ * 进度区展示用：空/缺省 reason → 「未填写」文案；有内容返回 trim 后全文。
+ * 仅 UI 映射，不写入请求。
+ */
+export const formatApprovalComment = (
+  reason: string | undefined | null,
+  notFilledText: string
+): string => {
+  if (!reason || reason.trim() === '') {
+    return notFilledText;
+  }
+  return reason;
+};

--- a/packages/base/src/page/DataExportManagement/Detail/hooks/useExportDetailAction.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/hooks/useExportDetailAction.ts
@@ -45,11 +45,12 @@ const useExportDetailAction = (messageApi: MessageInstance) => {
     { setFalse: finishApproveWorkflow, setTrue: startApproveWorkflow }
   ] = useBoolean();
 
-  const approveWorkflow = (workflowID: string) => {
+  const approveWorkflow = (workflowID: string, reason?: string) => {
     startApproveWorkflow();
-    DataExportWorkflows.ApproveDataExportWorkflow({
+    return DataExportWorkflows.ApproveDataExportWorkflow({
       data_export_workflow_uid: workflowID,
-      project_uid: projectID
+      project_uid: projectID,
+      ...(typeof reason === 'string' ? { payload: { reason } } : {})
     })
       .then((res) => {
         if (res.data.code === ResponseCode.SUCCESS) {

--- a/packages/shared/lib/api/base/service/DataExportWorkflows/index.d.ts
+++ b/packages/shared/lib/api/base/service/DataExportWorkflows/index.d.ts
@@ -99,6 +99,10 @@ export interface IApproveDataExportWorkflowParams {
   project_uid: string;
 
   data_export_workflow_uid: string;
+
+  payload?: {
+    reason?: string;
+  };
 }
 
 export interface IApproveDataExportWorkflowReturn extends IGenericResp {}
@@ -110,6 +114,14 @@ export interface IExportDataExportWorkflowParams {
 }
 
 export interface IExportDataExportWorkflowReturn extends IGenericResp {}
+
+export interface IDownloadOriginalDataExportWorkflowParams {
+  project_uid: string;
+
+  data_export_workflow_uid: string;
+
+  unmasking_workflow_uid: string;
+}
 
 export interface IRejectDataExportWorkflowParams
   extends IRejectDataExportWorkflowReq {

--- a/packages/shared/lib/api/base/service/DataExportWorkflows/index.d.ts
+++ b/packages/shared/lib/api/base/service/DataExportWorkflows/index.d.ts
@@ -115,14 +115,6 @@ export interface IExportDataExportWorkflowParams {
 
 export interface IExportDataExportWorkflowReturn extends IGenericResp {}
 
-export interface IDownloadOriginalDataExportWorkflowParams {
-  project_uid: string;
-
-  data_export_workflow_uid: string;
-
-  unmasking_workflow_uid: string;
-}
-
 export interface IRejectDataExportWorkflowParams
   extends IRejectDataExportWorkflowReq {
   project_uid: string;

--- a/packages/shared/lib/api/sqle/service/workflow/index.d.ts
+++ b/packages/shared/lib/api/sqle/service/workflow/index.d.ts
@@ -525,6 +525,8 @@ export interface IApproveWorkflowV2Params {
   workflow_step_id: string;
 
   project_name: string;
+
+  reason?: string;
 }
 
 export interface IApproveWorkflowV2Return extends IBaseRes {}

--- a/packages/sqle/src/locale/en-US/execWorkflow.ts
+++ b/packages/sqle/src/locale/en-US/execWorkflow.ts
@@ -142,37 +142,6 @@ export default {
   },
 
   detail: {
-    failDisplay: {
-      headerPrefix: 'Execution failed: ',
-      headerWithCount: 'Execution failed: {{count}} SQL(s) {{phrase}}',
-      headerWithSqlNumber: 'Execution failed: SQL #{{number}} execution failed',
-      statusLabel: 'Status',
-      stageLabel: 'Stage',
-      reasonLabel: 'Reason',
-      stage: {
-        sqlBackup: 'SQL backup',
-        sqlExecute: 'SQL execution',
-        datasourceConnect: 'Data source connection',
-        preCheck: 'Pre-check',
-        terminate: 'Task terminated',
-        unknown: 'Unknown'
-      },
-      phrase: {
-        sqlBackup: 'SQL backup failed',
-        sqlExecute: 'SQL execution failed',
-        datasourceConnect: 'Data source connection failed',
-        preCheck: 'Pre-check failed',
-        terminate: 'Task terminated',
-        unknown: 'Unknown'
-      },
-      status: {
-        backupFailed: 'Backup failed',
-        executeFailed: 'Execution failed',
-        connectFailed: 'Connection failed',
-        notExecuted: 'Not executed',
-        rolledBack: 'Rolled back'
-      }
-    },
     operator: {
       buttonText: 'Workflow details',
       title: 'Workflow information',
@@ -211,6 +180,9 @@ export default {
       batchSqlExecuteConfirmTips:
         'This operation will immediately execute all SQL statements under the workflow, and the data sources that have been scheduled for timed execution will still be executed at the scheduled time and will not be executed immediately, do you confirm to execute immediately in batch?',
       sqlReview: 'Audit passed',
+      approvalComment: 'Approval comment',
+      notFilled: 'Not filled',
+      confirmApprove: 'Confirm approval',
       terminate: 'Terminate execution',
       terminateSuccessTips: 'Terminate execution successful',
       terminateConfirmTips:

--- a/packages/sqle/src/locale/en-US/execWorkflow.ts
+++ b/packages/sqle/src/locale/en-US/execWorkflow.ts
@@ -142,6 +142,37 @@ export default {
   },
 
   detail: {
+    failDisplay: {
+      headerPrefix: 'Execution failed: ',
+      headerWithCount: 'Execution failed: {{count}} SQL(s) {{phrase}}',
+      headerWithSqlNumber: 'Execution failed: SQL #{{number}} execution failed',
+      statusLabel: 'Status',
+      stageLabel: 'Stage',
+      reasonLabel: 'Reason',
+      stage: {
+        sqlBackup: 'SQL backup',
+        sqlExecute: 'SQL execution',
+        datasourceConnect: 'Data source connection',
+        preCheck: 'Pre-check',
+        terminate: 'Task terminated',
+        unknown: 'Unknown'
+      },
+      phrase: {
+        sqlBackup: 'SQL backup failed',
+        sqlExecute: 'SQL execution failed',
+        datasourceConnect: 'Data source connection failed',
+        preCheck: 'Pre-check failed',
+        terminate: 'Task terminated',
+        unknown: 'Unknown'
+      },
+      status: {
+        backupFailed: 'Backup failed',
+        executeFailed: 'Execution failed',
+        connectFailed: 'Connection failed',
+        notExecuted: 'Not executed',
+        rolledBack: 'Rolled back'
+      }
+    },
     operator: {
       buttonText: 'Workflow details',
       title: 'Workflow information',

--- a/packages/sqle/src/locale/zh-CN/execWorkflow.ts
+++ b/packages/sqle/src/locale/zh-CN/execWorkflow.ts
@@ -159,6 +159,37 @@ export default {
   },
 
   detail: {
+    failDisplay: {
+      headerPrefix: '上线失败：',
+      headerWithCount: '上线失败：{{count}} 条 {{phrase}}',
+      headerWithSqlNumber: '上线失败：第 {{number}} 条 SQL 执行失败',
+      statusLabel: '状态',
+      stageLabel: '阶段',
+      reasonLabel: '原因',
+      stage: {
+        sqlBackup: 'SQL 备份',
+        sqlExecute: 'SQL 执行',
+        datasourceConnect: '数据源连接',
+        preCheck: '前置校验',
+        terminate: '任务中止',
+        unknown: '未知'
+      },
+      phrase: {
+        sqlBackup: 'SQL 备份失败',
+        sqlExecute: 'SQL 执行失败',
+        datasourceConnect: '数据源连接失败',
+        preCheck: '前置校验失败',
+        terminate: '任务中止',
+        unknown: '未知'
+      },
+      status: {
+        backupFailed: '备份失败',
+        executeFailed: '执行失败',
+        connectFailed: '连接失败',
+        notExecuted: '未执行',
+        rolledBack: '已回滚'
+      }
+    },
     operator: {
       buttonText: '工单详情',
       title: '工单信息',

--- a/packages/sqle/src/locale/zh-CN/execWorkflow.ts
+++ b/packages/sqle/src/locale/zh-CN/execWorkflow.ts
@@ -159,37 +159,6 @@ export default {
   },
 
   detail: {
-    failDisplay: {
-      headerPrefix: '上线失败：',
-      headerWithCount: '上线失败：{{count}} 条 {{phrase}}',
-      headerWithSqlNumber: '上线失败：第 {{number}} 条 SQL 执行失败',
-      statusLabel: '状态',
-      stageLabel: '阶段',
-      reasonLabel: '原因',
-      stage: {
-        sqlBackup: 'SQL 备份',
-        sqlExecute: 'SQL 执行',
-        datasourceConnect: '数据源连接',
-        preCheck: '前置校验',
-        terminate: '任务中止',
-        unknown: '未知'
-      },
-      phrase: {
-        sqlBackup: 'SQL 备份失败',
-        sqlExecute: 'SQL 执行失败',
-        datasourceConnect: '数据源连接失败',
-        preCheck: '前置校验失败',
-        terminate: '任务中止',
-        unknown: '未知'
-      },
-      status: {
-        backupFailed: '备份失败',
-        executeFailed: '执行失败',
-        connectFailed: '连接失败',
-        notExecuted: '未执行',
-        rolledBack: '已回滚'
-      }
-    },
     operator: {
       buttonText: '工单详情',
       title: '工单信息',
@@ -225,6 +194,9 @@ export default {
       batchSqlExecuteConfirmTips:
         '当前操作将立即执行工单下的所有SQL语句，且已经设置了定时上线的数据源仍然在定时时间上线，不会立即上线，是否确认立即批量上线?',
       sqlReview: '审核通过',
+      approvalComment: '审批意见',
+      notFilled: '未填写',
+      confirmApprove: '确认通过',
       terminate: '中止上线',
       terminateSuccessTips: '中止上线成功',
       terminateConfirmTips:

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/__tests__/__snapshots__/index.test.tsx.snap
@@ -4562,7 +4562,7 @@ exports[`sqle/ExecWorkflow/Detail render snap detail when have multiple states 1
                           class="ant-steps-item-title"
                         >
                           <div
-                            class="css-1jmll3s"
+                            class="css-1fq11aq"
                           >
                             <div
                               class="step-title"
@@ -4642,7 +4642,7 @@ exports[`sqle/ExecWorkflow/Detail render snap detail when have multiple states 1
                           class="ant-steps-item-title"
                         >
                           <div
-                            class="css-1jmll3s"
+                            class="css-1fq11aq"
                           >
                             <div
                               class="step-title"
@@ -4687,6 +4687,17 @@ exports[`sqle/ExecWorkflow/Detail render snap detail when have multiple states 1
                                   工单已被驳回
                                 </span>
                               </div>
+                              <div
+                                class="step-info-approval-comment"
+                              >
+                                <span>
+                                  审批意见
+                                  ：
+                                </span>
+                                <span>
+                                  1
+                                </span>
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -4728,7 +4739,7 @@ exports[`sqle/ExecWorkflow/Detail render snap detail when have multiple states 1
                           class="ant-steps-item-title"
                         >
                           <div
-                            class="css-1jmll3s"
+                            class="css-1fq11aq"
                           >
                             <div
                               class="step-title"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/__tests__/index.test.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/__tests__/index.test.tsx
@@ -317,6 +317,8 @@ describe('sqle/ExecWorkflow/Detail', () => {
     customRender();
     await act(async () => jest.advanceTimersByTime(3000));
     fireEvent.click(screen.getByText('审核通过'));
+    await act(async () => jest.advanceTimersByTime(300));
+    fireEvent.click(screen.getByText('确认通过'));
     await act(async () => jest.advanceTimersByTime(3000));
     expect(approveWorkflowSpy).toHaveBeenCalledTimes(1);
     expect(approveWorkflowSpy).toHaveBeenCalledWith({

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/ApproveWorkflowModal/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/ApproveWorkflowModal/index.tsx
@@ -1,0 +1,73 @@
+import { BasicButton, BasicInput, BasicModal } from '@actiontech/dms-kit';
+import { Form } from 'antd';
+import { useTranslation } from 'react-i18next';
+import {
+  ApproveWorkflowModalFormFields,
+  ApproveWorkflowModalProps
+} from './index.type';
+
+const APPROVAL_COMMENT_MAX_LENGTH = 255;
+
+const ApproveWorkflowModal: React.FC<ApproveWorkflowModalProps> = ({
+  open,
+  close,
+  loading,
+  approve
+}) => {
+  const [form] = Form.useForm<ApproveWorkflowModalFormFields>();
+  const { t } = useTranslation();
+  const resetAndCloseApproveModal = () => {
+    form.resetFields();
+    close();
+  };
+  return (
+    <BasicModal
+      title={t('execWorkflow.detail.operator.sqlReview')}
+      open={open}
+      closable={false}
+      footer={
+        <>
+          <BasicButton onClick={resetAndCloseApproveModal} disabled={loading}>
+            {t('common.cancel')}
+          </BasicButton>
+          <BasicButton
+            type="primary"
+            loading={loading}
+            disabled={loading}
+            onClick={async () => {
+              const values = await form.validateFields();
+              await approve({
+                reason: values.reason?.trim()
+              });
+              resetAndCloseApproveModal();
+            }}
+          >
+            {t('execWorkflow.detail.operator.confirmApprove')}
+          </BasicButton>
+        </>
+      }
+    >
+      <Form form={form} layout="vertical">
+        <Form.Item
+          label={t('execWorkflow.detail.operator.approvalComment')}
+          name="reason"
+          rules={[
+            {
+              max: APPROVAL_COMMENT_MAX_LENGTH,
+              message: t('common.form.rule.maxLength', {
+                max: APPROVAL_COMMENT_MAX_LENGTH
+              })
+            }
+          ]}
+        >
+          <BasicInput.TextArea
+            placeholder={t('common.form.placeholder.input')}
+            rows={3}
+            maxLength={APPROVAL_COMMENT_MAX_LENGTH}
+          />
+        </Form.Item>
+      </Form>
+    </BasicModal>
+  );
+};
+export default ApproveWorkflowModal;

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/ApproveWorkflowModal/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/ApproveWorkflowModal/index.type.ts
@@ -1,0 +1,12 @@
+export type ApproveWorkflowModalProps = {
+  open: boolean;
+  approve: (
+    values: ApproveWorkflowModalFormFields
+  ) => Promise<void> | undefined;
+  loading: boolean;
+  close: () => void;
+};
+
+export type ApproveWorkflowModalFormFields = {
+  reason?: string;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/RejectWorkflowModal/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/RejectWorkflowModal/index.tsx
@@ -46,7 +46,7 @@ const RejectWorkflowModal: React.FC<RejectWorkflowModalProps> = ({
       <>
         <Form form={form} onFinish={reject} layout="vertical">
           <Form.Item
-            label={t('execWorkflow.detail.operator.rejectReason')}
+            label={t('execWorkflow.detail.operator.approvalComment')}
             name="reason"
             rules={[
               {

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/__test__/__snapshots__/RejectWorkflowModal.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/__test__/__snapshots__/RejectWorkflowModal.test.tsx.snap
@@ -57,9 +57,9 @@ exports[`sqle/ExecWorkflow/Detail/RejectWorkflowModal render snap when open & lo
                       <label
                         class="ant-form-item-required"
                         for="reason"
-                        title="驳回原因"
+                        title="审批意见"
                       >
-                        驳回原因
+                        审批意见
                       </label>
                     </div>
                     <div

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/action.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/action.tsx
@@ -62,7 +62,8 @@ export const BatchRejectWorkflowAction = (
   );
 };
 export const ApproveWorkflowAction = (
-  approveWorkflowButtonMeta: WorkflowDetailActionMeta
+  approveWorkflowButtonMeta: WorkflowDetailActionMeta,
+  openApproveModal: () => void
 ) => {
   return (
     <PermissionControl
@@ -77,7 +78,7 @@ export const ApproveWorkflowAction = (
           approveWorkflowButtonMeta.disabled
         }
         loading={approveWorkflowButtonMeta.loading}
-        onClick={() => approveWorkflowButtonMeta.action()}
+        onClick={openApproveModal}
         type="primary"
       />
     </PermissionControl>

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/hooks/useWorkflowDetailAction.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/hooks/useWorkflowDetailAction.tsx
@@ -141,19 +141,24 @@ const useWorkflowDetailAction = ({
   const [passLoading, { setTrue: passStart, setFalse: passFinish }] =
     useBoolean();
 
-  const auditPassWorkflow = useCallback(() => {
-    if (!auditWorkflowButtonVisibility && currentStep) {
-      return;
-    }
-    passStart();
-    return passAction(currentStep?.workflow_step_id!).finally(passFinish);
-  }, [
-    auditWorkflowButtonVisibility,
-    currentStep,
-    passAction,
-    passFinish,
-    passStart
-  ]);
+  const auditPassWorkflow = useCallback(
+    (reason?: string) => {
+      if (!auditWorkflowButtonVisibility || !currentStep) {
+        return;
+      }
+      passStart();
+      return passAction(currentStep.workflow_step_id!, reason).finally(
+        passFinish
+      );
+    },
+    [
+      auditWorkflowButtonVisibility,
+      currentStep,
+      passAction,
+      passFinish,
+      passStart
+    ]
+  );
 
   const [rejectLoading, { setTrue: rejectStart, setFalse: rejectFinish }] =
     useBoolean();

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/index.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/index.tsx
@@ -7,6 +7,7 @@ import { WorkflowDetailPageHeaderExtraProps } from './index.type';
 import useWorkflowDetailAction from './hooks/useWorkflowDetailAction';
 import { useCurrentProject } from '@actiontech/shared/lib/features';
 import RejectWorkflowModal from './RejectWorkflowModal';
+import ApproveWorkflowModal from './ApproveWorkflowModal';
 import {
   ApproveWorkflowAction,
   BatchExecWorkflowAction,
@@ -29,6 +30,10 @@ const WorkflowDetailPageHeaderExtra: React.FC<
   const [
     rejectModalVisible,
     { setTrue: openRejectModal, setFalse: closeRejectModal }
+  ] = useBoolean();
+  const [
+    approveModalVisible,
+    { setTrue: openApproveModal, setFalse: closeApproveModal }
   ] = useBoolean();
   const {
     messageContextHolder,
@@ -63,7 +68,7 @@ const WorkflowDetailPageHeaderExtra: React.FC<
       {/* #endif */}
       {CloneWorkflowAction(executeInOtherInstanceMeta)}
       {BatchRejectWorkflowAction(rejectWorkflowButtonMeta, openRejectModal)}
-      {ApproveWorkflowAction(auditPassWorkflowButtonMeta)}
+      {ApproveWorkflowAction(auditPassWorkflowButtonMeta, openApproveModal)}
       {BatchExecWorkflowAction(
         batchExecutingWorkflowButtonMeta,
         executable,
@@ -112,6 +117,13 @@ const WorkflowDetailPageHeaderExtra: React.FC<
       >
         {t('execWorkflow.detail.operator.buttonText')}
       </div>
+
+      <ApproveWorkflowModal
+        open={approveModalVisible}
+        approve={(values) => auditPassWorkflowButtonMeta.action(values.reason)}
+        loading={auditPassWorkflowButtonMeta.loading}
+        close={closeApproveModal}
+      />
 
       <RejectWorkflowModal
         open={rejectModalVisible}

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/index.type.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/PageHeaderExtra/index.type.ts
@@ -11,7 +11,7 @@ export type MaintenanceTimeInfoType = Array<{
 export type WorkflowDetailPageHeaderExtraProps = {
   workflowInfo?: IWorkflowResV2;
   refreshWorkflow: () => void;
-  passAction: (stepId: number) => Promise<void>;
+  passAction: (stepId: number, reason?: string) => Promise<void>;
   rejectAction: (reason: string, stepId: number) => Promise<void>;
   executingAction: () => Promise<void>;
   completeAction: () => Promise<void>;

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/__tests__/__snapshots__/WorkflowSteps.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/__tests__/__snapshots__/WorkflowSteps.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow exec_fai
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -132,7 +132,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow exec_fai
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -211,7 +211,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow exec_fai
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -291,7 +291,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow exec_fai
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -379,7 +379,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow exec_fai
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -457,7 +457,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow executin
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -538,7 +538,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow executin
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -617,7 +617,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow executin
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -698,7 +698,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow executin
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -768,7 +768,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow executin
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -846,7 +846,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow finished
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -927,7 +927,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow finished
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1006,7 +1006,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow finished
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1087,7 +1087,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow finished
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1175,7 +1175,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow finished
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1253,7 +1253,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1334,7 +1334,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1413,7 +1413,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1492,7 +1492,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1562,7 +1562,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1640,7 +1640,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1721,7 +1721,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1800,7 +1800,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1879,7 +1879,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"
@@ -1949,7 +1949,7 @@ exports[`sqle/SqlExecWorkflow/Detail/WorkflowSteps render snap workflow rejected
                 class="ant-steps-item-title"
               >
                 <div
-                  class="css-1jmll3s"
+                  class="css-1fq11aq"
                 >
                   <div
                     class="step-title"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/__tests__/__snapshots__/index.ce.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/__tests__/__snapshots__/index.ce.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo ce render init snap 1`] = `
                     class="ant-steps-item-title"
                   >
                     <div
-                      class="css-1jmll3s"
+                      class="css-1fq11aq"
                     >
                       <div
                         class="step-title"
@@ -280,7 +280,7 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo ce render init snap 1`] = `
                     class="ant-steps-item-title"
                   >
                     <div
-                      class="css-1jmll3s"
+                      class="css-1fq11aq"
                     >
                       <div
                         class="step-title"
@@ -317,6 +317,17 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo ce render init snap 1`] = `
                               2024-01-17 11:36:25
                             </span>
                           </div>
+                        </div>
+                        <div
+                          class="step-info-approval-comment"
+                        >
+                          <span>
+                            审批意见
+                            ：
+                          </span>
+                          <span>
+                            未填写
+                          </span>
                         </div>
                       </div>
                     </div>
@@ -361,7 +372,7 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo ce render init snap 1`] = `
                     class="ant-steps-item-title"
                   >
                     <div
-                      class="css-1jmll3s"
+                      class="css-1fq11aq"
                     >
                       <div
                         class="step-title"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/__tests__/__snapshots__/index.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo render snap when has associated 
                     class="ant-steps-item-title"
                   >
                     <div
-                      class="css-1jmll3s"
+                      class="css-1fq11aq"
                     >
                       <div
                         class="step-title"
@@ -280,7 +280,7 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo render snap when has associated 
                     class="ant-steps-item-title"
                   >
                     <div
-                      class="css-1jmll3s"
+                      class="css-1fq11aq"
                     >
                       <div
                         class="step-title"
@@ -317,6 +317,17 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo render snap when has associated 
                               2024-01-17 11:36:25
                             </span>
                           </div>
+                        </div>
+                        <div
+                          class="step-info-approval-comment"
+                        >
+                          <span>
+                            审批意见
+                            ：
+                          </span>
+                          <span>
+                            未填写
+                          </span>
                         </div>
                       </div>
                     </div>
@@ -361,7 +372,7 @@ exports[`sqle/SqlExecWorkflow/Detail/RecordInfo render snap when has associated 
                     class="ant-steps-item-title"
                   >
                     <div
-                      class="css-1jmll3s"
+                      class="css-1fq11aq"
                     >
                       <div
                         class="step-title"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/components/WorkflowSteps.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/components/WorkflowSteps.tsx
@@ -19,6 +19,13 @@ import {
   PlusCircleFilled,
   CheckCircleFilled
 } from '@actiontech/icons';
+import { formatApprovalComment } from './formatApprovalComment';
+
+const isCompletedReviewStep = (step: IWorkflowStepResV2) =>
+  step.type === WorkflowStepResV2TypeEnum.sql_review &&
+  (step.state === WorkflowStepResV2StateEnum.approved ||
+    step.state === WorkflowStepResV2StateEnum.rejected);
+
 const WorkflowSteps: React.FC<WorkflowStepsProps> = ({
   workflowSteps,
   currentStepNumber,
@@ -143,6 +150,18 @@ const WorkflowSteps: React.FC<WorkflowStepsProps> = ({
           >
             <div className="step-info-rejected">
               <span>{t('execWorkflow.detail.operator.alreadyClosed')}</span>
+            </div>
+          </EmptyBox>
+
+          <EmptyBox if={isCompletedReviewStep(step)}>
+            <div className="step-info-approval-comment">
+              <span>{t('execWorkflow.detail.operator.approvalComment')}：</span>
+              <span>
+                {formatApprovalComment(
+                  step.reason,
+                  t('execWorkflow.detail.operator.notFilled')
+                )}
+              </span>
             </div>
           </EmptyBox>
         </>

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/components/formatApprovalComment.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/components/formatApprovalComment.ts
@@ -1,0 +1,13 @@
+/**
+ * 进度区展示用：空/缺省 reason → 「未填写」文案；有内容返回 trim 后全文。
+ * 仅 UI 映射，不写入请求。
+ */
+export const formatApprovalComment = (
+  reason: string | undefined | null,
+  notFilledText: string
+): string => {
+  if (!reason || reason.trim() === '') {
+    return notFilledText;
+  }
+  return reason;
+};

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/RecordInfo/style.ts
@@ -186,6 +186,17 @@ export const WorkflowStepsItemStyleWrapper = styled('div')`
       line-height: 20px;
       width: 100%;
     }
+
+    &-approval-comment {
+      margin-top: 8px;
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorTextSecondary};
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 19px;
+      width: 100%;
+      word-break: break-word;
+      white-space: pre-wrap;
+    }
   }
 `;
 

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/hooks/useGenerateWorkflowStepsProps.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/hooks/useGenerateWorkflowStepsProps.ts
@@ -35,12 +35,13 @@ const useGenerateWorkflowStepsProps = ({
   );
 
   const passAction = useCallback(
-    async (stepId: number) => {
+    async (stepId: number, reason?: string) => {
       return workflow
         .approveWorkflowV2({
           workflow_id: workflowId,
           workflow_step_id: `${stepId}`,
-          project_name: projectName
+          project_name: projectName,
+          ...(reason ? { reason } : {})
         })
         .then((res) => {
           if (res.data.code === ResponseCode.SUCCESS) {


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/sqle-ee/issues/3047

## 描述你的变更

- 工单审批意见按节点留痕：通过选填、驳回必填，详情节点回读
- SQL 上线与数据导出审批语义对齐；导出 Approve 兼容无 body
- 前端通过确认窗与进度区意见展示（CE/EE 已拆分同步）

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
