### PR TITLE
fix: show schema beside filename in SQL file overview

### DIFF
--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/FileMode.tsx
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/FileMode.tsx
@@ -14,7 +14,7 @@ import { Trans } from 'react-i18next';
 import { TasksResultCardStyleWrapper } from './style';
 import { SqlFileOutlined } from '@actiontech/icons';
 import { TypedLink, useTypedParams } from '@actiontech/shared';
-import { ROUTE_PATHS } from '@actiontech/dms-kit';
+import { EmptyBox, ROUTE_PATHS } from '@actiontech/dms-kit';
 
 const FileMode: React.FC<FileExecuteResultCardProps> = ({
   taskId,
@@ -105,6 +105,9 @@ const FileMode: React.FC<FileExecuteResultCardProps> = ({
                 >
                   {props.file_name}
                 </TypedLink>
+                <EmptyBox if={!!props.schema}>
+                  <span className="file-info-schema">{props.schema}</span>
+                </EmptyBox>
               </div>
             </Space>
             <div className="result-card-status-wrap">

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/FileMode.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/FileMode.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`test TaskResultList/Result/FileMode should match snapshot 1`] = `
 <div>
   <div
-    class="css-1nbx0m0"
+    class="css-16kuzaq"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -166,7 +166,7 @@ exports[`test TaskResultList/Result/FileMode should match snapshot 1`] = `
 exports[`test TaskResultList/Result/FileMode should match snapshot 2`] = `
 <div>
   <div
-    class="css-1nbx0m0"
+    class="css-16kuzaq"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -329,7 +329,7 @@ exports[`test TaskResultList/Result/FileMode should match snapshot 2`] = `
 exports[`test TaskResultList/Result/FileMode should render audit result count 1`] = `
 <div>
   <div
-    class="css-1nbx0m0"
+    class="css-16kuzaq"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -515,7 +515,7 @@ exports[`test TaskResultList/Result/FileMode should render audit result count 1`
 exports[`test TaskResultList/Result/FileMode should render collapse children and called request 1`] = `
 <div>
   <div
-    class="css-1nbx0m0"
+    class="css-16kuzaq"
   >
     <div
       class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.ce.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.ce.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode ce render init snap 1`] = `
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/__tests__/__snapshots__/SqlMode.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render associated rollback workfl
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -408,7 +408,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render backup strategy tip 1`] = 
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -868,7 +868,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -1251,7 +1251,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -1696,7 +1696,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -2141,7 +2141,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render change exec_sql & rollback
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -2591,7 +2591,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click add desc 1`] = `
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -2965,7 +2965,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click add desc 2`] = `
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -3363,7 +3363,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click icon arrow when has 
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -3760,7 +3760,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render click icon arrow when no c
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -4165,7 +4165,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render has backup conflict 1`] = 
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -4625,7 +4625,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render no sql execution result 1`
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -5118,7 +5118,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render no sql execution result an
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -5610,7 +5610,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render snap when data is empty 1`
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -5984,7 +5984,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render sql execution result 1`] =
 <body>
   <div>
     <div
-      class="css-1nbx0m0"
+      class="css-16kuzaq"
     >
       <div
         class="result-card-header"
@@ -6476,7 +6476,7 @@ exports[`sqle/ExecWorkflow/AuditDetail/SqlMode render sql execution result 1`] =
 exports[`sqle/ExecWorkflow/AuditDetail/SqlMode should render retry execute action when exec status is failed or initialized 1`] = `
 <div>
   <div
-    class="css-1nbx0m0"
+    class="css-16kuzaq"
   >
     <div
       class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/style.ts
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/Common/ResultCard/style.ts
@@ -124,6 +124,16 @@ export const TasksResultCardStyleWrapper = styled('div')`
         &-name {
           margin-left: 8px;
         }
+
+        &-schema {
+          margin-left: 12px;
+          color: ${({ theme }) =>
+            theme.sqleTheme.execWorkflow.common.auditResultFilter
+              .auditResultInfo.schemaValueColor};
+          font-size: 14px;
+          font-weight: 700;
+          line-height: 22px;
+        }
       }
     }
   }

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -304,7 +304,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1nbx0m0"
+              class="css-16kuzaq"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -466,7 +466,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1nbx0m0"
+              class="css-16kuzaq"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -604,7 +604,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1nbx0m0"
+              class="css-16kuzaq"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -766,7 +766,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1nbx0m0"
+              class="css-16kuzaq"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -904,7 +904,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1nbx0m0"
+              class="css-16kuzaq"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -1066,7 +1066,7 @@ exports[`test PaginationList/FileExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1nbx0m0"
+              class="css-16kuzaq"
             >
               <div
                 class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/PaginationList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`test PaginationList/SQLExecuteMode should match snapshot 2`] = `
             class="ant-list-item ant-list-item-no-flex"
           >
             <div
-              class="css-1nbx0m0"
+              class="css-16kuzaq"
             >
               <div
                 class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/FileExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -328,7 +328,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -466,7 +466,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -628,7 +628,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -766,7 +766,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"
@@ -928,7 +928,7 @@ exports[`test WaterfallList/FileExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="ant-collapse ant-collapse-icon-position-start ant-collapse-ghost file-result-collapse-wrapper"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/TaskResultList/WaterfallList/SqlExecuteMode/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`test WaterfallList/SQLExecuteMode render onUpdateDescription 1`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="result-card-header"
@@ -538,7 +538,7 @@ exports[`test WaterfallList/SQLExecuteMode should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="result-card-header"

--- a/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/sqle/src/page/SqlExecWorkflow/Detail/components/AuditExecResultPanel/__tests__/__snapshots__/index.test.tsx.snap
@@ -1030,7 +1030,7 @@ exports[`test AuditExecResultPanel matches snapshot and selects task on initial 
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="result-card-header"
@@ -2834,7 +2834,7 @@ exports[`test AuditExecResultPanel sql retry execute permission should enable re
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nbx0m0"
+                  class="css-16kuzaq"
                 >
                   <div
                     class="result-card-header"
@@ -3854,7 +3854,7 @@ exports[`test AuditExecResultPanel updates layout to waterfall and retrieves tas
                     class="ant-list-item ant-list-item-no-flex"
                   >
                     <div
-                      class="css-1nbx0m0"
+                      class="css-16kuzaq"
                     >
                       <div
                         class="result-card-header"


### PR DESCRIPTION
## Summary
- Fixes actiontech/dms-ee#947
- 文件执行模式下在文件名旁渲染 `instance_schema`，修复上传 SQL 工单详情看不到 schema 的问题
- 样式对齐既有 schema 展示色；空值不渲染；不改创建/落库/回读链路

## Related
- CSVW 定制分支 PR：https://github.com/actiontech/dms-ui-ee/pull/740

## Test plan
- [ ] 上传 `.sql` 创建工单后，审核结果文件任务概览文件名旁展示 schema
- [ ] schema 为空时不渲染旁标
- [ ] 在线输入 SQL 路径不回归
- [ ] FileMode / SqlMode 相关 snapshot 与 CI 通过