### PR TITLE
feat: surface data export failure status in community UI

### DIFF
--- a/packages/base/src/locale/en-US/dmsDataExport.ts
+++ b/packages/base/src/locale/en-US/dmsDataExport.ts
@@ -9,10 +9,26 @@ export default {
     finished: 'Export success',
     exporting: 'Exporting',
     export_failed: 'Export failed',
+    partial_failed: 'Partial export failed',
     expired: 'Expired',
     rejected: 'Rejected',
     canceled: 'Closed',
     file_deleted: 'Removed'
+  },
+  failStage: {
+    task_schedule: 'Task scheduling',
+    connect: 'Data source connection',
+    prepare: 'Export preparation',
+    sql_execute: 'SQL execution',
+    file_generate: 'File generation',
+    unknown: 'Unknown'
+  },
+  execStatus: {
+    success: 'Success',
+    failed: 'Failed',
+    not_executed: 'Not executed',
+    notExecutedHint:
+      'The export task has failed; this SQL statement was not executed'
   },
   batchCancel: {
     messageWarn:
@@ -105,9 +121,13 @@ export default {
       title: 'Export result',
       overview: {
         title: 'Overview',
+        partialFailedNotice:
+          'This workflow has partial export failures: successful tasks can still be downloaded; please fix failed tasks and retry.',
         column: {
           dbService: 'DB instance',
           status: 'Status',
+          failStage: 'Failure stage:',
+          failReason: 'Failure reason:',
           assigneeUser: 'Assignee',
           exportStartTime: 'Export start time',
           exportEndTime: 'Export end time',
@@ -135,7 +155,10 @@ export default {
         title: 'Basic info',
         createUser: 'Creator',
         createTime: 'Create time',
-        status: 'Status'
+        status: 'Status',
+        exportFailSummaryLabel: 'Failure reason:',
+        exportFailSummaryFallback:
+          'Export failed. No specific reason is available yet; please contact the administrator to check service logs'
       },
       steps: {
         title: 'Task progress',

--- a/packages/base/src/locale/zh-CN/dmsDataExport.ts
+++ b/packages/base/src/locale/zh-CN/dmsDataExport.ts
@@ -9,10 +9,25 @@ export default {
     finished: '导出成功',
     exporting: '正在导出',
     export_failed: '导出失败',
+    partial_failed: '部分导出失败',
     expired: '已过期',
     rejected: '已驳回',
     canceled: '已关闭',
     file_deleted: '已移除'
+  },
+  failStage: {
+    task_schedule: '任务调度',
+    connect: '数据源连接',
+    prepare: '导出准备',
+    sql_execute: 'SQL 执行',
+    file_generate: '文件生成',
+    unknown: '未知'
+  },
+  execStatus: {
+    success: '成功',
+    failed: '失败',
+    not_executed: '未执行',
+    notExecutedHint: '导出任务已失败，本条 SQL 未执行'
   },
   batchCancel: {
     messageWarn:
@@ -116,9 +131,13 @@ export default {
       title: '导出结果',
       overview: {
         title: '概览',
+        partialFailedNotice:
+          '当前工单存在“部分导出失败”：已成功任务可继续下载，失败任务请修复后重试。',
         column: {
           dbService: '数据源',
           status: '状态',
+          failStage: '失败阶段：',
+          failReason: '失败原因：',
           assigneeUser: '待操作人',
           exportStartTime: '导出开始时间',
           exportEndTime: '导出结束时间',
@@ -145,7 +164,10 @@ export default {
         title: '基本信息',
         createUser: '创建人',
         createTime: '创建时间',
-        status: '状态'
+        status: '状态',
+        exportFailSummaryLabel: '失败原因：',
+        exportFailSummaryFallback:
+          '导出失败，暂未获取到具体原因，请联系管理员查看服务日志'
       },
       steps: {
         title: '工单进度',

--- a/packages/base/src/page/DataExportManagement/Detail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/__tests__/__snapshots__/index.test.tsx.snap
@@ -1309,7 +1309,7 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -1338,24 +1338,36 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1590,7 +1602,7 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -1619,24 +1631,36 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1871,7 +1895,7 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -1900,24 +1924,36 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -2152,7 +2188,7 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -2181,24 +2217,36 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -2433,7 +2481,7 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -2462,24 +2510,36 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -2714,7 +2774,7 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -2743,24 +2803,36 @@ exports[`test base/DataExport/Detail should match snapshot 2`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -3901,7 +3973,7 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -3930,24 +4002,36 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -4182,7 +4266,7 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -4211,24 +4295,36 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -4463,7 +4559,7 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -4492,24 +4588,36 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -4744,7 +4852,7 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -4773,24 +4881,36 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -5025,7 +5145,7 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -5054,24 +5174,36 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -5306,7 +5438,7 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -5335,24 +5467,36 @@ exports[`test base/DataExport/Detail should match snapshot 3`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -6493,7 +6637,7 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -6522,24 +6666,36 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -6774,7 +6930,7 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -6803,24 +6959,36 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -7055,7 +7223,7 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -7084,24 +7252,36 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -7336,7 +7516,7 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -7365,24 +7545,36 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -7617,7 +7809,7 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -7646,24 +7838,36 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -7898,7 +8102,7 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -7927,24 +8131,36 @@ exports[`test base/DataExport/Detail should match snapshot 4`] = `
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -9117,7 +9333,7 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -9146,24 +9362,36 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -9398,7 +9626,7 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -9427,24 +9655,36 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -9679,7 +9919,7 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -9708,24 +9948,36 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -9960,7 +10212,7 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -9989,24 +10241,36 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -10241,7 +10505,7 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -10270,24 +10534,36 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -10522,7 +10798,7 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                           class="ant-list-item ant-list-item-no-flex"
                         >
                           <div
-                            class="css-1nwg602"
+                            class="css-13vmh2t"
                           >
                             <div
                               class="result-card-header"
@@ -10551,24 +10827,36 @@ exports[`test base/DataExport/Detail should match snapshot with reject workflow 
                                       class="ant-divider ant-divider-vertical result-card-status-divider"
                                       role="separator"
                                     />
-                                    <span
-                                      class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                    <div
+                                      class="ant-space ant-space-horizontal ant-space-align-center"
                                     >
-                                      <svg
-                                        height="16"
-                                        viewBox="0 0 20 20"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
+                                      <div
+                                        class="ant-space-item"
+                                        style="margin-right: 4px;"
                                       >
-                                        <path
-                                          d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                          fill="#41BF9A"
-                                        />
-                                      </svg>
-                                      <span>
-                                        审核通过
-                                      </span>
-                                    </span>
+                                        <span
+                                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                                        >
+                                          <svg
+                                            height="16"
+                                            viewBox="0 0 20 20"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                              fill="#41BF9A"
+                                            />
+                                          </svg>
+                                          <span>
+                                            审核通过
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="ant-space-item"
+                                      />
+                                    </div>
                                   </div>
                                 </div>
                               </div>

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/ExportExecStatusTag.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/ExportExecStatusTag.tsx
@@ -1,0 +1,46 @@
+import { BasicTag } from '@actiontech/dms-kit';
+import { BasicTagColor } from '@actiontech/dms-kit/es/theme/theme.type';
+import { ListDataExportTaskSQLExportStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+import { useTranslation } from 'react-i18next';
+import { resolveExportSqlStatusI18nKey } from '../../../../utils/exportFailDisplay';
+
+const exportExecStatusColorMap: Record<
+  ListDataExportTaskSQLExportStatusEnum,
+  BasicTagColor
+> = {
+  [ListDataExportTaskSQLExportStatusEnum.success]: 'green',
+  [ListDataExportTaskSQLExportStatusEnum.failed]: 'red',
+  [ListDataExportTaskSQLExportStatusEnum.not_executed]: 'orange'
+};
+
+export type ExportExecStatusTagProps = {
+  status?: string | null;
+};
+
+/**
+ * 数据导出 SQL 卡片执行状态 Tag（对齐上线 ExecStatusTag 习惯；与 AuditResultTag 分区）
+ */
+const ExportExecStatusTag: React.FC<ExportExecStatusTagProps> = ({
+  status
+}) => {
+  const { t } = useTranslation();
+  const i18nKey = resolveExportSqlStatusI18nKey(status);
+  if (!i18nKey) {
+    return null;
+  }
+  const normalized = status?.trim() as ListDataExportTaskSQLExportStatusEnum;
+  return (
+    <BasicTag
+      className="export-exec-status-tag"
+      color={exportExecStatusColorMap[normalized] ?? 'default'}
+      size="large"
+      bordered={false}
+      data-testid="export-exec-status-tag"
+      data-export-status={normalized}
+    >
+      {t(i18nKey)}
+    </BasicTag>
+  );
+};
+
+export default ExportExecStatusTag;

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`test base/DataExport/Detail/ExportTaskList/ResultCard should match snapshot 1`] = `
 <div>
   <div
-    class="css-1nwg602"
+    class="css-13vmh2t"
   >
     <div
       class="result-card-header"
@@ -32,24 +32,36 @@ exports[`test base/DataExport/Detail/ExportTaskList/ResultCard should match snap
               class="ant-divider ant-divider-vertical result-card-status-divider"
               role="separator"
             />
-            <span
-              class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+            <div
+              class="ant-space ant-space-horizontal ant-space-align-center"
             >
-              <svg
-                height="16"
-                viewBox="0 0 20 20"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="ant-space-item"
+                style="margin-right: 4px;"
               >
-                <path
-                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                  fill="#41BF9A"
-                />
-              </svg>
-              <span>
-                审核通过
-              </span>
-            </span>
+                <span
+                  class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                >
+                  <svg
+                    height="16"
+                    viewBox="0 0 20 20"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                      fill="#41BF9A"
+                    />
+                  </svg>
+                  <span>
+                    审核通过
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-space-item"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/__tests__/index.test.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/__tests__/index.test.tsx
@@ -4,6 +4,19 @@ import { baseSuperRender } from '../../../../../../../../testUtils/superRender';
 import { ListDataExportTaskSQLsResponseData } from '@actiontech/shared/lib/testUtil/mockApi/base/dataExport/data';
 import { mockDataExportDetailRedux } from '../../../../../testUtils/mockUseDataExportDetailReduxManage';
 import { Copy } from '@actiontech/dms-kit';
+import { ListDataExportTaskSQLExportStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+import { resolveExportResultDisplayText } from '../../../../../utils/exportFailDisplay';
+
+/** Ant Tree 默认折叠，「导出结果」子节点不在 DOM；与 Playwright expandExportResultTrees 对齐 */
+const expandExportResultTrees = () => {
+  document
+    .querySelectorAll(
+      '.result-card-content .ant-tree-switcher:not(.ant-tree-switcher-noop)'
+    )
+    .forEach((el) => {
+      fireEvent.click(el);
+    });
+};
 
 describe('test base/DataExport/Detail/ExportTaskList/ResultCard', () => {
   it('should match snapshot', () => {
@@ -26,5 +39,116 @@ describe('test base/DataExport/Detail/ExportTaskList/ResultCard', () => {
     expect(mockCopyTextByTextareaSpy).toHaveBeenCalledWith(
       ListDataExportTaskSQLsResponseData[1].sql
     );
+  });
+
+  it('should render success / failed / not_executed exec tags from export_status', () => {
+    const { rerender } = baseSuperRender(
+      <ExportResultCard
+        taskID={mockDataExportDetailRedux.curTaskID}
+        uid={1}
+        sql="SELECT 1"
+        export_status={ListDataExportTaskSQLExportStatusEnum.success}
+        export_result="ok"
+      />
+    );
+    expect(screen.getByText('成功')).toBeInTheDocument();
+    expect(screen.queryByText('失败')).not.toBeInTheDocument();
+
+    rerender(
+      <ExportResultCard
+        taskID={mockDataExportDetailRedux.curTaskID}
+        uid={2}
+        sql="SELECT missing"
+        export_status={ListDataExportTaskSQLExportStatusEnum.failed}
+        export_result="Table 'db.t' doesn't exist"
+      />
+    );
+    expect(screen.getByText('失败')).toBeInTheDocument();
+    expandExportResultTrees();
+    expect(screen.getByText("Table 'db.t' doesn't exist")).toBeInTheDocument();
+
+    rerender(
+      <ExportResultCard
+        taskID={mockDataExportDetailRedux.curTaskID}
+        uid={3}
+        sql="SELECT 3"
+        export_status={ListDataExportTaskSQLExportStatusEnum.not_executed}
+        export_result=""
+      />
+    );
+    expect(screen.getByText('未执行')).toBeInTheDocument();
+    expandExportResultTrees();
+    expect(
+      screen.getByText('导出任务已失败，本条 SQL 未执行')
+    ).toBeInTheDocument();
+  });
+
+  it('should not replace business export_result with fallback when failed', () => {
+    baseSuperRender(
+      <ExportResultCard
+        taskID={mockDataExportDetailRedux.curTaskID}
+        uid={4}
+        sql="SELECT x"
+        export_status={ListDataExportTaskSQLExportStatusEnum.failed}
+        export_result="Access denied for user"
+      />
+    );
+    expandExportResultTrees();
+    expect(screen.getByText('Access denied for user')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        '导出失败，暂未获取到具体原因，请联系管理员查看服务日志'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('should use fallback only when failed and export_result empty', () => {
+    baseSuperRender(
+      <ExportResultCard
+        taskID={mockDataExportDetailRedux.curTaskID}
+        uid={5}
+        sql="SELECT x"
+        export_status={ListDataExportTaskSQLExportStatusEnum.failed}
+        export_result=""
+      />
+    );
+    expandExportResultTrees();
+    expect(
+      screen.getByText('导出失败，暂未获取到具体原因，请联系管理员查看服务日志')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('resolveExportResultDisplayText', () => {
+  const fallback = 'FALLBACK';
+  const notExecutedHint = 'NOT_EXECUTED_HINT';
+
+  it('must not treat export_result==="ok" as success criterion', () => {
+    expect(
+      resolveExportResultDisplayText({
+        exportStatus: '',
+        exportResult: 'ok',
+        failedFallback: fallback,
+        notExecutedHint
+      })
+    ).toBe('ok');
+
+    expect(
+      resolveExportResultDisplayText({
+        exportStatus: ListDataExportTaskSQLExportStatusEnum.failed,
+        exportResult: 'ok',
+        failedFallback: fallback,
+        notExecutedHint
+      })
+    ).toBe('ok');
+
+    expect(
+      resolveExportResultDisplayText({
+        exportStatus: ListDataExportTaskSQLExportStatusEnum.success,
+        exportResult: '',
+        failedFallback: fallback,
+        notExecutedHint
+      })
+    ).toBe('-');
   });
 });

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/index.tsx
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/ResultCard/index.tsx
@@ -1,6 +1,6 @@
 import { BasicButton } from '@actiontech/dms-kit';
 import { Copy, HighlightCode } from '@actiontech/dms-kit';
-import { Divider, Space, message } from 'antd';
+import { Divider, Space, Tooltip, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { ExportResultCardProp } from './index.type';
 import AuditResultTree from './AuditResultTree';
@@ -10,8 +10,14 @@ import {
   ExportResultTreeStyleWrapper
 } from '../../style';
 import AuditResultTag from './AuditResultTag';
+import ExportExecStatusTag from './ExportExecStatusTag';
 import { DownOutlined } from '@actiontech/icons';
 import { CommonIconStyleWrapper } from '@actiontech/dms-kit';
+import { ListDataExportTaskSQLExportStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+import { resolveExportResultDisplayText } from '../../../../utils/exportFailDisplay';
+
+const EXPORT_RESULT_TOOLTIP_MIN_LEN = 48;
+
 const ExportResultCard: React.FC<ExportResultCardProp> = (props) => {
   const { t } = useTranslation();
   const [messageApi, contextHolder] = message.useMessage();
@@ -19,6 +25,41 @@ const ExportResultCard: React.FC<ExportResultCardProp> = (props) => {
     Copy.copyTextByTextarea(props.sql ?? '');
     messageApi.success(t('common.copied'));
   };
+
+  const exportStatus = props.export_status?.trim() ?? '';
+  const isFailed =
+    exportStatus === ListDataExportTaskSQLExportStatusEnum.failed;
+
+  const exportResultText = resolveExportResultDisplayText({
+    exportStatus: props.export_status,
+    exportResult: props.export_result,
+    failedFallback: t(
+      'dmsDataExport.detail.record.basicInfo.exportFailSummaryFallback'
+    ),
+    notExecutedHint: t('dmsDataExport.execStatus.notExecutedHint')
+  });
+
+  const exportResultTextNode = (
+    <span
+      className={
+        isFailed
+          ? 'export-result-text export-result-text-failed'
+          : 'export-result-text'
+      }
+      data-testid="export-result-text"
+      data-export-status={exportStatus || undefined}
+    >
+      {exportResultText}
+    </span>
+  );
+
+  const exportResultNode =
+    isFailed && exportResultText.length >= EXPORT_RESULT_TOOLTIP_MIN_LEN ? (
+      <Tooltip title={exportResultText}>{exportResultTextNode}</Tooltip>
+    ) : (
+      exportResultTextNode
+    );
+
   return (
     <ExportResultCardStyleWrapper>
       {contextHolder}
@@ -27,7 +68,10 @@ const ExportResultCard: React.FC<ExportResultCardProp> = (props) => {
           <span className="number">#{props.uid}</span>
           <div className="result-card-status-wrap">
             <Divider type="vertical" className="result-card-status-divider" />
-            <AuditResultTag auditResult={props.audit_sql_result} />
+            <Space size={4}>
+              <AuditResultTag auditResult={props.audit_sql_result} />
+              <ExportExecStatusTag status={props.export_status} />
+            </Space>
           </div>
         </Space>
         <Space>
@@ -69,7 +113,7 @@ const ExportResultCard: React.FC<ExportResultCardProp> = (props) => {
               key: 'export_result_wrap',
               children: [
                 {
-                  title: props.export_result || '-',
+                  title: exportResultNode,
                   key: 'export_result'
                 }
               ]

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/ExportTaskList/__snapshots__/index.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`test ExportTaskList should match snapshot 2`] = `
               class="ant-list-item ant-list-item-no-flex"
             >
               <div
-                class="css-1nwg602"
+                class="css-13vmh2t"
               >
                 <div
                   class="result-card-header"
@@ -252,24 +252,36 @@ exports[`test ExportTaskList should match snapshot 2`] = `
                           class="ant-divider ant-divider-vertical result-card-status-divider"
                           role="separator"
                         />
-                        <span
-                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                        <div
+                          class="ant-space ant-space-horizontal ant-space-align-center"
                         >
-                          <svg
-                            height="16"
-                            viewBox="0 0 20 20"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="ant-space-item"
+                            style="margin-right: 4px;"
                           >
-                            <path
-                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                              fill="#41BF9A"
-                            />
-                          </svg>
-                          <span>
-                            审核通过
-                          </span>
-                        </span>
+                            <span
+                              class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                            >
+                              <svg
+                                height="16"
+                                viewBox="0 0 20 20"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                              <span>
+                                审核通过
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="ant-space-item"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -504,7 +516,7 @@ exports[`test ExportTaskList should match snapshot 2`] = `
               class="ant-list-item ant-list-item-no-flex"
             >
               <div
-                class="css-1nwg602"
+                class="css-13vmh2t"
               >
                 <div
                   class="result-card-header"
@@ -533,24 +545,36 @@ exports[`test ExportTaskList should match snapshot 2`] = `
                           class="ant-divider ant-divider-vertical result-card-status-divider"
                           role="separator"
                         />
-                        <span
-                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                        <div
+                          class="ant-space ant-space-horizontal ant-space-align-center"
                         >
-                          <svg
-                            height="16"
-                            viewBox="0 0 20 20"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="ant-space-item"
+                            style="margin-right: 4px;"
                           >
-                            <path
-                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                              fill="#41BF9A"
-                            />
-                          </svg>
-                          <span>
-                            审核通过
-                          </span>
-                        </span>
+                            <span
+                              class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                            >
+                              <svg
+                                height="16"
+                                viewBox="0 0 20 20"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                              <span>
+                                审核通过
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="ant-space-item"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -785,7 +809,7 @@ exports[`test ExportTaskList should match snapshot 2`] = `
               class="ant-list-item ant-list-item-no-flex"
             >
               <div
-                class="css-1nwg602"
+                class="css-13vmh2t"
               >
                 <div
                   class="result-card-header"
@@ -814,24 +838,36 @@ exports[`test ExportTaskList should match snapshot 2`] = `
                           class="ant-divider ant-divider-vertical result-card-status-divider"
                           role="separator"
                         />
-                        <span
-                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                        <div
+                          class="ant-space ant-space-horizontal ant-space-align-center"
                         >
-                          <svg
-                            height="16"
-                            viewBox="0 0 20 20"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="ant-space-item"
+                            style="margin-right: 4px;"
                           >
-                            <path
-                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                              fill="#41BF9A"
-                            />
-                          </svg>
-                          <span>
-                            审核通过
-                          </span>
-                        </span>
+                            <span
+                              class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                            >
+                              <svg
+                                height="16"
+                                viewBox="0 0 20 20"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                              <span>
+                                审核通过
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="ant-space-item"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1066,7 +1102,7 @@ exports[`test ExportTaskList should match snapshot 2`] = `
               class="ant-list-item ant-list-item-no-flex"
             >
               <div
-                class="css-1nwg602"
+                class="css-13vmh2t"
               >
                 <div
                   class="result-card-header"
@@ -1095,24 +1131,36 @@ exports[`test ExportTaskList should match snapshot 2`] = `
                           class="ant-divider ant-divider-vertical result-card-status-divider"
                           role="separator"
                         />
-                        <span
-                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                        <div
+                          class="ant-space ant-space-horizontal ant-space-align-center"
                         >
-                          <svg
-                            height="16"
-                            viewBox="0 0 20 20"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="ant-space-item"
+                            style="margin-right: 4px;"
                           >
-                            <path
-                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                              fill="#41BF9A"
-                            />
-                          </svg>
-                          <span>
-                            审核通过
-                          </span>
-                        </span>
+                            <span
+                              class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                            >
+                              <svg
+                                height="16"
+                                viewBox="0 0 20 20"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                              <span>
+                                审核通过
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="ant-space-item"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1347,7 +1395,7 @@ exports[`test ExportTaskList should match snapshot 2`] = `
               class="ant-list-item ant-list-item-no-flex"
             >
               <div
-                class="css-1nwg602"
+                class="css-13vmh2t"
               >
                 <div
                   class="result-card-header"
@@ -1376,24 +1424,36 @@ exports[`test ExportTaskList should match snapshot 2`] = `
                           class="ant-divider ant-divider-vertical result-card-status-divider"
                           role="separator"
                         />
-                        <span
-                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                        <div
+                          class="ant-space ant-space-horizontal ant-space-align-center"
                         >
-                          <svg
-                            height="16"
-                            viewBox="0 0 20 20"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="ant-space-item"
+                            style="margin-right: 4px;"
                           >
-                            <path
-                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                              fill="#41BF9A"
-                            />
-                          </svg>
-                          <span>
-                            审核通过
-                          </span>
-                        </span>
+                            <span
+                              class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                            >
+                              <svg
+                                height="16"
+                                viewBox="0 0 20 20"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                              <span>
+                                审核通过
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="ant-space-item"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1628,7 +1688,7 @@ exports[`test ExportTaskList should match snapshot 2`] = `
               class="ant-list-item ant-list-item-no-flex"
             >
               <div
-                class="css-1nwg602"
+                class="css-13vmh2t"
               >
                 <div
                   class="result-card-header"
@@ -1657,24 +1717,36 @@ exports[`test ExportTaskList should match snapshot 2`] = `
                           class="ant-divider ant-divider-vertical result-card-status-divider"
                           role="separator"
                         />
-                        <span
-                          class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                        <div
+                          class="ant-space ant-space-horizontal ant-space-align-center"
                         >
-                          <svg
-                            height="16"
-                            viewBox="0 0 20 20"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="ant-space-item"
+                            style="margin-right: 4px;"
                           >
-                            <path
-                              d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                              fill="#41BF9A"
-                            />
-                          </svg>
-                          <span>
-                            审核通过
-                          </span>
-                        </span>
+                            <span
+                              class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                            >
+                              <svg
+                                height="16"
+                                viewBox="0 0 20 20"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                  fill="#41BF9A"
+                                />
+                              </svg>
+                              <span>
+                                审核通过
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="ant-space-item"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/__tests__/__snapshots__/index.test.tsx.snap
@@ -464,7 +464,7 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nwg602"
+                  class="css-13vmh2t"
                 >
                   <div
                     class="result-card-header"
@@ -493,24 +493,36 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                             class="ant-divider ant-divider-vertical result-card-status-divider"
                             role="separator"
                           />
-                          <span
-                            class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                          <div
+                            class="ant-space ant-space-horizontal ant-space-align-center"
                           >
-                            <svg
-                              height="16"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="ant-space-item"
+                              style="margin-right: 4px;"
                             >
-                              <path
-                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                fill="#41BF9A"
-                              />
-                            </svg>
-                            <span>
-                              审核通过
-                            </span>
-                          </span>
+                              <span
+                                class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                              >
+                                <svg
+                                  height="16"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                    fill="#41BF9A"
+                                  />
+                                </svg>
+                                <span>
+                                  审核通过
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="ant-space-item"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -745,7 +757,7 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nwg602"
+                  class="css-13vmh2t"
                 >
                   <div
                     class="result-card-header"
@@ -774,24 +786,36 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                             class="ant-divider ant-divider-vertical result-card-status-divider"
                             role="separator"
                           />
-                          <span
-                            class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                          <div
+                            class="ant-space ant-space-horizontal ant-space-align-center"
                           >
-                            <svg
-                              height="16"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="ant-space-item"
+                              style="margin-right: 4px;"
                             >
-                              <path
-                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                fill="#41BF9A"
-                              />
-                            </svg>
-                            <span>
-                              审核通过
-                            </span>
-                          </span>
+                              <span
+                                class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                              >
+                                <svg
+                                  height="16"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                    fill="#41BF9A"
+                                  />
+                                </svg>
+                                <span>
+                                  审核通过
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="ant-space-item"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1026,7 +1050,7 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nwg602"
+                  class="css-13vmh2t"
                 >
                   <div
                     class="result-card-header"
@@ -1055,24 +1079,36 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                             class="ant-divider ant-divider-vertical result-card-status-divider"
                             role="separator"
                           />
-                          <span
-                            class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                          <div
+                            class="ant-space ant-space-horizontal ant-space-align-center"
                           >
-                            <svg
-                              height="16"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="ant-space-item"
+                              style="margin-right: 4px;"
                             >
-                              <path
-                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                fill="#41BF9A"
-                              />
-                            </svg>
-                            <span>
-                              审核通过
-                            </span>
-                          </span>
+                              <span
+                                class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                              >
+                                <svg
+                                  height="16"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                    fill="#41BF9A"
+                                  />
+                                </svg>
+                                <span>
+                                  审核通过
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="ant-space-item"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1307,7 +1343,7 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nwg602"
+                  class="css-13vmh2t"
                 >
                   <div
                     class="result-card-header"
@@ -1336,24 +1372,36 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                             class="ant-divider ant-divider-vertical result-card-status-divider"
                             role="separator"
                           />
-                          <span
-                            class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                          <div
+                            class="ant-space ant-space-horizontal ant-space-align-center"
                           >
-                            <svg
-                              height="16"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="ant-space-item"
+                              style="margin-right: 4px;"
                             >
-                              <path
-                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                fill="#41BF9A"
-                              />
-                            </svg>
-                            <span>
-                              审核通过
-                            </span>
-                          </span>
+                              <span
+                                class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                              >
+                                <svg
+                                  height="16"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                    fill="#41BF9A"
+                                  />
+                                </svg>
+                                <span>
+                                  审核通过
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="ant-space-item"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1588,7 +1636,7 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nwg602"
+                  class="css-13vmh2t"
                 >
                   <div
                     class="result-card-header"
@@ -1617,24 +1665,36 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                             class="ant-divider ant-divider-vertical result-card-status-divider"
                             role="separator"
                           />
-                          <span
-                            class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                          <div
+                            class="ant-space ant-space-horizontal ant-space-align-center"
                           >
-                            <svg
-                              height="16"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="ant-space-item"
+                              style="margin-right: 4px;"
                             >
-                              <path
-                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                fill="#41BF9A"
-                              />
-                            </svg>
-                            <span>
-                              审核通过
-                            </span>
-                          </span>
+                              <span
+                                class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                              >
+                                <svg
+                                  height="16"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                    fill="#41BF9A"
+                                  />
+                                </svg>
+                                <span>
+                                  审核通过
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="ant-space-item"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1869,7 +1929,7 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                 class="ant-list-item ant-list-item-no-flex"
               >
                 <div
-                  class="css-1nwg602"
+                  class="css-13vmh2t"
                 >
                   <div
                     class="result-card-header"
@@ -1898,24 +1958,36 @@ exports[`test base/DataExport/Detail/ExportDetail should match snapshot 2`] = `
                             class="ant-divider ant-divider-vertical result-card-status-divider"
                             role="separator"
                           />
-                          <span
-                            class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                          <div
+                            class="ant-space ant-space-horizontal ant-space-align-center"
                           >
-                            <svg
-                              height="16"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="ant-space-item"
+                              style="margin-right: 4px;"
                             >
-                              <path
-                                d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
-                                fill="#41BF9A"
-                              />
-                            </svg>
-                            <span>
-                              审核通过
-                            </span>
-                          </span>
+                              <span
+                                class="ant-tag ant-tag-green ant-tag-borderless basic-tag-wrapper basic-large-tag-wrapper css-6zycqe"
+                              >
+                                <svg
+                                  height="16"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M10 18.333a8.333 8.333 0 1 1 0-16.666 8.333 8.333 0 1 1 0 16.666m-.83-5 5.89-5.892-1.177-1.178-4.714 4.714-2.357-2.358-1.179 1.179z"
+                                    fill="#41BF9A"
+                                  />
+                                </svg>
+                                <span>
+                                  审核通过
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="ant-space-item"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/style.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/components/ExportDetail/style.ts
@@ -191,6 +191,10 @@ export const ExportResultCardStyleWrapper = styled('div')`
       }
     }
 
+    .export-result-text-failed {
+      color: ${({ theme }) => theme.sharedTheme.uiToken.colorError};
+    }
+
     & .ant-collapse.result-record-collapse .ant-collapse-header {
       padding: 8px 0;
 

--- a/packages/base/src/page/DataExportManagement/Detail/hooks/__tests__/useInitDataWithRequest.test.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/hooks/__tests__/useInitDataWithRequest.test.ts
@@ -106,4 +106,31 @@ describe('test base/DataExport/Detail/hooks/useInitDataWithRequest', () => {
       data_export_workflow_uid: workflowID
     });
   });
+
+  it('should skip batch task query when workflow has no valid task_uid', async () => {
+    getWorkflowSpy.mockImplementation(() =>
+      createSpySuccessResponse({
+        data: {
+          ...GetDataExportWorkflowResponseData,
+          workflow_record: {
+            ...GetDataExportWorkflowResponseData.workflow_record,
+            tasks: [{ task_uid: '' }, { task_uid: '   ' }, {}]
+          }
+        }
+      })
+    );
+
+    renderHook(() => useInitDataWithRequest());
+    await act(async () => jest.advanceTimersByTime(3000));
+
+    expect(batchGetTaskSpy).not.toHaveBeenCalled();
+    expect(mockDataExportDetailRedux.updateTaskInfos).toHaveBeenCalledWith([]);
+    expect(
+      mockDataExportDetailRedux.updateTaskStatusNumber
+    ).toHaveBeenCalledWith({
+      failed: 0,
+      success: 0,
+      exporting: 0
+    });
+  });
 });

--- a/packages/base/src/page/DataExportManagement/Detail/hooks/useInitDataWithRequest.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/hooks/useInitDataWithRequest.ts
@@ -36,11 +36,22 @@ const useInitDataWithRequest = () => {
       }).then((res) => {
         if (res.data.code === ResponseCode.SUCCESS && res.data.data) {
           updateWorkflowInfo(res.data.data);
-          batchGetDataExportTask(
+          const taskIDs =
             res.data.data?.workflow_record?.tasks
-              ?.map((v) => v.task_uid ?? '')
-              ?.join(',') ?? ''
-          );
+              ?.map((v) => v.task_uid?.trim() ?? '')
+              .filter((uid) => !!uid)
+              .join(',') ?? '';
+          // 无有效 task_uid（调度失败无任务）时不发批量查询，避免 code 7001 校验弹错
+          if (taskIDs) {
+            batchGetDataExportTask(taskIDs);
+          } else {
+            updateTaskInfos([]);
+            updateTaskStatusNumber({
+              failed: 0,
+              success: 0,
+              exporting: 0
+            });
+          }
 
           // Stop polling when no longer in exporting status
           if (

--- a/packages/base/src/page/DataExportManagement/Detail/utils/exportFailDisplay.ts
+++ b/packages/base/src/page/DataExportManagement/Detail/utils/exportFailDisplay.ts
@@ -1,0 +1,89 @@
+/**
+ * 数据导出失败展示常量与解析（对齐 S1/S2/S3；wire 与后端一致，禁止另造）
+ */
+
+import type { I18nKey } from '../../../../locale';
+import { ListDataExportTaskSQLExportStatusEnum } from '@actiontech/shared/lib/api/base/service/common.enum';
+
+export const EXPORT_FAIL_STAGE = {
+  task_schedule: 'task_schedule',
+  connect: 'connect',
+  prepare: 'prepare',
+  sql_execute: 'sql_execute',
+  file_generate: 'file_generate'
+} as const;
+
+export type ExportFailStage =
+  (typeof EXPORT_FAIL_STAGE)[keyof typeof EXPORT_FAIL_STAGE];
+
+export const exportFailStageI18nKey: Record<string, I18nKey> = {
+  [EXPORT_FAIL_STAGE.task_schedule]: 'dmsDataExport.failStage.task_schedule',
+  [EXPORT_FAIL_STAGE.connect]: 'dmsDataExport.failStage.connect',
+  [EXPORT_FAIL_STAGE.prepare]: 'dmsDataExport.failStage.prepare',
+  [EXPORT_FAIL_STAGE.sql_execute]: 'dmsDataExport.failStage.sql_execute',
+  [EXPORT_FAIL_STAGE.file_generate]: 'dmsDataExport.failStage.file_generate'
+};
+
+export const resolveExportFailStageI18nKey = (
+  stage?: string | null
+): I18nKey | null => {
+  const trimmed = stage?.trim() ?? '';
+  if (!trimmed) {
+    return null;
+  }
+  return exportFailStageI18nKey[trimmed] ?? 'dmsDataExport.failStage.unknown';
+};
+
+/** SQL 级执行状态（对齐 S3 §8.2 / §9.4；成败只认本字段） */
+export const EXPORT_SQL_STATUS = ListDataExportTaskSQLExportStatusEnum;
+
+export const exportSqlStatusI18nKey: Partial<
+  Record<ListDataExportTaskSQLExportStatusEnum, I18nKey>
+> = {
+  [ListDataExportTaskSQLExportStatusEnum.success]:
+    'dmsDataExport.execStatus.success',
+  [ListDataExportTaskSQLExportStatusEnum.failed]:
+    'dmsDataExport.execStatus.failed',
+  [ListDataExportTaskSQLExportStatusEnum.not_executed]:
+    'dmsDataExport.execStatus.not_executed'
+};
+
+export const resolveExportSqlStatusI18nKey = (
+  status?: string | null
+): I18nKey | null => {
+  const trimmed = status?.trim() ?? '';
+  if (!trimmed) {
+    return null;
+  }
+  return (
+    exportSqlStatusI18nKey[trimmed as ListDataExportTaskSQLExportStatusEnum] ??
+    null
+  );
+};
+
+/**
+ * 解析「导出结果」区展示文案。
+ * - 成败只看 export_status，禁止用 export_result==="ok" 判成败
+ * - failed 且有业务错误 → 原样；空才兜底
+ * - not_executed → 优先 API 文案，空则固定未执行说明（由调用方注入 i18n 默认值）
+ */
+export const resolveExportResultDisplayText = (params: {
+  exportStatus?: string | null;
+  exportResult?: string | null;
+  failedFallback: string;
+  notExecutedHint: string;
+}): string => {
+  const status = params.exportStatus?.trim() ?? '';
+  const result = params.exportResult?.trim() ?? '';
+
+  if (status === ListDataExportTaskSQLExportStatusEnum.failed) {
+    return result || params.failedFallback;
+  }
+  if (status === ListDataExportTaskSQLExportStatusEnum.not_executed) {
+    return result || params.notExecutedHint;
+  }
+  if (status === ListDataExportTaskSQLExportStatusEnum.success) {
+    return result || '-';
+  }
+  return result || '-';
+};

--- a/packages/shared/lib/api/base/service/common.d.ts
+++ b/packages/shared/lib/api/base/service/common.d.ts
@@ -904,6 +904,10 @@ export interface IGetDataExportTask {
 
   export_end_time?: string;
 
+  export_fail_reason?: string;
+
+  export_fail_stage?: string;
+
   export_file_type?: string;
 
   export_start_time?: string;
@@ -1733,6 +1737,9 @@ export interface IListDataExportTaskSQL {
   audit_sql_result?: IAuditSQLResult[];
 
   export_result?: string;
+
+  // 导出执行状态：success / failed / not_executed；未开始可为空（成败勿用 export_result==="ok"）
+  export_status?: string;
 
   export_sql_type?: string;
 
@@ -3579,6 +3586,9 @@ export interface IWebHooksMessage {
 
 export interface IWorkflowRecord {
   current_step_number?: number;
+
+  // 导出失败摘要（人类可读）；失败类状态时有值，成功/非导出失败为空
+  export_fail_summary?: string;
 
   status?: WorkflowRecordStatusEnum;
 

--- a/packages/shared/lib/api/base/service/common.enum.ts
+++ b/packages/shared/lib/api/base/service/common.enum.ts
@@ -34,6 +34,14 @@ export enum GetDataExportTaskStatusEnum {
   'file_deleted' = 'file_deleted'
 }
 
+export enum ListDataExportTaskSQLExportStatusEnum {
+  'success' = 'success',
+
+  'failed' = 'failed',
+
+  'not_executed' = 'not_executed'
+}
+
 export enum GetUserAuthenticationTypeEnum {
   'ldap' = 'ldap',
 


### PR DESCRIPTION
## 关联的 issue

https://github.com/actiontech/dms-ee/issues/951

## 描述你的变更

- 将数据导出失败可见性公共能力下沉到社区版（ResultCard / ExportExecStatusTag / exportFailDisplay / locale / shared 类型枚举）
- 无有效 task_uid 时跳过批量任务查询，避免详情初始化校验弹错
- 同步单测与快照，便于 CE 审阅 AC-027 / AC-028

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------